### PR TITLE
Fix Mobile: Splash screen crop circle no android

### DIFF
--- a/apps/mobile/android/app/src/main/res/drawable/bootsplash_inset.xml
+++ b/apps/mobile/android/app/src/main/res/drawable/bootsplash_inset.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<inset xmlns:android="http://schemas.android.com/apk/res/android"
+    android:drawable="@drawable/bootsplash_logo"
+    android:insetLeft="7dp"
+    android:insetRight="7dp"
+    android:insetTop="7dp"
+    android:insetBottom="7dp" />

--- a/apps/mobile/android/app/src/main/res/values/styles.xml
+++ b/apps/mobile/android/app/src/main/res/values/styles.xml
@@ -10,7 +10,7 @@
         <!-- enforce status bar style as the example app doesn't support dark mode -->
         <item name="darkContentBarsStyle">true</item>
         <item name="bootSplashBackground">@color/bootsplash_background</item>
-        <item name="bootSplashLogo">@drawable/bootsplash_logo</item>
+        <item name="bootSplashLogo">@drawable/bootsplash_inset</item>
         <item name="postBootSplashTheme">@style/AppTheme</item>
     </style>
 


### PR DESCRIPTION
Mobile App: splash screen crop circle no android
[#3431](https://github.com/nccasia/mezon-fe/issues/3431)