### PR TITLE
Mobile app: fix topic message edit init message and send sticker, gif mobile

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/components/ChatBox/ChatMessageSending/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/ChatBox/ChatMessageSending/index.tsx
@@ -180,7 +180,9 @@ export const ChatMessageSending = memo(
 					...(voiceLinkRoomOnMessage?.current || []),
 					...(markdownsOnMessage?.current || []),
 					...(boldsOnMessage?.current || [])
-				]
+				],
+				cid: messageActionNeedToResolve?.targetMessage?.content?.cid,
+				tp: messageActionNeedToResolve?.targetMessage?.content?.tp
 			};
 
 			const payloadThreadSendMessage: IPayloadThreadSendMessage = {

--- a/apps/mobile/src/app/screens/home/homedrawer/components/TopicDiscussion/TopicDiscussion.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/TopicDiscussion/TopicDiscussion.tsx
@@ -1,5 +1,13 @@
 import { ThemeModeBase, useTheme } from '@mezon/mobile-ui';
-import { messagesActions, selectCurrentChannel, selectCurrentClanId, selectCurrentTopicId, topicsActions, useAppDispatch } from '@mezon/store-mobile';
+import {
+	appActions,
+	messagesActions,
+	selectCurrentChannel,
+	selectCurrentClanId,
+	selectCurrentTopicId,
+	topicsActions,
+	useAppDispatch
+} from '@mezon/store-mobile';
 import { checkIsThread, isPublicChannel } from '@mezon/utils';
 import { useNavigation } from '@react-navigation/native';
 import { ChannelStreamMode, ChannelType } from 'mezon-js';
@@ -82,6 +90,14 @@ export default function TopicDiscussion() {
 		},
 		[navigation]
 	);
+
+	useEffect(() => {
+		dispatch(appActions.setIsFocusOnChannelInput(false));
+
+		return () => {
+			dispatch(appActions.setIsFocusOnChannelInput(true));
+		};
+	}, [dispatch]);
 
 	const onGoBack = useCallback(() => {
 		navigation.goBack();


### PR DESCRIPTION
Mobile app: fix topic message edit init message and send sticker, gif mobile
- update cid and topic id for payload edit message.
- update logic focus channel for topic discussion.