### PR TITLE
Mobile app: fix notification setting not save status mobile

### DIFF
--- a/apps/mobile/src/app/components/NotificationSetting/index.tsx
+++ b/apps/mobile/src/app/components/NotificationSetting/index.tsx
@@ -54,12 +54,16 @@ export default function NotificationSetting({ channel }: { channel?: ChannelThre
 	const [isChecked, setIsChecked] = useState<boolean>(false);
 	const currentClanId = useSelector(selectCurrentClanId);
 	const notifyReactMessage = useSelector(selectNotifiReactMessage);
-	const getNotificationChannelSelected = useSelector(selectNotifiSettingsEntitiesById(currentChannelId));
+	const getNotificationChannelSelected = useSelector(selectNotifiSettingsEntitiesById(channel?.id || currentChannelId));
 	const defaultNotificationCategory = useSelector(selectDefaultNotificationCategory);
 	const defaultNotificationClan = useSelector(selectDefaultNotificationClan);
 	const [defaultNotifyName, setDefaultNotifyName] = useState('');
 	useEffect(() => {
 		setIsChecked(notifyReactMessage?.id !== '0');
+		if (!getNotificationChannelSelected?.notification_setting_type) {
+			setRadioBox((prev) => prev.map((item) => (item.id === 0 ? { ...item, isChecked: true } : item)));
+			return;
+		}
 		setRadioBox(radioBox.map((item) => item && { ...item, isChecked: getNotificationChannelSelected?.notification_setting_type === item.value }));
 	}, [notifyReactMessage, getNotificationChannelSelected]);
 

--- a/apps/mobile/src/app/components/ThreadDetail/ActionRow/index.tsx
+++ b/apps/mobile/src/app/components/ThreadDetail/ActionRow/index.tsx
@@ -4,11 +4,13 @@ import React, { useContext } from 'react';
 import { usePermissionChecker } from '@mezon/core';
 import { ENotificationActive, ETypeSearch } from '@mezon/mobile-components';
 import { useTheme } from '@mezon/mobile-ui';
+import { selectCurrentChannel } from '@mezon/store-mobile';
 import { EOverriddenPermission, EPermission } from '@mezon/utils';
 import { ChannelType } from 'mezon-js';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Pressable, Text, View } from 'react-native';
+import { useSelector } from 'react-redux';
 import MezonIconCDN from '../../../componentUI/MezonIconCDN';
 import { IconCDN } from '../../../constants/icon_cdn';
 import useStatusMuteChannel from '../../../hooks/useStatusMuteChannel';
@@ -33,7 +35,9 @@ export const ActionRow = React.memo(() => {
 		[EOverriddenPermission.manageThread, EPermission.manageChannel],
 		currentChannel?.channel_id ?? ''
 	);
+	const selectedcurrentChannel = useSelector(selectCurrentChannel);
 	const { statusMute } = useStatusMuteChannel();
+	console.log('statusMute', statusMute, currentChannel, selectedcurrentChannel);
 	const isChannelDm = useMemo(() => {
 		return [ChannelType.CHANNEL_TYPE_DM, ChannelType.CHANNEL_TYPE_GROUP].includes(currentChannel?.type);
 	}, [currentChannel]);
@@ -125,7 +129,13 @@ export const ActionRow = React.memo(() => {
 									action.icon
 								)}
 							</View>
-							<Text style={styles.optionText}>{action.title}</Text>
+							<Text style={styles.optionText}>
+								{[EActionRow.Mute].includes(action.type)
+									? statusMute === ENotificationActive.ON
+										? t('muteNotification')
+										: t('unmuteNotification')
+									: action.title}
+							</Text>
 						</View>
 					</Pressable>
 				) : null

--- a/apps/mobile/src/app/screens/home/homedrawer/components/ChannelMenu/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/ChannelMenu/index.tsx
@@ -165,9 +165,9 @@ export default function ChannelMenu({ channel }: IChannelMenuProps) {
 				DeviceEventEmitter.emit(ActionEmitEvent.ON_TRIGGER_BOTTOM_SHEET, { isDismiss: true });
 			},
 			icon: isChannelUnmute ? (
-				<MezonIconCDN icon={IconCDN.bellSlashIcon} color={themeValue.textStrong} />
+				<MezonIconCDN icon={IconCDN.bellIcon} color={themeValue.textStrong} />
 			) : (
-				<MezonIconCDN icon={IconCDN.bellIcon} color={themeValue.text} />
+				<MezonIconCDN icon={IconCDN.bellSlashIcon} color={themeValue.text} />
 			),
 			isShow: true
 		},

--- a/libs/translations/src/languages/en/common.json
+++ b/libs/translations/src/languages/en/common.json
@@ -9,5 +9,6 @@
     "media": "Media",
     "files": "Files",
     "pins": "Pins",
-    "wallet": "Wallet"
+    "wallet": "Wallet",
+    "unmuteNotification": "Un-mute"
 }

--- a/libs/translations/src/languages/vi/common.json
+++ b/libs/translations/src/languages/vi/common.json
@@ -9,5 +9,6 @@
     "media": "File phương tiện",
     "files": "Tệp",
     "pins": "Ghim",
-    "wallet": "Ví"
+    "wallet": "Ví",
+    "unmuteNotification": "Bật tiếng"
 }


### PR DESCRIPTION
Mobile app: fix notification setting not save status mobile.
Issue: https://github.com/orgs/nccasia/projects/16/views/1?filterQuery=hoang&pane=issue&itemId=114080653
Expect case:
- Open notication setting in channel not setting before, check option default.
- Show correct notication type option channel.
- Save status notification type when choose other option.