### PR TITLE
Mobile app: feat apply heading in content message mobile

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/components/RenderTextMarkdown/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/RenderTextMarkdown/index.tsx
@@ -389,7 +389,7 @@ export const RenderTextMarkdownContent = ({
 
 		switch (element?.kindOf) {
 			case ETokenMessage.EMOJIS: {
-				const srcEmoji = getSrcEmoji(element.emojiid);
+				const srcEmoji = getSrcEmoji(element?.emojiid);
 				textParts.push(
 					<View key={`emoji-${index}`} style={!isOnlyContainEmoji && markdownStyles(themeValue).emojiInMessageContain}>
 						<ImageNative
@@ -409,8 +409,8 @@ export const RenderTextMarkdownContent = ({
 				const usersInChannel = selectAllChannelMembers(store.getState() as RootState, currentChannelId as string);
 				const mention = MentionUser({
 					tagName: contentInElement,
-					roleId: element.role_id || '',
-					tagUserId: element.user_id,
+					roleId: element?.role_id || '',
+					tagUserId: element?.user_id,
 					mode,
 					usersClan,
 					usersInChannel
@@ -442,7 +442,7 @@ export const RenderTextMarkdownContent = ({
 					const channelsEntities = selectChannelsEntities(store.getState() as any);
 					const hashtagDmEntities = selectHashtagDmEntities(store.getState() as any);
 					const mention = ChannelHashtag({
-						channelHashtagId: element.channelid,
+						channelHashtagId: element?.channelid,
 						mode,
 						currentChannelId,
 						channelsEntities,
@@ -489,7 +489,7 @@ export const RenderTextMarkdownContent = ({
 			}
 
 			case ETokenMessage.MARKDOWNS: {
-				switch (element.type) {
+				switch (element?.type) {
 					case EBacktickType.SINGLE:
 					case EBacktickType.CODE:
 						textParts.push(

--- a/apps/mobile/src/app/screens/home/homedrawer/components/RenderTextMarkdown/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/RenderTextMarkdown/index.tsx
@@ -67,37 +67,31 @@ export const markdownStyles = (
 		heading1: {
 			color: colors.text,
 			fontSize: size.h1,
-			lineHeight: size.h1 + size.s_8,
 			fontWeight: '600'
 		},
 		heading2: {
 			color: colors.text,
 			fontSize: size.h2,
-			lineHeight: size.h2 + size.s_8,
 			fontWeight: '600'
 		},
 		heading3: {
 			color: colors.text,
 			fontSize: size.h3,
-			lineHeight: size.h3 + size.s_8,
 			fontWeight: '600'
 		},
 		heading4: {
 			color: colors.text,
 			fontSize: size.h4,
-			lineHeight: size.h4 + size.s_8,
 			fontWeight: '600'
 		},
 		heading5: {
 			color: colors.text,
 			fontSize: size.h5,
-			lineHeight: size.h5 + size.s_8,
 			fontWeight: '600'
 		},
 		heading6: {
 			color: colors.text,
 			fontSize: size.h6,
-			lineHeight: size.h6 + size.s_8,
 			fontWeight: '600'
 		},
 		body: commonHeadingStyle,
@@ -292,6 +286,62 @@ const renderChannelIcon = (channelType: number, channelId: string, themeValue: A
 	return null;
 };
 
+const renderTextPalainContain = (themeValue: Attributes, text: string, lastIndex: number, isLastText = false) => {
+	const lines = text?.split('\n');
+	const headingFormattedLines = [];
+	let hasHeadings = false;
+
+	if (!lines?.length) {
+		return (
+			<Text key={`text-end_${lastIndex}`} style={[themeValue ? markdownStyles(themeValue).body : {}]}>
+				{text}
+			</Text>
+		);
+	}
+
+	lines.forEach((line, idx) => {
+		const headingMatch = line.match(/^(#{1,6})\s+(.+)$/);
+		if (headingMatch && themeValue) {
+			hasHeadings = true;
+			const headingLevel = headingMatch[1].length;
+			const headingText = headingMatch[2].trim();
+
+			if (headingLevel) {
+				headingFormattedLines.push(
+					<Text key={`line-${idx}`} style={[themeValue ? markdownStyles(themeValue)?.[`heading${headingLevel}`] : {}]}>
+						{headingText}
+						{idx !== lines.length - 1 || !isLastText ? '\n' : ''}
+					</Text>
+				);
+			} else {
+				headingFormattedLines.push(
+					<Text key={`line-${idx}`} style={[themeValue ? markdownStyles(themeValue).body : {}]}>
+						{line}
+						{idx !== lines.length - 1 || !isLastText ? '\n' : ''}
+					</Text>
+				);
+			}
+		} else {
+			headingFormattedLines.push(
+				<Text key={`line-${idx}`} style={[themeValue ? markdownStyles(themeValue).body : {}]}>
+					{line}
+					{idx !== lines.length - 1 || !isLastText ? '\n' : ''}
+				</Text>
+			);
+		}
+	});
+
+	if (!hasHeadings) {
+		return (
+			<Text key={`text-end_${lastIndex}`} style={[themeValue ? markdownStyles(themeValue).body : {}]}>
+				{text}
+			</Text>
+		);
+	} else {
+		return <Text>{headingFormattedLines}</Text>;
+	}
+};
+
 export const RenderTextMarkdownContent = ({
 	content,
 	isEdited,
@@ -334,16 +384,12 @@ export const RenderTextMarkdownContent = ({
 		const contentInElement = t?.substring(s, e);
 
 		if (lastIndex < s) {
-			textParts.push(
-				<Text key={`text-${index}`} style={themeValue ? markdownStyles(themeValue, isUnReadChannel, isLastMessage, isBuzzMessage).body : {}}>
-					{t?.slice(lastIndex, s).replace(/^\n|\n$/, '')}
-				</Text>
-			);
+			textParts.push(renderTextPalainContain(themeValue, t?.slice(lastIndex, s) ?? '', index));
 		}
 
 		switch (element?.kindOf) {
 			case ETokenMessage.EMOJIS: {
-				const srcEmoji = getSrcEmoji(element?.emojiid);
+				const srcEmoji = getSrcEmoji(element.emojiid);
 				textParts.push(
 					<View key={`emoji-${index}`} style={!isOnlyContainEmoji && markdownStyles(themeValue).emojiInMessageContain}>
 						<ImageNative
@@ -363,8 +409,8 @@ export const RenderTextMarkdownContent = ({
 				const usersInChannel = selectAllChannelMembers(store.getState() as RootState, currentChannelId as string);
 				const mention = MentionUser({
 					tagName: contentInElement,
-					roleId: element?.role_id || '',
-					tagUserId: element?.user_id,
+					roleId: element.role_id || '',
+					tagUserId: element.user_id,
 					mode,
 					usersClan,
 					usersInChannel
@@ -396,7 +442,7 @@ export const RenderTextMarkdownContent = ({
 					const channelsEntities = selectChannelsEntities(store.getState() as any);
 					const hashtagDmEntities = selectHashtagDmEntities(store.getState() as any);
 					const mention = ChannelHashtag({
-						channelHashtagId: element?.channelid,
+						channelHashtagId: element.channelid,
 						mode,
 						currentChannelId,
 						channelsEntities,
@@ -443,7 +489,7 @@ export const RenderTextMarkdownContent = ({
 			}
 
 			case ETokenMessage.MARKDOWNS: {
-				switch (element?.type) {
+				switch (element.type) {
 					case EBacktickType.SINGLE:
 					case EBacktickType.CODE:
 						textParts.push(
@@ -458,13 +504,6 @@ export const RenderTextMarkdownContent = ({
 
 					case EBacktickType.PRE:
 					case EBacktickType.TRIPLE: {
-						const lines = (
-							contentInElement?.startsWith('```') && contentInElement?.endsWith('```')
-								? contentInElement.slice(3, -3)
-								: contentInElement
-						)
-							?.replace(/^\n+|\n+$/g, '')
-							?.split('\n');
 						textParts.push(
 							<Text>
 								{s !== 0 && '\n'}
@@ -484,31 +523,12 @@ export const RenderTextMarkdownContent = ({
 												: {}
 										}
 									>
-										{lines.map((line, idx) => {
-											const headingMatch = line.match(/^#{1,6}\s+.+$/);
-											if (headingMatch && themeValue) {
-												const level = line.indexOf(' ');
-												const headingText = line.substring(level).trim();
-
-												return (
-													<Text
-														key={`line-${idx}`}
-														style={[
-															markdownStyles(themeValue).code_block,
-															markdownStyles(themeValue)?.[`heading${level}`]
-														]}
-													>
-														{headingText}
-													</Text>
-												);
-											}
-
-											return (
-												<Text key={`line-${idx}`} style={themeValue ? markdownStyles(themeValue).code_block : {}}>
-													{line}
-												</Text>
-											);
-										})}
+										<Text style={themeValue ? markdownStyles(themeValue).code_block : {}}>
+											{(contentInElement?.startsWith('```') && contentInElement?.endsWith('```')
+												? contentInElement?.slice(3, -3)
+												: contentInElement
+											)?.replace(/^\n+|\n+$/g, '')}
+										</Text>
 									</View>
 								</View>
 							</Text>
@@ -650,11 +670,7 @@ export const RenderTextMarkdownContent = ({
 	});
 
 	if (lastIndex < (t?.length ?? 0)) {
-		textParts.push(
-			<Text key="text-end" style={[themeValue ? markdownStyles(themeValue, isUnReadChannel, isLastMessage, isBuzzMessage).body : {}]}>
-				{t?.slice(lastIndex).replace(/^\n|\n$/, '')}
-			</Text>
-		);
+		textParts.push(renderTextPalainContain(themeValue, t?.slice(lastIndex).replace(/^\n|\n$/, ''), lastIndex, true));
 	}
 
 	return (
@@ -683,7 +699,7 @@ export const RenderTextMarkdownContent = ({
 				/>
 			)}
 
-			<View style={{ flexDirection: 'row', gap: size.s_6, flexWrap: 'wrap' }}>
+			<View style={{ flexDirection: 'row', gap: size.s_6, flexWrap: 'wrap', alignItems: 'flex-end' }}>
 				<View style={{ flexDirection: 'column', alignItems: 'flex-start' }}>
 					{textParts?.length > 0 && <Text>{textParts}</Text>}
 					{markdownBlackParts?.length > 0 && markdownBlackParts.map((item) => item)}


### PR DESCRIPTION
Mobile app: feat render heading for content message mobile.
Issue: https://github.com/orgs/nccasia/projects/16/views/1?filterQuery=hoang&pane=issue&itemId=113931875
Expert case:
- render text header with correct level.
- render text header with no unnecessary spacing.
- break the line when rendering others element in text.