### PR TITLE
Mobile app: fix validate datetime when create event mobile

### DIFF
--- a/apps/mobile/src/app/components/EventCreator/EventCreatorDetails/EventCreatorDetails.tsx
+++ b/apps/mobile/src/app/components/EventCreator/EventCreatorDetails/EventCreatorDetails.tsx
@@ -111,8 +111,8 @@ export function EventCreatorDetails({ navigation, route }: MenuClanScreenProps<C
 	}, [endDate, startDate]);
 
 	const isErrorEndTime = useMemo(() => {
-		return startTime.getTime() >= endTime.getTime();
-	}, [endTime, startTime]);
+		return startDate.getDate() >= endDate.getDate() && startTime.getTime() >= endTime.getTime();
+	}, [endDate, endTime, startDate, startTime]);
 
 	function handlePressNext() {
 		setIsValidEventTitle(!!eventTitle?.trim()?.length);

--- a/apps/mobile/src/app/components/EventCreator/EventCreatorDetails/EventCreatorDetails.tsx
+++ b/apps/mobile/src/app/components/EventCreator/EventCreatorDetails/EventCreatorDetails.tsx
@@ -100,19 +100,19 @@ export function EventCreatorDetails({ navigation, route }: MenuClanScreenProps<C
 
 	const isErrorStartDate = useMemo(() => {
 		return startDate.getTime() <= today.getTime();
-	}, [startDate]);
+	}, [startDate, today]);
 
 	const isErrorStartTime = useMemo(() => {
 		return startTime.getTime() <= today.getTime();
-	}, [startTime]);
+	}, [startTime, today]);
 
 	const isErrorEndDate = useMemo(() => {
 		return startDate.getTime() >= endDate.getTime();
-	}, [endDate]);
+	}, [endDate, startDate]);
 
 	const isErrorEndTime = useMemo(() => {
 		return startTime.getTime() >= endTime.getTime();
-	}, [endTime]);
+	}, [endTime, startTime]);
 
 	function handlePressNext() {
 		setIsValidEventTitle(!!eventTitle?.trim()?.length);


### PR DESCRIPTION
Mobile app: fix validate datetime when create event mobile.
Issue: https://github.com/orgs/nccasia/projects/16/views/1?filterQuery=hoang&pane=issue&itemId=115379628
Expect case:
- StartTime < endTime and startDate <= endDate, user can go to next step.
- StartTime >= endTime and startDate < endDate, user can go to next step.
- StartTime >= endTime and startDate = endDate, show error.
- StartDate > EndDate, show error.
- StartDate < present time, show error.