### PR TITLE
Mobile app: fix wrong init tab permission channel setting mobile

### DIFF
--- a/apps/mobile/src/app/screens/channelPermissionSetting/index.tsx
+++ b/apps/mobile/src/app/screens/channelPermissionSetting/index.tsx
@@ -16,7 +16,7 @@ export const ChannelPermissionSetting = ({ navigation, route }: MenuChannelScree
 	const currentChannel = useAppSelector((state) => selectChannelById(state, channelId || ''));
 	const { themeValue } = useTheme();
 	const { t } = useTranslation('channelSetting');
-	const [currentTab, setCurrentTab] = useState<EPermissionSetting>(EPermissionSetting.AdvancedView);
+	const [currentTab, setCurrentTab] = useState<EPermissionSetting>(EPermissionSetting.BasicView);
 	const [isAdvancedEditMode, setIsAdvancedEditMode] = useState(false);
 
 	const onTabChange = (tab: EPermissionSetting) => {

--- a/apps/mobile/src/app/screens/home/homedrawer/components/ChatBox/ChatMessageInput/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/ChatBox/ChatMessageInput/index.tsx
@@ -182,6 +182,7 @@ export const ChatMessageInput = memo(
 							multiline={true}
 							spellCheck={false}
 							numberOfLines={4}
+							textBreakStrategy="simple"
 							onChange={() => handleTypingMessage()}
 							{...textInputProps}
 							style={[styles.inputStyle, { height: Platform.OS === 'ios' ? 'auto' : Math.max(size.s_40, heightInput) }]}


### PR DESCRIPTION
Mobile app: fix wrong init tab permission channel setting mobile.
issue: https://github.com/orgs/nccasia/projects/16/views/1?filterQuery=hoang&pane=issue&itemId=108123354 https://github.com/orgs/nccasia/projects/16/views/1?filterQuery=hoang&pane=issue&itemId=108123447