### PR TITLE
Fix mobile: Keyboard hidden in create thread screen

### DIFF
--- a/apps/mobile/src/app/components/ThreadDetail/CreateThreadForm/index.tsx
+++ b/apps/mobile/src/app/components/ThreadDetail/CreateThreadForm/index.tsx
@@ -154,7 +154,9 @@ export default function CreateThreadForm() {
 		store.dispatch(channelsActions.joinChannel({ clanId: clanId ?? '', channelId: channelId, noFetchMembers: false }));
 	};
 	return (
-		<KeyboardAvoidingView style={styles.createChannelContainer}>
+		<KeyboardAvoidingView
+			behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+			style={styles.createChannelContainer}>
 			<ScrollView contentContainerStyle={{ flex: 1 }}>
 				<Formik
 					validate={(values) => {


### PR DESCRIPTION
[Mobile App: Thread creation from > The Thread name text field is hidden by the keyboard](https://github.com/nccasia/mezon-fe/issues/2690)
#2690