### PR TITLE
fix: noti badge increases incorrectly when sending a message to another user

### DIFF
--- a/libs/core/src/lib/chat/contexts/ChatContext.tsx
+++ b/libs/core/src/lib/chat/contexts/ChatContext.tsx
@@ -152,6 +152,9 @@ const ChatContextProvider: React.FC<ChatContextProviderProps> = ({ children }) =
 				dispatch(directMetaActions.updateDMSocket(message));
 				dispatch(directMetaActions.setDirectLastSentTimestamp({ channelId: message.channel_id, timestamp }));
 				dispatch(directMetaActions.setCountMessUnread({ channelId: message.channel_id }));
+				if (mess.isMe) {
+					dispatch(directMetaActions.setDirectLastSeenTimestamp({ channelId: message.channel_id, timestamp }));
+				}
 			} else {
 				dispatch(channelMetaActions.setChannelLastSentTimestamp({ channelId: message.channel_id, timestamp }));
 			}


### PR DESCRIPTION
onchannelmessage không cập nhật lại lastSeen -> khi user nhắn lastSeen < lastSent -> tăng thông báo

->solution: update lại lastSeen khi user gửi tin nhắn