### PR TITLE
fix scroll messages

### DIFF
--- a/libs/chat-scroll/src/lib/scroll-options.ts
+++ b/libs/chat-scroll/src/lib/scroll-options.ts
@@ -1,0 +1,7 @@
+export const SCROLL_DEFAULT_OPTIONS: IScrollOptions = {
+  debounce: 100,
+}
+
+export interface IScrollOptions {
+  debounce?: number;
+}

--- a/libs/chat-scroll/src/lib/scroll.ts
+++ b/libs/chat-scroll/src/lib/scroll.ts
@@ -1,11 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { IScrollOptions, SCROLL_DEFAULT_OPTIONS } from './scroll-options';
 
 /**
  * React hook for controlling scrollable HTML element.
  * @private
  * @param targetRef Reference of scrollable HTML element.
  */
-export const useScroll = (targetRef: React.MutableRefObject<Element>): IUseScrollResponse => {
+export const useScroll = (targetRef: React.MutableRefObject<Element>, options: IScrollOptions = SCROLL_DEFAULT_OPTIONS): IUseScrollResponse => {
 	const scrollEventHandlerRef = useRef<EventListener>(() => {
 		return;
 	});
@@ -57,16 +58,23 @@ export const useScroll = (targetRef: React.MutableRefObject<Element>): IUseScrol
 	const getClientHeight = useCallback(() => targetRef.current.clientHeight, [targetRef]);
 
 	useEffect(() => {
-		const handler = scrollEventHandlerRef.current;
+    let scrollHandlerTimeoutId: NodeJS.Timeout;
+
+		const handler = (event: Event) => {
+      scrollHandlerTimeoutId && clearTimeout(scrollHandlerTimeoutId);
+      scrollHandlerTimeoutId = setTimeout(() => {
+        scrollEventHandlerRef.current(event);
+      }, options?.debounce);
+		};
+
 		const el = targetRef.current;
 
-		handler({} as Event);
 		el.addEventListener('scroll', handler);
 
 		return () => {
 			el.removeEventListener('scroll', handler);
 		};
-	}, [handlerId, targetRef]);
+	}, [handlerId, targetRef, options]);
 
 	return {
 		isFetching,
@@ -154,3 +162,4 @@ export interface IUseScrollResponse {
 	 */
 	setScrollEventHandler: (newScrollHandler: IScrollEventHandler) => void;
 }
+

--- a/libs/chat-scroll/src/lib/sticky-scroll.ts
+++ b/libs/chat-scroll/src/lib/sticky-scroll.ts
@@ -65,6 +65,7 @@ export const useStickyScroll = (
 		}
 
 		function moveScroll() {
+      console.log('moveScroll');
 			targetRef.current.scrollTop = targetRef.current.scrollHeight;
 			return false;
 		}
@@ -80,6 +81,9 @@ export const useStickyScroll = (
 	}, [targetRef, animationRef]);
 
 	const updateStuckToBottom = useCallback(() => {
+    if (!targetRef.current) {
+      return;
+    }
 		const { scrollHeight, clientHeight, scrollTop } = targetRef.current;
 		const currentlyAtBottom = scrollHeight === scrollTop + clientHeight;
 
@@ -91,7 +95,7 @@ export const useStickyScroll = (
 	}, [targetRef, stickyRef]);
 
 	const handleScroll = useCallback(
-		(e: any) => {
+		(e: Event) => {
 			updateStuckToBottom();
 		},
 		[updateStuckToBottom],
@@ -183,8 +187,6 @@ export interface IChatScrollData {
 	 */
 	data: any[];
 
-	/**
-	
 	/**
 	 * has next page
 	 */

--- a/libs/store/src/lib/messages/messages.slice.ts
+++ b/libs/store/src/lib/messages/messages.slice.ts
@@ -1,27 +1,27 @@
 import {
-    ApiChannelMessageHeaderWithChannel,
-    ChannelDraftMessages,
-    Direction_Mode,
-    EMessageCode,
-    EmojiDataOptionals,
-    IMessageSendPayload,
-    IMessageWithUser,
-    LIMIT_MESSAGE,
-    LoadingStatus,
-    MessageTypeUpdateLink,
-    checkContinuousMessagesByCreateTimeMs,
-    checkSameDayByCreateTime,
+  ApiChannelMessageHeaderWithChannel,
+  ChannelDraftMessages,
+  Direction_Mode,
+  EMessageCode,
+  EmojiDataOptionals,
+  IMessageSendPayload,
+  IMessageWithUser,
+  LIMIT_MESSAGE,
+  LoadingStatus,
+  MessageTypeUpdateLink,
+  checkContinuousMessagesByCreateTimeMs,
+  checkSameDayByCreateTime,
 } from '@mezon/utils';
 import {
-    EntityState,
-    GetThunkAPI,
-    PayloadAction,
-    createAsyncThunk,
-    createEntityAdapter,
-    createSelector,
-    createSelectorCreator,
-    createSlice,
-    weakMapMemoize,
+  EntityState,
+  GetThunkAPI,
+  PayloadAction,
+  createAsyncThunk,
+  createEntityAdapter,
+  createSelector,
+  createSelectorCreator,
+  createSlice,
+  weakMapMemoize,
 } from '@reduxjs/toolkit';
 import memoize from 'memoizee';
 import { ChannelMessage, ChannelStreamMode } from 'mezon-js';
@@ -198,7 +198,7 @@ export const fetchMessages = createAsyncThunk(
 		}
 
 		const firstMessage = response.messages[response.messages.length - 1];
-		if (firstMessage.code === EMessageCode.FIRST_MESSAGE) {
+		if (firstMessage?.code === EMessageCode.FIRST_MESSAGE) {
 			thunkAPI.dispatch(messagesActions.setFirstMessageId({ channelId, firstMessageId: firstMessage.id }));
 		}
 
@@ -226,7 +226,7 @@ export const fetchMessages = createAsyncThunk(
 		thunkAPI.dispatch(reactionActions.updateBulkMessageReactions({ messages }));
 
 		const lastLoadMessage = messages[messages.length - 1];
-		const hasMore = lastLoadMessage.isFirst === false ? false : true;
+		const hasMore = lastLoadMessage?.isFirst === false ? false : true;
 
 		if (messages.length > 0) {
 			thunkAPI.dispatch(messagesActions.setMessageParams({ channelId, param: { lastLoadMessageId: lastLoadMessage.id, hasMore } }));


### PR DESCRIPTION
fix issue #2916: API is called repeatedly
problems:
- scroll event fires multiple times after messsage was deleted
- scroll event fires multiple times by scroll anchoring behavior, see https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-anchor for more detail
- wrong logic on `loadMoreMessage` function: should call API once when scroll to bottom

