### PR TITLE
Mobile app: fix mute show action direct header detail mobile

### DIFF
--- a/apps/mobile/src/app/components/ThreadDetail/ActionRow/index.tsx
+++ b/apps/mobile/src/app/components/ThreadDetail/ActionRow/index.tsx
@@ -4,13 +4,12 @@ import React, { useContext } from 'react';
 import { usePermissionChecker } from '@mezon/core';
 import { ENotificationActive, ETypeSearch } from '@mezon/mobile-components';
 import { useTheme } from '@mezon/mobile-ui';
-import { selectCurrentChannel } from '@mezon/store-mobile';
+import { notificationSettingActions, useAppDispatch } from '@mezon/store-mobile';
 import { EOverriddenPermission, EPermission } from '@mezon/utils';
 import { ChannelType } from 'mezon-js';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Pressable, Text, View } from 'react-native';
-import { useSelector } from 'react-redux';
 import MezonIconCDN from '../../../componentUI/MezonIconCDN';
 import { IconCDN } from '../../../constants/icon_cdn';
 import useStatusMuteChannel from '../../../hooks/useStatusMuteChannel';
@@ -35,9 +34,8 @@ export const ActionRow = React.memo(() => {
 		[EOverriddenPermission.manageThread, EPermission.manageChannel],
 		currentChannel?.channel_id ?? ''
 	);
-	const selectedcurrentChannel = useSelector(selectCurrentChannel);
 	const { statusMute } = useStatusMuteChannel();
-	console.log('statusMute', statusMute, currentChannel, selectedcurrentChannel);
+	const dispatch = useAppDispatch();
 	const isChannelDm = useMemo(() => {
 		return [ChannelType.CHANNEL_TYPE_DM, ChannelType.CHANNEL_TYPE_GROUP].includes(currentChannel?.type);
 	}, [currentChannel]);
@@ -45,6 +43,11 @@ export const ActionRow = React.memo(() => {
 	useEffect(() => {
 		setIsChannel(!!currentChannel?.channel_label && !Number(currentChannel?.parent_id));
 	}, [currentChannel]);
+
+	useEffect(() => {
+		dispatch(notificationSettingActions.getNotificationSetting({ channelId: currentChannel?.channel_id }));
+	}, []);
+
 	const actionList = [
 		{
 			title: t('search'),

--- a/apps/mobile/src/app/hooks/useStatusMuteChannel.ts
+++ b/apps/mobile/src/app/hooks/useStatusMuteChannel.ts
@@ -3,6 +3,7 @@ import {
 	selectCurrentChannel,
 	selectDefaultNotificationCategory,
 	selectDefaultNotificationClan,
+	selectDmGroupCurrentId,
 	selectNotifiSettingsEntitiesById
 } from '@mezon/store-mobile';
 import { NotificationType } from 'mezon-js';
@@ -11,9 +12,10 @@ import { useSelector } from 'react-redux';
 
 const useStatusMuteChannel = () => {
 	const currentChannel = useSelector(selectCurrentChannel);
+	const currentDmId = useSelector(selectDmGroupCurrentId);
 	const [statusMute, setStatusMute] = useState<ENotificationActive>(ENotificationActive.ON);
 	const defaultNotificationCategory = useSelector(selectDefaultNotificationCategory);
-	const getNotificationChannelSelected = useSelector(selectNotifiSettingsEntitiesById(currentChannel?.id));
+	const getNotificationChannelSelected = useSelector(selectNotifiSettingsEntitiesById(currentDmId || currentChannel?.id));
 	const defaultNotificationClan = useSelector(selectDefaultNotificationClan);
 	useEffect(() => {
 		if (

--- a/apps/mobile/src/app/screens/home/homedrawer/components/MessageMenu/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/MessageMenu/index.tsx
@@ -195,9 +195,9 @@ function MessageMenu({ messageInfo }: IServerMenuProps) {
 				dismiss();
 			},
 			icon: isDmUnmute ? (
-				<MezonIconCDN icon={IconCDN.bellSlashIcon} color={themeValue.textStrong} />
+				<MezonIconCDN icon={IconCDN.bellIcon} color={themeValue.textStrong} />
 			) : (
-				<MezonIconCDN icon={IconCDN.bellIcon} width={22} height={22} color={themeValue.text} />
+				<MezonIconCDN icon={IconCDN.bellSlashIcon} width={22} height={22} color={themeValue.text} />
 			)
 		}
 		// {


### PR DESCRIPTION
Mobile app: fix mute show action direct header detail mobile.
Issue: https://github.com/orgs/nccasia/projects/16/views/1?filterQuery=hoang&pane=issue&itemId=114080653
Expect case:
- Show true status of direct message mute status when open header detail.
- Open mute screen when press mute.
- Open unmute screen when press mute.
- State sync between direct message item menu and header detail.