### PR TITLE
Mobile app: fix candidate save profile setting mobile

### DIFF
--- a/apps/mobile/src/app/screens/settings/ProfileSetting/UserProfile/components/Info/index.tsx
+++ b/apps/mobile/src/app/screens/settings/ProfileSetting/UserProfile/components/Info/index.tsx
@@ -23,7 +23,7 @@ export default function DetailInfo({ value, onChange }: IDetailInfoProps) {
 				</View>
 
 				<MezonInput
-					value={value?.displayName || value?.username}
+					value={value?.displayName}
 					onTextChange={(newValue) => onChange({ displayName: newValue })}
 					placeHolder={value?.username}
 					maxCharacter={32}

--- a/apps/mobile/src/app/screens/settings/ProfileSetting/index.tsx
+++ b/apps/mobile/src/app/screens/settings/ProfileSetting/index.tsx
@@ -100,7 +100,7 @@ export const ProfileSetting = ({ navigation, route }: { navigation: any; route: 
 		const initialValue = {
 			username,
 			imgUrl: avatar_url,
-			displayName: display_name,
+			displayName: display_name || username,
 			aboutMe: about_me
 		};
 		setOriginUserProfileValue(initialValue);
@@ -271,25 +271,22 @@ export const ProfileSetting = ({ navigation, route }: { navigation: any; route: 
 
 	const saveCurrentTab = () => {
 		if (tab === EProfileTab.UserProfile) {
-			if (isUserProfileNotChanged) {
-				navigation.goBack();
-				return;
-			}
 			if (isUserProfileEmptyName) {
 				Toast.show({
 					type: 'error',
 					text1: t('emptyUsername')
 				});
-				return;
 			}
 			updateUserProfile();
 			return;
 		}
 
 		if (tab === EProfileTab.ClanProfile) {
-			if (isClanProfileNotChanged || isDuplicateClanNickname) {
-				navigation.goBack();
-				return;
+			if (isDuplicateClanNickname) {
+				Toast.show({
+					type: 'error',
+					text1: t('emptyUsername')
+				});
 			}
 			updateClanProfile();
 			return;

--- a/apps/mobile/src/app/screens/settings/ProfileSetting/index.tsx
+++ b/apps/mobile/src/app/screens/settings/ProfileSetting/index.tsx
@@ -226,17 +226,7 @@ export const ProfileSetting = ({ navigation, route }: { navigation: any; route: 
 		headerStatusBarHeight: Platform.OS === 'android' ? 0 : undefined,
 		headerRight: () => (
 			<Pressable onPress={() => saveCurrentTab()}>
-				<Text
-					style={[
-						styles.saveChangeButton,
-						(tab === EProfileTab.UserProfile && !isUserProfileEmptyName) ||
-						(tab === EProfileTab.ClanProfile && !isClanProfileEmptyName && !isDuplicateClanNickname)
-							? styles.changed
-							: styles.notChange
-					]}
-				>
-					{t('header.save')}
-				</Text>
+				<Text style={[styles.saveChangeButton, styles.changed]}>{t('header.save')}</Text>
 			</Pressable>
 		),
 		headerLeft: () => (
@@ -281,13 +271,26 @@ export const ProfileSetting = ({ navigation, route }: { navigation: any; route: 
 
 	const saveCurrentTab = () => {
 		if (tab === EProfileTab.UserProfile) {
-			if (isUserProfileEmptyName) return;
+			if (isUserProfileNotChanged) {
+				navigation.goBack();
+				return;
+			}
+			if (isUserProfileEmptyName) {
+				Toast.show({
+					type: 'error',
+					text1: t('emptyUsername')
+				});
+				return;
+			}
 			updateUserProfile();
 			return;
 		}
 
 		if (tab === EProfileTab.ClanProfile) {
-			if (isClanProfileEmptyName || isDuplicateClanNickname) return;
+			if (isClanProfileNotChanged || isDuplicateClanNickname) {
+				navigation.goBack();
+				return;
+			}
 			updateClanProfile();
 			return;
 		}

--- a/apps/mobile/src/app/screens/settings/ProfileSetting/index.tsx
+++ b/apps/mobile/src/app/screens/settings/ProfileSetting/index.tsx
@@ -276,6 +276,7 @@ export const ProfileSetting = ({ navigation, route }: { navigation: any; route: 
 					type: 'error',
 					text1: t('emptyUsername')
 				});
+				return;
 			}
 			updateUserProfile();
 			return;
@@ -287,6 +288,7 @@ export const ProfileSetting = ({ navigation, route }: { navigation: any; route: 
 					type: 'error',
 					text1: t('emptyUsername')
 				});
+				return;
 			}
 			updateClanProfile();
 			return;

--- a/libs/translations/src/languages/en/profileSetting.json
+++ b/libs/translations/src/languages/en/profileSetting.json
@@ -34,5 +34,6 @@
     "searchClanPlaceholder": "Search Clan",
     "updateProfileSuccess": "Update profile successfully",
     "updateClanProfileSuccess": "Update clan profile successfully",
-    "emptyUsername": "Display name cannot be blank!"
+    "emptyUsername": "Display name cannot be blank!",
+    "duplicateClannick": "Clan nick is duplicate!"
 }

--- a/libs/translations/src/languages/en/profileSetting.json
+++ b/libs/translations/src/languages/en/profileSetting.json
@@ -33,5 +33,6 @@
     "selectAClan": "Select A Clan",
     "searchClanPlaceholder": "Search Clan",
     "updateProfileSuccess": "Update profile successfully",
-    "updateClanProfileSuccess": "Update clan profile successfully"
+    "updateClanProfileSuccess": "Update clan profile successfully",
+    "emptyUsername": "Display name cannot be blank!"
 }

--- a/libs/translations/src/languages/vi/profileSetting.json
+++ b/libs/translations/src/languages/vi/profileSetting.json
@@ -33,5 +33,6 @@
     "selectAClan": "Chọn một clan",
     "searchClanPlaceholder": "Tìm kiếm clan",
     "updateProfileSuccess": "Cập nhật hồ sơ cá nhân thành công",
-    "updateClanProfileSuccess": "Cập nhật hồ sơ clan thành công"
+    "updateClanProfileSuccess": "Cập nhật hồ sơ clan thành công",
+    "emptyUsername": "Tên hiển thị không được để trống!"
 }

--- a/libs/translations/src/languages/vi/profileSetting.json
+++ b/libs/translations/src/languages/vi/profileSetting.json
@@ -34,5 +34,6 @@
     "searchClanPlaceholder": "Tìm kiếm clan",
     "updateProfileSuccess": "Cập nhật hồ sơ cá nhân thành công",
     "updateClanProfileSuccess": "Cập nhật hồ sơ clan thành công",
-    "emptyUsername": "Tên hiển thị không được để trống!"
+    "emptyUsername": "Tên hiển thị không được để trống!",
+    "duplicateClannick": "Tên clan bị trùng lặp"
 }


### PR DESCRIPTION
Mobile app: fix candidate save profile setting mobile.
Issue: https://github.com/orgs/nccasia/projects/16/views/1?filterQuery=hoang&pane=issue&itemId=114613666
Expect case:
- In Userprofile, when have no change, press save will go back profile screen.
- In Clanprofile, when have no change, press save will go back profile screen.
- In Userprofile, when display name empty, press save will show error toast.
- When have change in user profile or clan profile, press save will show loading and save new user information.