### PR TITLE
Mobile app: fix break UI when show album name mobile

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/AlbumPannel.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/AlbumPannel.tsx
@@ -227,7 +227,9 @@ export const AlbumPanel = ({ valueAlbum, onAlbumChange }: IAlbumProps) => {
 			>
 				<Image source={{ uri: item?.coverPhoto }} style={styles.albumCoverImage} />
 				<View style={styles.albumTitleAndCount}>
-					<Text style={styles.albumTitle}>{item.title}</Text>
+					<Text numberOfLines={1} ellipsizeMode="tail" style={styles.albumTitle}>
+						{item.title}
+					</Text>
 					<Text style={styles.albumImageCount}>{item.count}</Text>
 				</View>
 				{item?.title === valueAlbum && (

--- a/apps/mobile/src/app/screens/home/homedrawer/styles.ts
+++ b/apps/mobile/src/app/screens/home/homedrawer/styles.ts
@@ -817,7 +817,8 @@ export const style = (colors: Attributes) =>
 		albumTitleAndCount: {
 			gap: size.s_10,
 			justifyContent: 'flex-start',
-			marginLeft: size.s_10
+			marginLeft: size.s_10,
+			width: '55%'
 		},
 		albumImageCount: {
 			fontSize: size.s_12,


### PR DESCRIPTION
Mobile app: fix break UI when show album name mobile.
Issue: https://github.com/orgs/nccasia/projects/16/views/1?filterQuery=hoang&pane=issue&itemId=114377088
Expect case: render title of album with elipped size when it's too long.