### PR TITLE
Fix mobile: Update edited status when upload attachment

### DIFF
--- a/apps/mobile/src/app/hooks/useUpdateAttachmentMessages.ts
+++ b/apps/mobile/src/app/hooks/useUpdateAttachmentMessages.ts
@@ -57,7 +57,7 @@ export default function useUpdateAttachmentMessages({ currentChannelId, currentC
                         newMessage.mentions,
                         results,
                         undefined,
-                        true
+                        false
                     );
                 })
                 .then(() => {
@@ -80,7 +80,7 @@ export default function useUpdateAttachmentMessages({ currentChannelId, currentC
                         newMessage.mentions,
                         [failAttachment],
                         undefined,
-                        true
+                        false
                     );
 
                     dispatch(


### PR DESCRIPTION
Mobile App: Should not display "Edited" lable when send NEW message with image
[#3077](https://github.com/nccasia/mezon-fe/issues/3077)