### PR TITLE
Mobile app: fix append emoji picked in cursor position mobile

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/components/ChatBox/ChatBoxBottomBar/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/ChatBox/ChatBoxBottomBar/index.tsx
@@ -192,7 +192,7 @@ export const ChatBoxBottomBar = memo(
 					textFormat = textBeforeFormat + shortName + textAfterFormat;
 				}
 				setTextChange(textFormat);
-				cursorPositionRef.current = cursorPositionRef?.current || 0 + shortName.length + textSpacing;
+				cursorPositionRef.current = (cursorPositionRef.current || 0) + shortName.length + textSpacing;
 				await handleTextInputChange(textFormat);
 			},
 			[textChange]
@@ -229,6 +229,7 @@ export const ChatBoxBottomBar = memo(
 			[onShowKeyboardBottomSheet]
 		);
 		const handleTextInputChange = async (text: string) => {
+			console.log('xtttt', text);
 			const store = getStore();
 			setTextChange(text);
 			textValueInputRef.current = text;

--- a/libs/mobile-components/src/lib/helper/mentions/index.ts
+++ b/libs/mobile-components/src/lib/helper/mentions/index.ts
@@ -124,3 +124,26 @@ export const formatContentEditMessage = (message: IMessageWithUser) => {
 
 	return { formatContentDraft, emojiPicked };
 };
+
+export const adjustCursorPosition = (text: string, pos: number): number => {
+	const mentionRegex = /({@}|{#})\[([^\]]+)\]\((\d+)\)/g;
+	let offset = 0;
+	let match: RegExpExecArray | null;
+
+	while ((match = mentionRegex.exec(text)) !== null) {
+		const originalTokenStart = match.index;
+		const originalTokenLength = match[0].length;
+		const prefixOriginal = text.slice(0, originalTokenStart);
+		const prefixDisplay = convertMentionsToText(prefixOriginal);
+		const displayTokenStart = prefixDisplay.length;
+		const displayToken = match[1] === '{@}' ? `@[${match[2]}]` : `<#${match[2]}>`;
+		const displayTokenLength = displayToken.length;
+		const displayTokenEnd = displayTokenStart + displayTokenLength;
+		if (pos >= displayTokenEnd) {
+			offset += originalTokenLength - displayTokenLength;
+		} else if (pos >= displayTokenStart && pos < displayTokenEnd) {
+			return originalTokenStart + originalTokenLength;
+		}
+	}
+	return pos + offset;
+};


### PR DESCRIPTION
Mobile app: fix append emoji picked in cursor position mobile.
Issue: https://github.com/orgs/nccasia/projects/16/views/1?filterQuery=hoang&pane=issue&itemId=115380729
Expect case:
- Open emoji picker, press emoji will add emoji to the position of cursor.
- Add only emoji will add emoji with spacing and when send will send large size.
- Add Emoji with hashtag, mention will add correct position for not impact mention and calculate right new cursor.
- Add Emoji will add a spacing before and after emoji if text before and after not start or end with spacing.