### PR TITLE
Mobile app: fix custom status can't close modal mobile

### DIFF
--- a/apps/mobile/src/app/components/AddStatusUserModal/AddStatusUserModal.styles.ts
+++ b/apps/mobile/src/app/components/AddStatusUserModal/AddStatusUserModal.styles.ts
@@ -2,7 +2,7 @@ import { Colors, size } from '@mezon/mobile-ui';
 import { StyleSheet } from 'react-native';
 
 export const styles = StyleSheet.create({
-	headerModal: { backgroundColor: Colors.transparent },
+	headerModal: { backgroundColor: Colors.transparent, paddingHorizontal: 0 },
 	titleHeader: {
 		width: '76%',
 		textAlign: 'center'
@@ -23,6 +23,7 @@ export const styles = StyleSheet.create({
 		position: 'absolute',
 		alignSelf: 'center',
 		left: 0,
-		right: 0
+		right: 0,
+		zIndex: -1
 	}
 });


### PR DESCRIPTION
Mobile app: fix custom status can't close modal mobile.
expect case:
- click close button will collapse modal edit status with out save.
- click save will change use custom status and collapse modal edit status.
- button close and save padding correct from left and right.