### PR TITLE
Include Transaction Details When Sending Tokens; Display Transaction History when clicking on Mezon Transfer

### DIFF
--- a/libs/components/src/lib/components/FooterProfile/index.tsx
+++ b/libs/components/src/lib/components/FooterProfile/index.tsx
@@ -105,11 +105,11 @@ function FooterProfile({ name, status, avatar, userId, isDM }: FooterProfileProp
 	};
 
 	const sendNotificationMessage = useCallback(
-		async (userId: string, tokenValue: number) => {
+		async (userId: string, tokenValue: number, note: string) => {
 			const response = await createDirectMessageWithUser(userId);
 			if (response.channel_id) {
 				const channelMode = ChannelStreamMode.STREAM_MODE_DM;
-				sendInviteMessage(`Tokens sent: ${formatMoney(tokenValue)}₫`, response.channel_id, channelMode, TypeMessage.SendToken);
+				sendInviteMessage(`Tokens sent: ${formatMoney(tokenValue)}₫ | ${note}`, response.channel_id, channelMode, TypeMessage.SendToken);
 			}
 		},
 		[createDirectMessageWithUser, sendInviteMessage]
@@ -142,7 +142,7 @@ function FooterProfile({ name, status, avatar, userId, isDM }: FooterProfileProp
 		try {
 			await dispatch(giveCoffeeActions.sendToken(tokenEvent)).unwrap();
 			dispatch(giveCoffeeActions.setSendTokenEvent({ tokenEvent: tokenEvent, status: TOKEN_SUCCESS_STATUS }));
-			await sendNotificationMessage(infoSendToken?.receiver_id ?? userId, infoSendToken?.amount ?? token);
+			await sendNotificationMessage(infoSendToken?.receiver_id ?? userId, infoSendToken?.amount ?? token, note ?? '');
 		} catch (err) {
 			dispatch(giveCoffeeActions.setSendTokenEvent({ tokenEvent: tokenEvent, status: TOKEN_FAILED_STATUS }));
 		}

--- a/libs/components/src/lib/components/Message/ChannelMessageOpt.tsx
+++ b/libs/components/src/lib/components/Message/ChannelMessageOpt.tsx
@@ -211,7 +211,7 @@ function useGiveACoffeeMenuBuilder(message: IMessageWithUser) {
 			if (response.channel_id) {
 				const channelMode = ChannelStreamMode.STREAM_MODE_DM;
 				sendInviteMessage(
-					`Tokens sent: ${formatMoney(TOKEN_TO_AMOUNT.ONE_THOUNSAND * 10)}₫`,
+					`Tokens sent: ${formatMoney(TOKEN_TO_AMOUNT.ONE_THOUNSAND * 10)}₫ | Give coffee action`,
 					response.channel_id,
 					channelMode,
 					TypeMessage.SendToken

--- a/libs/components/src/lib/components/PanelMember/index.tsx
+++ b/libs/components/src/lib/components/PanelMember/index.tsx
@@ -158,8 +158,8 @@ const PanelMember = ({
 
 	const handleClickMention = () => {
 		const mentionInInput = `@[${displayMentionName}](${member?.user?.id})`;
-		const mentionPlainTextIndex = request?.content ? request?.content?.length : 0;
-		const mentionInputValueIndex = request?.valueTextInput ? request?.valueTextInput?.length : 0;
+		const mentionPlainTextIndex = request?.content?.length ?? 0;
+		const mentionInputValueIndex = request?.valueTextInput?.length ?? 0;
 
 		const mentionItem: MentionItem = {
 			display: `@${displayMentionName}`,

--- a/libs/components/src/lib/components/TokenTransactionMsg/TokenTransactionMsg.tsx
+++ b/libs/components/src/lib/components/TokenTransactionMsg/TokenTransactionMsg.tsx
@@ -32,7 +32,7 @@ const TokenTransactionMessage = ({ message }: ITokenTransactionMessageProps) => 
 						</div>
 					</div>
 					<div className="p-3 flex justify-center">
-						<div onClick={handleToggleHistoryModal} className="cursor-pointer text-xs dark:text-blue-500 text-blue-600 font-semibold">
+						<div onClick={handleToggleHistoryModal} className="cursor-pointer dark:text-blue-500 text-blue-600 font-semibold">
 							Mezon transfer
 						</div>
 					</div>

--- a/libs/components/src/lib/components/TokenTransactionMsg/TokenTransactionMsg.tsx
+++ b/libs/components/src/lib/components/TokenTransactionMsg/TokenTransactionMsg.tsx
@@ -1,26 +1,45 @@
 import { MessagesEntity } from '@mezon/store';
 import { Icons } from '@mezon/ui';
+import { useState } from 'react';
+import HistoryTransaction from '../HistoryTransaction';
 
 interface ITokenTransactionMessageProps {
 	message: MessagesEntity;
 }
 
 const TokenTransactionMessage = ({ message }: ITokenTransactionMessageProps) => {
+	const transactionData = message?.content?.t ?? '';
+	const [title, ...rest] = transactionData.split(' | ');
+	const description = rest.join(' | ');
+	const [isShowModalHistory, setIsShowModalHistory] = useState<boolean>(false);
+	const handleToggleHistoryModal = () => {
+		setIsShowModalHistory(!isShowModalHistory);
+	};
 	return (
-		<div className="py-2 w-[230px]">
-			<div className="border dark:border-borderDivider rounded-md dark:bg-bgSecondary bg-bgLightSecondary text-[#4E5057] dark:text-[#DFDFE0]">
-				<div className="p-3 flex gap-2 border-b dark:border-borderDivider w-full">
-					<div className="w-[50px] flex items-center">
-						<Icons.Transaction className="w-full dark:text-green-600 text-green-700" />
+		<>
+			<div className="py-2 w-[230px]">
+				<div className="border dark:border-borderDivider rounded-md dark:bg-bgSecondary bg-bgLightSecondary text-[#4E5057] dark:text-[#DFDFE0]">
+					<div className="p-3 flex gap-2 border-b dark:border-borderDivider w-full">
+						<div className="w-[50px]">
+							<Icons.Transaction className="w-full dark:text-green-600 text-green-700" />
+						</div>
+						<div className="flex flex-col gap-2 flex-1">
+							<div className="font-semibold ">{title}</div>
+							<div className="text-xs font-medium ">
+								<span className="dark:text-blue-500 text-blue-600">Detail: </span>
+								{description}
+							</div>
+						</div>
 					</div>
-					<div className="flex flex-col gap-2 flex-1">
-						<div className="font-semibold ">{message.content.t}</div>
-						<div className="text-xs font-medium">Transaction</div>
+					<div className="p-3 flex justify-center">
+						<div onClick={handleToggleHistoryModal} className="cursor-pointer text-xs dark:text-blue-500 text-blue-600 font-semibold">
+							Mezon transfer
+						</div>
 					</div>
 				</div>
-				<div className="text-xs dark:text-blue-500 text-blue-600 font-semibold p-3">Mezon transfer</div>
 			</div>
-		</div>
+			{isShowModalHistory && <HistoryTransaction onClose={handleToggleHistoryModal} />}
+		</>
 	);
 };
 

--- a/libs/components/src/lib/components/TokenTransactionMsg/TokenTransactionMsg.tsx
+++ b/libs/components/src/lib/components/TokenTransactionMsg/TokenTransactionMsg.tsx
@@ -32,7 +32,7 @@ const TokenTransactionMessage = ({ message }: ITokenTransactionMessageProps) => 
 						</div>
 					</div>
 					<div className="p-3 flex justify-center">
-						<div onClick={handleToggleHistoryModal} className="cursor-pointer dark:text-blue-500 text-blue-600 font-semibold">
+						<div onClick={handleToggleHistoryModal} className="cursor-pointer dark:text-blue-500 text-blue-600 font-semibold text-[15px]">
 							Mezon transfer
 						</div>
 					</div>


### PR DESCRIPTION
- add description in transaction message with the symbol " | ". Detect the "title" with the texts stand before the first " | ", while the rest texts are for description
- update for clean code