### PR TITLE
Mobile fix : make cate uppercase when typing on chatbox

### DIFF
--- a/apps/mobile/src/app/components/Suggestions/index.tsx
+++ b/apps/mobile/src/app/components/Suggestions/index.tsx
@@ -116,7 +116,7 @@ const HashtagSuggestions: FC<MentionHashtagSuggestionsProps> = ({ keyword, onSel
 			data={listChannelsMention?.filter((item) => item?.name?.toLocaleLowerCase().includes(keyword?.toLocaleLowerCase()))}
 			renderItem={({ item }) => (
 				<Pressable onPress={() => handleSuggestionPress(item)}>
-					<SuggestItem isDisplayDefaultAvatar={false} name={item?.display ?? ''} symbol="#" subText={(item as ChannelsMention).subText} />
+					<SuggestItem isDisplayDefaultAvatar={false} name={item?.display ?? ''} symbol="#" subText={(item as ChannelsMention).subText.toUpperCase()} />
 				</Pressable>
 			)}
 			keyExtractor={(_, index) => index.toString()}


### PR DESCRIPTION
Mobile App: Channel msg >Mention a channel > The category names are in lower cases format #2653
