### PR TITLE
Mobile app: fix spacing between user display name and date

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/components/InfoUserMessage/styles.ts
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/InfoUserMessage/styles.ts
@@ -6,7 +6,7 @@ export const style = (colors: Attributes) =>
 			fontSize: size.medium,
 			marginRight: size.s_10,
 			fontWeight: '700',
-			width: '65%'
+			maxWidth: '65%'
 		},
 		dateMessageBox: {
 			fontSize: size.small,


### PR DESCRIPTION
Mobile app: fix spacing between user display name and date
- replace width with maxWidth