### PR TITLE
 Mobile App: fix display wrong time notification in tab For you Notification

### DIFF
--- a/apps/mobile/src/app/screens/Notifications/NotificationIndividualItem/index.tsx
+++ b/apps/mobile/src/app/screens/Notifications/NotificationIndividualItem/index.tsx
@@ -11,7 +11,7 @@ import { style } from './NotificationIndividualItem.styles';
 function NotificationIndividualItem({ notify, onLongPressNotify, onPressNotify }: NotifyProps) {
 	const user = useSelector((state) => selectMemberClanByUserId2(state, notify?.sender_id ?? ''));
 	const username = notify?.content?.username || user?.user?.display_name || user?.user?.username;
-	const unixTimestamp = Math.floor(new Date(notify?.content?.create_time).getTime() / 1000);
+	const unixTimestamp = Math.floor(new Date(notify?.create_time).getTime() / 1000);
 	const messageTimeDifference = convertTimestampToTimeAgo(unixTimestamp);
 	const colorsUsername = useColorsRoleById(notify?.sender_id)?.highestPermissionRoleColor;
 	const { themeValue } = useTheme();


### PR DESCRIPTION
fix display wrong time notification in tab For you Notification
issue: https://github.com/orgs/nccasia/projects/16/views/6?filterQuery=thanhlich&pane=issue&itemId=106999575