### PR TITLE
Mobile app: fix size avatar image in profile setting mobile.

### DIFF
--- a/apps/mobile/src/app/componentUI/MezonClanAvatar/index.tsx
+++ b/apps/mobile/src/app/componentUI/MezonClanAvatar/index.tsx
@@ -1,6 +1,6 @@
 import { size, useTheme } from '@mezon/mobile-ui';
 import { createImgproxyUrl } from '@mezon/utils';
-import React from 'react';
+import React, { memo } from 'react';
 import { StyleProp, TextStyle, View } from 'react-native';
 import FastImage from 'react-native-fast-image';
 import Images from '../../../assets/Images';
@@ -14,9 +14,20 @@ interface IMezonClanAvatarProps {
 	textStyle?: StyleProp<TextStyle>;
 	noDefaultText?: boolean;
 	lightMode?: boolean;
+	imageHeight?: number;
+	imageWidth?: number;
 }
 
-export default function MezonClanAvatar({ image, alt = '', defaultColor, textStyle, noDefaultText = false, lightMode }: IMezonClanAvatarProps) {
+export default memo(function MezonClanAvatar({
+	image,
+	alt = '',
+	defaultColor,
+	textStyle,
+	noDefaultText = false,
+	lightMode,
+	imageHeight = 100,
+	imageWidth = 100
+}: IMezonClanAvatarProps) {
 	const { themeValue } = useTheme();
 
 	const styles = style(themeValue);
@@ -24,7 +35,7 @@ export default function MezonClanAvatar({ image, alt = '', defaultColor, textSty
 	if (image) {
 		return (
 			<ImageNative
-				url={createImgproxyUrl(image ?? '', { width: 100, height: 100, resizeType: 'fit' })}
+				url={createImgproxyUrl(image ?? '', { width: imageWidth, height: imageHeight, resizeType: 'fit' })}
 				style={styles.image}
 				resizeMode={'cover'}
 			/>
@@ -40,4 +51,4 @@ export default function MezonClanAvatar({ image, alt = '', defaultColor, textSty
 			) : null}
 		</View>
 	);
-}
+});

--- a/apps/mobile/src/app/componentUI/MezonImagePicker/index.tsx
+++ b/apps/mobile/src/app/componentUI/MezonImagePicker/index.tsx
@@ -1,10 +1,10 @@
-import { QUALITY_IMAGE_UPLOAD } from '@mezon/mobile-components';
+import { ActionEmitEvent, QUALITY_IMAGE_UPLOAD } from '@mezon/mobile-components';
 import { useTheme } from '@mezon/mobile-ui';
 import { selectCurrentChannel } from '@mezon/store-mobile';
 import { handleUploadFileMobile, useMezon } from '@mezon/transport';
 import { setTimeout } from '@testing-library/react-native/build/helpers/timers';
 import { forwardRef, memo, useEffect, useImperativeHandle, useRef, useState } from 'react';
-import { DimensionValue, Platform, StyleProp, Text, View, ViewStyle } from 'react-native';
+import { DeviceEventEmitter, DimensionValue, Platform, StyleProp, Text, View, ViewStyle } from 'react-native';
 import { TouchableOpacity } from 'react-native-gesture-handler';
 import { openCropper } from 'react-native-image-crop-picker';
 import { launchImageLibrary } from 'react-native-image-picker';
@@ -139,6 +139,7 @@ export default memo(
 			if (file) {
 				timerRef.current = setTimeout(
 					async () => {
+						DeviceEventEmitter.emit(ActionEmitEvent.ON_TRIGGER_BOTTOM_SHEET, { isDismiss: true });
 						const croppedFile = await openCropper({
 							path: file.uri,
 							mediaType: 'photo',

--- a/apps/mobile/src/app/componentUI/MezonImagePicker/index.tsx
+++ b/apps/mobile/src/app/componentUI/MezonImagePicker/index.tsx
@@ -1,5 +1,5 @@
 import { QUALITY_IMAGE_UPLOAD } from '@mezon/mobile-components';
-import { size, useTheme } from '@mezon/mobile-ui';
+import { useTheme } from '@mezon/mobile-ui';
 import { selectCurrentChannel } from '@mezon/store-mobile';
 import { handleUploadFileMobile, useMezon } from '@mezon/transport';
 import { setTimeout } from '@testing-library/react-native/build/helpers/timers';
@@ -9,9 +9,7 @@ import { TouchableOpacity } from 'react-native-gesture-handler';
 import { openCropper } from 'react-native-image-crop-picker';
 import { launchImageLibrary } from 'react-native-image-picker';
 import { useSelector } from 'react-redux';
-import { IconCDN } from '../../constants/icon_cdn';
 import MezonClanAvatar from '../MezonClanAvatar';
-import MezonIconCDN from '../MezonIconCDN';
 import { style as _style } from './styles';
 
 export interface IFile {
@@ -46,6 +44,8 @@ interface IMezonImagePickerProps {
 	noDefaultText?: boolean;
 	disabled?: boolean;
 	onPressAvatar?: () => void;
+	imageWidth?: number;
+	imageHeight?: number;
 }
 
 export interface IMezonImagePickerHandler {
@@ -100,7 +100,9 @@ export default memo(
 			},
 			noDefaultText,
 			disabled,
-			onPressAvatar
+			onPressAvatar,
+			imageHeight,
+			imageWidth
 		}: IMezonImagePickerProps,
 		ref
 	) {
@@ -142,8 +144,8 @@ export default memo(
 							mediaType: 'photo',
 							includeBase64: true,
 							compressImageQuality: QUALITY_IMAGE_UPLOAD,
-							...(typeof width === 'number' && { width: width * SCALE }),
-							...(typeof height === 'number' && { height: height * SCALE })
+							...(typeof width === 'number' && { width: imageWidth || width * SCALE }),
+							...(typeof height === 'number' && { height: imageWidth || height * SCALE })
 						});
 						setImage(croppedFile.path);
 						onChange && onChange(croppedFile);
@@ -153,7 +155,9 @@ export default memo(
 								name: file.name,
 								uri: croppedFile.path,
 								size: croppedFile.size,
-								type: croppedFile.mime
+								type: croppedFile.mime,
+								height: croppedFile.height,
+								width: croppedFile.width
 							} as IFile;
 							const url = await handleUploadImage(uploadImagePayload);
 							if (url) {
@@ -184,7 +188,14 @@ export default memo(
 						{localValue ? (
 							localValue
 						) : image || !showHelpText ? (
-							<MezonClanAvatar image={image} alt={alt} defaultColor={defaultColor} noDefaultText={noDefaultText} />
+							<MezonClanAvatar
+								image={image}
+								alt={alt}
+								defaultColor={defaultColor}
+								noDefaultText={noDefaultText}
+								imageHeight={imageHeight}
+								imageWidth={imageWidth}
+							/>
 						) : (
 							<Text style={styles.textPlaceholder}>Choose an image</Text>
 						)}

--- a/apps/mobile/src/app/components/BottomSheetRootListener/index.tsx
+++ b/apps/mobile/src/app/components/BottomSheetRootListener/index.tsx
@@ -129,6 +129,7 @@ const BottomSheetRootListener = () => {
 			if (isDismiss) {
 				onCloseBottomSheet();
 			} else {
+				if (!data) return;
 				Keyboard.dismiss();
 				onTriggerBottomSheet(data);
 			}

--- a/apps/mobile/src/app/components/BottomSheetRootListener/index.tsx
+++ b/apps/mobile/src/app/components/BottomSheetRootListener/index.tsx
@@ -129,7 +129,6 @@ const BottomSheetRootListener = () => {
 			if (isDismiss) {
 				onCloseBottomSheet();
 			} else {
-				if (!data) return;
 				Keyboard.dismiss();
 				onTriggerBottomSheet(data);
 			}

--- a/apps/mobile/src/app/screens/settings/ProfileSetting/UserProfile/components/Banner/index.tsx
+++ b/apps/mobile/src/app/screens/settings/ProfileSetting/UserProfile/components/Banner/index.tsx
@@ -1,6 +1,6 @@
 import { ActionEmitEvent } from '@mezon/mobile-components';
 import { baseColor, size, useTheme } from '@mezon/mobile-ui';
-import { useMemo, useRef } from 'react';
+import { memo, useCallback, useMemo, useRef } from 'react';
 import { DeviceEventEmitter, View } from 'react-native';
 import { useMixImageColor } from '../../../../../../../app/hooks/useMixImageColor';
 import MezonImagePicker, { IMezonImagePickerHandler } from '../../../../../../componentUI/MezonImagePicker';
@@ -14,15 +14,18 @@ interface IBannerAvatarProps {
 	defaultAvatar?: string;
 }
 
-export default function BannerAvatar({ avatar, onLoad, alt, defaultAvatar }: IBannerAvatarProps) {
+export default memo(function BannerAvatar({ avatar, onLoad, alt, defaultAvatar }: IBannerAvatarProps) {
 	const { themeValue } = useTheme();
 	const styles = style(themeValue);
 	const { color } = useMixImageColor(avatar);
 	const avatarPickerRef = useRef<IMezonImagePickerHandler>();
 
-	const handleOnload = async (url: string) => {
-		onLoad && onLoad(url);
-	};
+	const handleOnload = useCallback(
+		async (url: string) => {
+			onLoad && onLoad(url);
+		},
+		[onLoad]
+	);
 
 	const removeAvatar = () => {
 		DeviceEventEmitter.emit(ActionEmitEvent.ON_TRIGGER_BOTTOM_SHEET, { isDismiss: true });
@@ -52,7 +55,7 @@ export default function BannerAvatar({ avatar, onLoad, alt, defaultAvatar }: IBa
 		[]
 	);
 
-	const openAvatarBS = () => {
+	const openAvatarBS = useCallback(() => {
 		const data = {
 			heightFitContent: true,
 			children: (
@@ -62,7 +65,7 @@ export default function BannerAvatar({ avatar, onLoad, alt, defaultAvatar }: IBa
 			)
 		};
 		DeviceEventEmitter.emit(ActionEmitEvent.ON_TRIGGER_BOTTOM_SHEET, { isDismiss: false, data });
-	};
+	}, [menu]);
 
 	return (
 		<View>
@@ -92,10 +95,12 @@ export default function BannerAvatar({ avatar, onLoad, alt, defaultAvatar }: IBa
 					autoUpload
 					penPosition={{ right: 5, top: 5 }}
 					onPressAvatar={openAvatarBS}
+					imageHeight={400}
+					imageWidth={400}
 				/>
 
 				<View style={[styles.onLineStatus]}></View>
 			</View>
 		</View>
 	);
-}
+});

--- a/apps/mobile/src/app/screens/settings/ProfileSetting/UserProfile/index.tsx
+++ b/apps/mobile/src/app/screens/settings/ProfileSetting/UserProfile/index.tsx
@@ -1,7 +1,7 @@
 import { TouchableOpacity } from '@gorhom/bottom-sheet';
 import { useAuth } from '@mezon/core';
 import { size, useTheme } from '@mezon/mobile-ui';
-import { memo } from 'react';
+import { memo, useCallback } from 'react';
 import { KeyboardAvoidingView, View } from 'react-native';
 import Toast from 'react-native-toast-message';
 import { IUserProfileValue } from '..';
@@ -21,12 +21,15 @@ function UserProfile({ userProfileValue, setCurrentUserProfileValue }: IUserProf
 	const { themeValue } = useTheme();
 	const styles = style(themeValue);
 	const auth = useAuth();
-	const handleAvatarChange = async (imgUrl: string) => {
-		setCurrentUserProfileValue((prevValue) => ({
-			...prevValue,
-			imgUrl
-		}));
-	};
+	const handleAvatarChange = useCallback(
+		async (imgUrl: string) => {
+			setCurrentUserProfileValue((prevValue) => ({
+				...prevValue,
+				imgUrl
+			}));
+		},
+		[setCurrentUserProfileValue]
+	);
 
 	const handleDetailChange = (newValue: Partial<IUserProfileValue>) => {
 		setCurrentUserProfileValue((prevValue) => ({ ...prevValue, ...newValue }));


### PR DESCRIPTION
Mobile app: fix size avatar image in profile setting mobile.
Issue: https://github.com/orgs/nccasia/projects/16/views/1?filterQuery=hoang&pane=issue&itemId=113578523
Expect case:
- Image in userProfile and clanProfile render with true size 400x400 imageProxy.
- Image upload with width and height and can view right size in user profile web and desktop.
- click useProfile to open options menu, press change avatar will close all bottom sheet and open image picker.