### PR TITLE
Mobile app: fix header edit user status not center mobile.

### DIFF
--- a/apps/mobile/src/app/components/AddStatusUserModal/AddStatusUserModal.styles.ts
+++ b/apps/mobile/src/app/components/AddStatusUserModal/AddStatusUserModal.styles.ts
@@ -17,5 +17,12 @@ export const styles = StyleSheet.create({
 		marginBottom: size.s_10,
 		marginTop: size.s_30
 	},
-	titleModal: { flex: 1, textAlign: 'center' }
+	titleModal: {
+		flex: 1,
+		textAlign: 'center',
+		position: 'absolute',
+		alignSelf: 'center',
+		left: 0,
+		right: 0
+	}
 });


### PR DESCRIPTION
Mobile app: fix header edit user status not center mobile.
Expect: header text "Edit status" is in center of header component.
issue: https://github.com/orgs/nccasia/projects/16/views/1?filterQuery=hoang&pane=issue&itemId=113241909