### PR TITLE
Mobile app: fix size off embed message description content size mobile

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/components/RenderTextMarkdown/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/RenderTextMarkdown/index.tsx
@@ -88,7 +88,7 @@ export const markdownStyles = (colors: Attributes, isUnReadChannel?: boolean, is
 		},
 		fence: {
 			color: colors.text,
-			width: codeBlockMaxWidth,
+			maxWidth: codeBlockMaxWidth,
 			backgroundColor: colors.secondaryLight,
 			borderColor: colors.black,
 			borderRadius: size.s_4,

--- a/apps/mobile/src/app/screens/home/homedrawer/components/RenderTextMarkdown/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/RenderTextMarkdown/index.tsx
@@ -76,7 +76,7 @@ export const markdownStyles = (colors: Attributes, isUnReadChannel?: boolean, is
 			color: colors.text,
 			paddingVertical: size.s_10,
 			borderColor: colors.secondary,
-			fontSize: size.medium,
+			fontSize: size.h7,
 			lineHeight: size.s_22,
 			paddingHorizontal: size.s_10
 		},


### PR DESCRIPTION
Mobile app: fix size off embed message description content size mobile.
issue: https://github.com/orgs/nccasia/projects/16/views/1?filterQuery=hoang&pane=issue&itemId=104269371