### PR TITLE
Mobile app: fix setup permission item toggle switch mobile

### DIFF
--- a/apps/mobile/src/app/screens/serverRoles/SetupPermissions/index.tsx
+++ b/apps/mobile/src/app/screens/serverRoles/SetupPermissions/index.tsx
@@ -1,5 +1,5 @@
 import { usePermissionChecker, useRoles } from '@mezon/core';
-import { CheckIcon, isEqual } from '@mezon/mobile-components';
+import { CheckIcon } from '@mezon/mobile-components';
 import { Colors, Text, size, useTheme } from '@mezon/mobile-ui';
 import { selectAllPermissionsDefault, selectAllRolesClan, selectEveryoneRole, selectRoleByRoleId } from '@mezon/store-mobile';
 import { EPermission } from '@mezon/utils';
@@ -14,7 +14,7 @@ import MezonSwitch from '../../../componentUI/MezonSwitch';
 import { SeparatorWithLine } from '../../../components/Common';
 import { IconCDN } from '../../../constants/icon_cdn';
 import { APP_SCREEN, MenuClanScreenProps } from '../../../navigation/ScreenTypes';
-import { normalizeString } from '../../../utils/helpers';
+import { isEqualStringArrayUnordered, normalizeString } from '../../../utils/helpers';
 
 type SetupPermissionsScreen = typeof APP_SCREEN.MENU_CLAN.SETUP_PERMISSIONS;
 export const SetupPermissions = ({ navigation, route }: MenuClanScreenProps<SetupPermissionsScreen>) => {
@@ -73,7 +73,7 @@ export const SetupPermissions = ({ navigation, route }: MenuClanScreenProps<Setu
 	}, [defaultPermissionList, getDisablePermission]);
 
 	const isNotChange = useMemo(() => {
-		return isEqual(originSelectedPermissions, selectedPermissions);
+		return isEqualStringArrayUnordered(originSelectedPermissions, selectedPermissions);
 	}, [originSelectedPermissions, selectedPermissions]);
 
 	const handleEditPermissions = async () => {
@@ -249,7 +249,7 @@ export const SetupPermissions = ({ navigation, route }: MenuClanScreenProps<Setu
 
 												<MezonSwitch
 													value={selectedPermissions?.includes(item?.id)}
-													onValueChange={(isSelect) => onSelectPermissionChange(isSelect, item?.id)}
+													onValueChange={(isSelect) => onSelectPermissionChange(!isSelect, item?.id)}
 													disabled={item?.disabled}
 												/>
 											</View>

--- a/apps/mobile/src/app/utils/helpers.ts
+++ b/apps/mobile/src/app/utils/helpers.ts
@@ -117,3 +117,8 @@ export function combineMessageReactions(reactions: any[], message_id: string): a
 
 	return dataCombinedArray;
 }
+
+export function isEqualStringArrayUnordered(a: string[], b: string[]): boolean {
+	if (a.length !== b.length) return false;
+	return JSON.stringify([...a].sort()) === JSON.stringify([...b].sort());
+}

--- a/apps/mobile/src/app/utils/helpers.ts
+++ b/apps/mobile/src/app/utils/helpers.ts
@@ -119,6 +119,11 @@ export function combineMessageReactions(reactions: any[], message_id: string): a
 }
 
 export function isEqualStringArrayUnordered(a: string[], b: string[]): boolean {
-	if (a.length !== b.length) return false;
-	return JSON.stringify([...a].sort()) === JSON.stringify([...b].sort());
+	try {
+		if (a.length !== b.length) return false;
+		return JSON.stringify([...a].sort()) === JSON.stringify([...b].sort());
+	} catch (error) {
+		console.error('Error comparing string arrays:', error);
+		return false;
+	}
 }


### PR DESCRIPTION
Mobile app: fix setup permission item toggle switch mobile.
Issue: https://github.com/orgs/nccasia/projects/16/views/1?filterQuery=hoang&pane=issue&itemId=113243388
Expect: 
- Click to switch will change UI and state switch permission state.
- Click to item will toggle switch and change permission state.
- Show save button when have any change in permission list.
- Hide save button in init and when permission change is equal init permission state.
- Save and change permission list of role when click save button.