### PR TITLE
Mobile app: fix break ui tablet in small device

### DIFF
--- a/apps/mobile/android/app/src/main/java/com/mobile/DeviceUtilsModule.kt
+++ b/apps/mobile/android/app/src/main/java/com/mobile/DeviceUtilsModule.kt
@@ -1,10 +1,15 @@
 package com.mezon.mobile
 
+import android.content.Intent;
+import android.os.Bundle;
 import android.content.res.Configuration
+import android.content.pm.ActivityInfo
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
+import android.content.Context;
+import android.util.DisplayMetrics;
 
 class DeviceUtilsModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
 
@@ -12,11 +17,22 @@ class DeviceUtilsModule(reactContext: ReactApplicationContext) : ReactContextBas
         return "DeviceUtils"
     }
 
+    fun checkIsTablet(context: Context): Boolean {
+        val metrics = context.resources.displayMetrics
+        val widthInches = metrics.widthPixels / metrics.xdpi
+        val heightInches = metrics.heightPixels / metrics.ydpi
+        val screenSize =
+            Math.sqrt(
+                (widthInches.toDouble() * widthInches.toDouble()) +
+                    (heightInches.toDouble() * heightInches.toDouble())
+            )
+        return screenSize >= 7.0
+    }
+
     @ReactMethod
     fun isTablet(promise: Promise) {
         try {
-            val isTablet = (reactApplicationContext.resources.configuration.screenLayout
-                    and Configuration.SCREENLAYOUT_SIZE_MASK) >= Configuration.SCREENLAYOUT_SIZE_LARGE
+            val isTablet = checkIsTablet(reactApplicationContext)
             promise.resolve(isTablet)
         } catch (e: Exception) {
             promise.reject("ERROR", e)

--- a/apps/mobile/android/app/src/main/java/com/mobile/MainActivity.kt
+++ b/apps/mobile/android/app/src/main/java/com/mobile/MainActivity.kt
@@ -12,7 +12,8 @@ import com.facebook.react.modules.network.OkHttpClientProvider;
 import com.mezon.mobile.CustomClientFactory;
 import com.zoontek.rnbootsplash.RNBootSplash;
 import android.app.NotificationManager
-import android.content.Context
+import android.content.Context;
+import android.util.DisplayMetrics;
 
 class MainActivity : ReactActivity() {
 
@@ -22,14 +23,23 @@ class MainActivity : ReactActivity() {
    */
   override fun getMainComponentName(): String = "Mobile"
 
+  fun isTablet(context: Context): Boolean {
+    val metrics = context.resources.displayMetrics
+    val widthInches = metrics.widthPixels / metrics.xdpi
+    val heightInches = metrics.heightPixels / metrics.ydpi
+    val screenSize =
+        Math.sqrt(
+            (widthInches.toDouble() * widthInches.toDouble()) +
+                (heightInches.toDouble() * heightInches.toDouble())
+        )
+    return screenSize >= 7.0
+  }
+
   override fun onCreate(savedInstanceState: Bundle?) {
     RNBootSplash.init(this, R.style.BootTheme)
     super.onCreate(null);
 
-    val isTablet = (this.resources.configuration.screenLayout and
-            Configuration.SCREENLAYOUT_SIZE_MASK) >= Configuration.SCREENLAYOUT_SIZE_LARGE
-
-    if (isTablet) {
+    if (isTablet(this)) {
       requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
     } else {
       requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_FULL_USER

--- a/apps/mobile/src/app/components/ThreadDetail/AssetViewer/index.tsx
+++ b/apps/mobile/src/app/components/ThreadDetail/AssetViewer/index.tsx
@@ -61,7 +61,7 @@ export const AssetsViewer = React.memo(({ channelId }: { channelId: string }) =>
 	);
 
 	return (
-		<>
+		<View style={styles.wrapper}>
 			<AssetsHeader tabActive={tabActive} onChange={handelHeaderTabChange} tabList={headerTablist} />
 			<View style={styles.container}>
 				<ScrollView horizontal pagingEnabled ref={ref} scrollEventThrottle={100}>
@@ -97,6 +97,6 @@ export const AssetsViewer = React.memo(({ channelId }: { channelId: string }) =>
 					)}
 				</ScrollView>
 			</View>
-		</>
+		</View>
 	);
 });

--- a/apps/mobile/src/app/components/ThreadDetail/AssetViewer/style.ts
+++ b/apps/mobile/src/app/components/ThreadDetail/AssetViewer/style.ts
@@ -2,12 +2,13 @@ import { Dimensions, StyleSheet } from 'react-native';
 
 const styles = StyleSheet.create({
 	container: {
-		width: '100%',
-		flexGrow: 1,
-		flexBasis: 500,
-		overflow: 'hidden'
+		overflow: 'hidden',
+		flex: 1
 	},
-	widthTab: { width: Dimensions.get('window').width }
+	widthTab: { width: Dimensions.get('window').width },
+	wrapper: {
+		flex: 1
+	}
 });
 
 export default styles;

--- a/apps/mobile/src/app/screens/home/homedrawer/components/ChannelList/ChannelItem/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/ChannelList/ChannelItem/index.tsx
@@ -55,7 +55,8 @@ function ChannelItem({ data, isUnRead, isActive }: IChannelItemProps) {
 					shadowOffset: { width: 0, height: 2 },
 					shadowOpacity: 0.25,
 					shadowRadius: 3.84,
-					elevation: 5
+					elevation: 5,
+					zIndex: 1
 				}
 			]}
 		>

--- a/apps/mobile/src/app/screens/home/homedrawer/components/ChannelList/ChannelListHeader/styles.ts
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/ChannelList/ChannelListHeader/styles.ts
@@ -49,7 +49,8 @@ export const style = (colors: Attributes) =>
 			borderBottomColor: colors.border,
 			backgroundColor: colors.secondary,
 			paddingHorizontal: size.s_12,
-			elevation: 10
+			elevation: 10,
+			zIndex: 2
 		},
 		wrapperSearch: {
 			flex: 1,

--- a/libs/mobile-ui/src/lib/themes/Metrics.ts
+++ b/libs/mobile-ui/src/lib/themes/Metrics.ts
@@ -1,6 +1,6 @@
 import { Dimensions, Platform } from 'react-native';
 
-export const { width, height } = Dimensions.get('window');
+export const { width, height } = Dimensions.get('screen');
 
 //Guideline sizes are based on standard ~5" screen mobile device
 const guidelineBaseWidth = 375;
@@ -82,4 +82,5 @@ const propsToStyle = <T = Record<string, number | string>>(arrStyle: Array<T>) =
 		);
 };
 
-export { CONTAINER_FLUID_SPACING, CONTAINER_SPACING, Metrics, horizontalScale, moderateScale, propsToStyle, verticalScale };
+export { CONTAINER_FLUID_SPACING, CONTAINER_SPACING, horizontalScale, Metrics, moderateScale, propsToStyle, verticalScale };
+


### PR DESCRIPTION
Mobile app: fix break ui tablet in small device.
issue: https://github.com/orgs/nccasia/projects/16/views/1?filterQuery=hoang&pane=issue&itemId=113519621
expect case rotate screen:
- enter app from portrait, show UI mobile portrait.
- rotate screen, show UI mobile landscape.
- enter app from tablet portrait, open app in landscape.
- enter app from tablet landscape, open app in landscape.
- open app from small device tablet, show UI not break size.
- open app in large layout mobile device not force open in landscape and show UI tablet landscape.

expect case channel list:
- selected channel list not overflow on header channel list.

expect case channel detail:
- show full display of assetviewer contents in mobile.
- show full display of assetviewer contents in tablet.