### PR TITLE
Fix Mobile: Height of input message too short and UI error with placeholder when upload attachment 

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/components/ChatBox/ChatBoxBottomBar/style.ts
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/ChatBox/ChatBoxBottomBar/style.ts
@@ -16,7 +16,6 @@ export const style = (colors: Attributes) =>
 			borderRadius: size.s_22
 		},
 		inputStyle: {
-			maxHeight: size.s_40 * 2,
 			lineHeight: size.s_20,
 			width: '100%',
 			borderBottomWidth: 0,
@@ -24,7 +23,6 @@ export const style = (colors: Attributes) =>
 			paddingLeft: Platform.OS === 'ios' ? size.s_16 : size.s_20,
 			paddingRight: size.s_40,
 			fontSize: size.medium,
-			paddingTop: size.s_8,
 			backgroundColor: colors.tertiary,
 			color: colors.textStrong,
 			textAlignVertical: 'center'

--- a/apps/mobile/src/app/screens/home/homedrawer/components/ChatBox/ChatMessageInput/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/ChatBox/ChatMessageInput/index.tsx
@@ -168,16 +168,16 @@ export const ChatMessageInput = memo(
 							onBlur={handleInputBlur}
 							multiline={true}
 							spellCheck={false}
-							numberOfLines={3}
+							numberOfLines={4}
 							onChange={() => handleTypingMessage()}
 							{...textInputProps}
 							style={[styles.inputStyle, { height: Math.max(size.s_40, heightInput) }]}
 							children={renderTextContent(text)}
 							onContentSizeChange={(e) => {
-								if (e.nativeEvent.contentSize.height < size.s_40 * 2) {
+								if (e.nativeEvent.contentSize.height < size.s_40 * 2.5) {
 									setHeightInput(e.nativeEvent.contentSize.height);
 								} else {
-									setHeightInput(size.s_40 * 2);
+									setHeightInput(size.s_40 * 2.5);
 								}
 							}}
 						/>


### PR DESCRIPTION
Mobile app: height of input message too short and UI error with placeholder when upload attachment
[#3552](https://github.com/nccasia/mezon-fe/issues/3552)