### PR TITLE
Mobile app: Fix forward embed message and down load image mobile

### DIFF
--- a/apps/mobile/src/app/components/ImageListModal/ImageListModal.tsx
+++ b/apps/mobile/src/app/components/ImageListModal/ImageListModal.tsx
@@ -17,7 +17,6 @@ import { RenderHeaderModal } from './RenderHeaderModal';
 interface IImageListModalProps {
 	imageSelected?: AttachmentEntity;
 	channelId: string;
-	isShowForward?: boolean;
 }
 
 interface IVisibleToolbarConfig {
@@ -29,7 +28,7 @@ const TIME_TO_HIDE_THUMBNAIL = 5000;
 const TIME_TO_SHOW_SAVE_IMAGE_SUCCESS = 3000;
 
 export const ImageListModal = React.memo((props: IImageListModalProps) => {
-	const { imageSelected, channelId, isShowForward = false } = props;
+	const { imageSelected, channelId } = props;
 	const { t } = useTranslation('common');
 	const [currentImage, setCurrentImage] = useState<AttachmentEntity | null>(null);
 	const [visibleToolbarConfig, setVisibleToolbarConfig] = useState<IVisibleToolbarConfig>({ showHeader: true, showFooter: false });
@@ -174,13 +173,7 @@ export const ImageListModal = React.memo((props: IImageListModalProps) => {
 	return (
 		<View style={{ flex: 1 }}>
 			{visibleToolbarConfig.showHeader && (
-				<RenderHeaderModal
-					onClose={onClose}
-					imageSelected={currentImage}
-					onImageSaved={onImageSaved}
-					onLoading={onLoading}
-					isShowForward={isShowForward}
-				/>
+				<RenderHeaderModal onClose={onClose} imageSelected={currentImage} onImageSaved={onImageSaved} onLoading={onLoading} />
 			)}
 			<GalleryAwesome
 				ref={ref}

--- a/apps/mobile/src/app/components/ImageListModal/ImageListModal.tsx
+++ b/apps/mobile/src/app/components/ImageListModal/ImageListModal.tsx
@@ -17,6 +17,7 @@ import { RenderHeaderModal } from './RenderHeaderModal';
 interface IImageListModalProps {
 	imageSelected?: AttachmentEntity;
 	channelId: string;
+	isShowForward?: boolean;
 }
 
 interface IVisibleToolbarConfig {
@@ -28,7 +29,7 @@ const TIME_TO_HIDE_THUMBNAIL = 5000;
 const TIME_TO_SHOW_SAVE_IMAGE_SUCCESS = 3000;
 
 export const ImageListModal = React.memo((props: IImageListModalProps) => {
-	const { imageSelected, channelId } = props;
+	const { imageSelected, channelId, isShowForward = false } = props;
 	const { t } = useTranslation('common');
 	const [currentImage, setCurrentImage] = useState<AttachmentEntity | null>(null);
 	const [visibleToolbarConfig, setVisibleToolbarConfig] = useState<IVisibleToolbarConfig>({ showHeader: true, showFooter: false });
@@ -173,7 +174,13 @@ export const ImageListModal = React.memo((props: IImageListModalProps) => {
 	return (
 		<View style={{ flex: 1 }}>
 			{visibleToolbarConfig.showHeader && (
-				<RenderHeaderModal onClose={onClose} imageSelected={currentImage} onImageSaved={onImageSaved} onLoading={onLoading} />
+				<RenderHeaderModal
+					onClose={onClose}
+					imageSelected={currentImage}
+					onImageSaved={onImageSaved}
+					onLoading={onLoading}
+					isShowForward={isShowForward}
+				/>
 			)}
 			<GalleryAwesome
 				ref={ref}

--- a/apps/mobile/src/app/components/ImageListModal/RenderHeaderModal.tsx
+++ b/apps/mobile/src/app/components/ImageListModal/RenderHeaderModal.tsx
@@ -3,14 +3,13 @@ import { Colors, size, Text, useTheme } from '@mezon/mobile-ui';
 import {
 	AttachmentEntity,
 	getStore,
-	selectChannelById2,
 	selectDmGroupCurrentId,
 	selectMemberClanByUserId2,
 	selectMessageByMessageId,
 	useAppDispatch,
 	useAppSelector
 } from '@mezon/store-mobile';
-import { convertTimeString, isPublicChannel, sleep } from '@mezon/utils';
+import { convertTimeString, sleep } from '@mezon/utils';
 import { useNavigation } from '@react-navigation/native';
 import React from 'react';
 import { DeviceEventEmitter, Platform, TouchableOpacity, View } from 'react-native';
@@ -60,7 +59,6 @@ export const RenderHeaderModal = React.memo(({ onClose, imageSelected, onImageSa
 		if (!imageSelected?.message_id) return;
 		try {
 			const store = getStore();
-			const channel = selectChannelById2(store?.getState(), imageSelected?.channelId);
 			const message = selectMessageByMessageId(store?.getState(), imageSelected?.channelId, imageSelected?.message_id);
 			if (message) {
 				onClose();
@@ -69,8 +67,7 @@ export const RenderHeaderModal = React.memo(({ onClose, imageSelected, onImageSa
 				navigation.navigate(APP_SCREEN.MESSAGES.STACK, {
 					screen: APP_SCREEN.MESSAGES.FORWARD_MESSAGE,
 					params: {
-						message: message,
-						isPublic: isPublicChannel(channel)
+						message: message
 					}
 				});
 			}

--- a/apps/mobile/src/app/components/ImageListModal/RenderHeaderModal.tsx
+++ b/apps/mobile/src/app/components/ImageListModal/RenderHeaderModal.tsx
@@ -7,7 +7,6 @@ import {
 	selectDmGroupCurrentId,
 	selectMemberClanByUserId2,
 	selectMessageByMessageId,
-	setIsForwardAll,
 	useAppDispatch,
 	useAppSelector
 } from '@mezon/store-mobile';
@@ -28,10 +27,9 @@ interface IRenderFooterModalProps {
 	imageSelected?: AttachmentEntity;
 	onImageSaved?: () => void;
 	onLoading?: (isLoading: boolean) => void;
-	isShowForward?: boolean;
 }
 
-export const RenderHeaderModal = React.memo(({ onClose, imageSelected, onImageSaved, onLoading, isShowForward = false }: IRenderFooterModalProps) => {
+export const RenderHeaderModal = React.memo(({ onClose, imageSelected, onImageSaved, onLoading }: IRenderFooterModalProps) => {
 	const { themeValue } = useTheme();
 	const styles = style(themeValue);
 	const uploader = useAppSelector((state) => selectMemberClanByUserId2(state, imageSelected?.uploader || ''));
@@ -46,7 +44,7 @@ export const RenderHeaderModal = React.memo(({ onClose, imageSelected, onImageSa
 		onLoading(true);
 		try {
 			const { url, filetype } = imageSelected;
-			const filetypeParts = filetype?.split('/');
+			const filetypeParts = filetype?.split?.('/');
 			const filePath = await downloadImage(url, filetypeParts[1]);
 			if (filePath) {
 				await saveImageToCameraRoll('file://' + filePath, filetypeParts[0], false);
@@ -66,7 +64,6 @@ export const RenderHeaderModal = React.memo(({ onClose, imageSelected, onImageSa
 			const message = selectMessageByMessageId(store?.getState(), imageSelected?.channelId, imageSelected?.message_id);
 			if (message) {
 				onClose();
-				dispatch(setIsForwardAll(false));
 				DeviceEventEmitter.emit(ActionEmitEvent.ON_TRIGGER_BOTTOM_SHEET, { isDismiss: true });
 				await sleep(500);
 				navigation.navigate(APP_SCREEN.MESSAGES.STACK, {
@@ -122,11 +119,9 @@ export const RenderHeaderModal = React.memo(({ onClose, imageSelected, onImageSa
 				)}
 			</View>
 			<View style={styles.option}>
-				{isShowForward && (
-					<TouchableOpacity onPress={handleForwardMessage}>
-						<MezonIconCDN icon={IconCDN.arrowAngleRightUpIcon} color={Colors.white} />
-					</TouchableOpacity>
-				)}
+				<TouchableOpacity onPress={handleForwardMessage}>
+					<MezonIconCDN icon={IconCDN.arrowAngleRightUpIcon} color={Colors.white} />
+				</TouchableOpacity>
 				<TouchableOpacity onPress={handleDownloadImage}>
 					<MezonIconCDN icon={IconCDN.downloadIcon} color={Colors.white} />
 				</TouchableOpacity>

--- a/apps/mobile/src/app/components/ImageListModal/styles.ts
+++ b/apps/mobile/src/app/components/ImageListModal/styles.ts
@@ -41,5 +41,9 @@ export const style = (colors: Attributes) =>
 			width: '100%',
 			height: '100%',
 			borderRadius: 3
+		},
+		option: {
+			flexDirection: 'row',
+			gap: size.s_20
 		}
 	});

--- a/apps/mobile/src/app/screens/home/homedrawer/MessageItem.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/MessageItem.tsx
@@ -378,7 +378,13 @@ const MessageItem = React.memo(
 										) : null}
 										{!!message?.content?.embed?.length &&
 											message?.content?.embed?.map((embed, index) => (
-												<EmbedMessage message_id={message?.id} embed={embed} key={`message_embed_${message?.id}_${index}`} />
+												<EmbedMessage
+													message_id={message?.id}
+													channel_id={message?.channel_id}
+													embed={embed}
+													key={`message_embed_${message?.id}_${index}`}
+													onLongPress={handleLongPressMessage}
+												/>
 											))}
 										{!!message?.content?.components?.length &&
 											message?.content.components?.map((component, index) => (

--- a/apps/mobile/src/app/screens/home/homedrawer/components/EmbedMessage/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/EmbedMessage/index.tsx
@@ -1,6 +1,5 @@
 import { ActionEmitEvent } from '@mezon/mobile-components';
 import { useTheme } from '@mezon/mobile-ui';
-import { AttachmentEntity } from '@mezon/store';
 import { createImgproxyUrl, IEmbedProps } from '@mezon/utils';
 import React, { memo } from 'react';
 import { DeviceEventEmitter, TouchableOpacity, View } from 'react-native';
@@ -17,13 +16,29 @@ import { style } from './styles';
 type EmbedMessageProps = {
 	message_id: string;
 	embed: IEmbedProps;
+	channel_id: string;
+	onLongPress: () => void;
 };
 
-export const EmbedMessage = memo(({ message_id, embed }: EmbedMessageProps) => {
+export const EmbedMessage = memo(({ message_id, embed, channel_id, onLongPress }: EmbedMessageProps) => {
 	const { color, title, url, author, description, fields, image, timestamp, footer, thumbnail } = embed;
 	const isTabletLandscape = useTabletLandscape();
 	const { themeValue } = useTheme();
 	const styles = style(themeValue);
+
+	const handlePressImage = () => {
+		const imageData = {
+			...image,
+			id: '',
+			filetype: 'image/jpeg',
+			message_id: message_id,
+			channelId: channel_id
+		};
+		const data = {
+			children: <ImageListModal channelId={''} imageSelected={imageData} isShowForward={true} />
+		};
+		DeviceEventEmitter.emit(ActionEmitEvent.ON_TRIGGER_MODAL, { isDismiss: false, data });
+	};
 
 	return (
 		<View style={[styles.container, isTabletLandscape && { width: '60%' }]}>
@@ -46,14 +61,7 @@ export const EmbedMessage = memo(({ message_id, embed }: EmbedMessageProps) => {
 					)}
 				</View>
 				{!!image && (
-					<TouchableOpacity
-						onPress={() => {
-							const data = {
-								children: <ImageListModal channelId={''} imageSelected={image as AttachmentEntity} />
-							};
-							DeviceEventEmitter.emit(ActionEmitEvent.ON_TRIGGER_MODAL, { isDismiss: false, data });
-						}}
-					>
+					<TouchableOpacity onPress={handlePressImage} onLongPress={onLongPress}>
 						<FastImage
 							source={{ uri: image?.url }}
 							style={[styles.imageWrapper, { aspectRatio: image?.width / image?.height || 1 }]}

--- a/apps/mobile/src/app/screens/home/homedrawer/components/EmbedMessage/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/EmbedMessage/index.tsx
@@ -35,7 +35,7 @@ export const EmbedMessage = memo(({ message_id, embed, channel_id, onLongPress }
 			channelId: channel_id
 		};
 		const data = {
-			children: <ImageListModal channelId={''} imageSelected={imageData} isShowForward={true} />
+			children: <ImageListModal channelId={''} imageSelected={imageData} />
 		};
 		DeviceEventEmitter.emit(ActionEmitEvent.ON_TRIGGER_MODAL, { isDismiss: false, data });
 	};

--- a/apps/mobile/src/app/screens/home/homedrawer/components/ForwardMessage/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/ForwardMessage/index.tsx
@@ -38,7 +38,7 @@ export interface IForwardIObject {
 	name?: string;
 	avatar?: string;
 	clanName?: string;
-	isPrivate?: boolean;
+	isChannelPublic?: boolean;
 }
 
 const ForwardMessageScreen = () => {
@@ -79,7 +79,7 @@ const ForwardMessageScreen = () => {
 			name: dm?.channel_label,
 			clanId: '',
 			clanName: '',
-			isPrivate: false
+			isChannelPublic: false
 		};
 	};
 
@@ -91,7 +91,7 @@ const ForwardMessageScreen = () => {
 			name: channel?.channel_label,
 			clanId: channel?.clan_id,
 			clanName: channel?.clan_name,
-			isPrivate: !!channel?.channel_private || false
+			isChannelPublic: !channel?.channel_private || false
 		};
 	};
 
@@ -189,7 +189,7 @@ const ForwardMessageScreen = () => {
 		if (!selectedForwardObjectsRef.current?.length) return;
 		try {
 			for (const selectedObjectSend of selectedForwardObjectsRef.current) {
-				const { type, channelId, clanId = '', isPrivate } = selectedObjectSend;
+				const { type, channelId, clanId = '', isChannelPublic } = selectedObjectSend;
 				switch (type) {
 					case ChannelType.CHANNEL_TYPE_DM:
 						sendForwardMessage('', channelId, ChannelStreamMode.STREAM_MODE_DM, false, message);
@@ -198,7 +198,7 @@ const ForwardMessageScreen = () => {
 						sendForwardMessage('', channelId, ChannelStreamMode.STREAM_MODE_GROUP, false, message);
 						break;
 					case ChannelType.CHANNEL_TYPE_CHANNEL:
-						sendForwardMessage(clanId, channelId, ChannelStreamMode.STREAM_MODE_CHANNEL, !isPrivate, message);
+						sendForwardMessage(clanId, channelId, ChannelStreamMode.STREAM_MODE_CHANNEL, isChannelPublic, message);
 						break;
 					default:
 						break;

--- a/apps/mobile/src/app/screens/home/homedrawer/components/ForwardMessage/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/ForwardMessage/index.tsx
@@ -38,6 +38,7 @@ export interface IForwardIObject {
 	name?: string;
 	avatar?: string;
 	clanName?: string;
+	isPrivate?: boolean;
 }
 
 const ForwardMessageScreen = () => {
@@ -77,7 +78,8 @@ const ForwardMessageScreen = () => {
 			avatar: dm?.type === ChannelType.CHANNEL_TYPE_DM ? dm?.channel_avatar?.[0] : 'assets/images/avatar-group.png',
 			name: dm?.channel_label,
 			clanId: '',
-			clanName: ''
+			clanName: '',
+			isPrivate: false
 		};
 	};
 
@@ -88,7 +90,8 @@ const ForwardMessageScreen = () => {
 			avatar: '#',
 			name: channel?.channel_label,
 			clanId: channel?.clan_id,
-			clanName: channel?.clan_name
+			clanName: channel?.clan_name,
+			isPrivate: !!channel?.channel_private || false
 		};
 	};
 
@@ -186,7 +189,7 @@ const ForwardMessageScreen = () => {
 		if (!selectedForwardObjectsRef.current?.length) return;
 		try {
 			for (const selectedObjectSend of selectedForwardObjectsRef.current) {
-				const { type, channelId, clanId = '' } = selectedObjectSend;
+				const { type, channelId, clanId = '', isPrivate } = selectedObjectSend;
 				switch (type) {
 					case ChannelType.CHANNEL_TYPE_DM:
 						sendForwardMessage('', channelId, ChannelStreamMode.STREAM_MODE_DM, false, message);
@@ -195,7 +198,8 @@ const ForwardMessageScreen = () => {
 						sendForwardMessage('', channelId, ChannelStreamMode.STREAM_MODE_GROUP, false, message);
 						break;
 					case ChannelType.CHANNEL_TYPE_CHANNEL:
-						sendForwardMessage(clanId, channelId, ChannelStreamMode.STREAM_MODE_CHANNEL, isPublic, message);
+						console.log('send forward message to channel', message, clanId, channelId, selectedForwardObjectsRef.current);
+						sendForwardMessage(clanId, channelId, ChannelStreamMode.STREAM_MODE_CHANNEL, !isPrivate, message);
 						break;
 					default:
 						break;

--- a/apps/mobile/src/app/screens/home/homedrawer/components/ForwardMessage/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/ForwardMessage/index.tsx
@@ -198,7 +198,6 @@ const ForwardMessageScreen = () => {
 						sendForwardMessage('', channelId, ChannelStreamMode.STREAM_MODE_GROUP, false, message);
 						break;
 					case ChannelType.CHANNEL_TYPE_CHANNEL:
-						console.log('send forward message to channel', message, clanId, channelId, selectedForwardObjectsRef.current);
 						sendForwardMessage(clanId, channelId, ChannelStreamMode.STREAM_MODE_CHANNEL, !isPrivate, message);
 						break;
 					default:

--- a/apps/mobile/src/app/screens/home/homedrawer/components/MessageItemBS/ContainerMessageActionModal.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/MessageItemBS/ContainerMessageActionModal.tsx
@@ -348,8 +348,7 @@ export const ContainerMessageActionModal = React.memo((props: IReplyBottomSheet)
 		navigation.navigate(APP_SCREEN.MESSAGES.STACK, {
 			screen: APP_SCREEN.MESSAGES.FORWARD_MESSAGE,
 			params: {
-				message: message,
-				isPublic: isPublicChannel(currentChannel)
+				message: message
 			}
 		});
 	};


### PR DESCRIPTION
Mobile app: Fix forward embed message and down load image mobile.
issue: https://github.com/orgs/nccasia/projects/16/views/1?filterQuery=hoang&pane=issue&itemId=113461241.
Forward message expect case:
- show menu forward on longpress image or embed item.
- show forward icon in image view for embed message image.
- forward message to public channel and DM success.
- forward message to private channel success.

Image view expect case:
- Press image will show full screen image view.
- press back button to close modal.
- press download, show loading and successful notification, new image is added to device library.
- press forward message will close image modal and navigate to forward screen.