### PR TITLE
Mobile app: fix buzz message send empty content mobile.

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/components/ConfirmBuzzMessage/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/ConfirmBuzzMessage/index.tsx
@@ -1,5 +1,6 @@
 import { ActionEmitEvent } from '@mezon/mobile-components';
 import { useTheme } from '@mezon/mobile-ui';
+import { MAX_LENGTH_MESSAGE_BUZZ } from '@mezon/utils';
 import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { DeviceEventEmitter, Text, TextInput, TouchableOpacity, View } from 'react-native';
@@ -20,7 +21,7 @@ export const ConfirmBuzzMessageModal = memo((props: IBuzzMessageModalProps) => {
 
 	const onConfirm = async () => {
 		onClose();
-		if (!messageBuzz) {
+		if (!messageBuzz?.trim()) {
 			return;
 		}
 		onSubmit(messageBuzz);
@@ -37,7 +38,14 @@ export const ConfirmBuzzMessageModal = memo((props: IBuzzMessageModalProps) => {
 					<Text style={styles.title}>{t('buzz.description')}</Text>
 				</View>
 				<View style={styles.textBox}>
-					<TextInput style={styles.input} value={messageBuzz} onChangeText={setMessageBuzz} />
+					<TextInput
+						style={styles.input}
+						value={messageBuzz}
+						multiline={true}
+						numberOfLines={4}
+						maxLength={MAX_LENGTH_MESSAGE_BUZZ}
+						onChangeText={setMessageBuzz}
+					/>
 				</View>
 				<View style={styles.buttonsWrapper}>
 					<TouchableOpacity onPress={onConfirm} style={styles.yesButton}>

--- a/apps/mobile/src/app/screens/home/homedrawer/components/ConfirmBuzzMessage/styles.ts
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/ConfirmBuzzMessage/styles.ts
@@ -62,7 +62,7 @@ export const style = (colors: Attributes) =>
 			padding: size.s_4
 		},
 		input: {
-			height: size.s_40,
+			paddingVertical: size.s_10,
 			color: colors.text
 		}
 	});


### PR DESCRIPTION
Mobile app: fix buzz message send empty content mobile.
Expect:
- Send valid text message.
- Not send empty message or only white-space message.
- limit max length of buzz message.

issue: https://github.com/orgs/nccasia/projects/16/views/1?filterQuery=hoang&pane=issue&itemId=113052989
