### PR TITLE
Mobile app: fix select emoji cannot fill in chat box mobile.

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/components/ChatBox/ChatBoxBottomBar/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/ChatBox/ChatBoxBottomBar/index.tsx
@@ -487,7 +487,7 @@ export const ChatBoxBottomBar = memo(
 				clearTextInputListener.remove();
 				addEmojiPickedListener.remove();
 			};
-		}, [handleEventAfterEmojiPicked]);
+		}, [channelId, handleEventAfterEmojiPicked]);
 
 		return (
 			<View


### PR DESCRIPTION
Mobile app: fix select emoji cannot fill in chat box mobile.
issue: https://github.com/orgs/nccasia/projects/16/views/1?filterQuery=hoang&pane=issue&itemId=111754897