### PR TITLE
Mobile app: fix wrong list image view in message mobile

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/components/MessageAttachment/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/MessageAttachment/index.tsx
@@ -44,7 +44,7 @@ export const MessageAttachment = React.memo(({ attachments, onLongPressImage, cl
 	const [videos, setVideos] = useState<ApiMessageAttachment[]>([]);
 	const [images, setImages] = useState<ApiMessageAttachment[]>([]);
 	const [documents, setDocuments] = useState<ApiMessageAttachment[]>([]);
-	const visibleImages = useMemo(() => images?.slice(0, 3), [images]);
+	const visibleImages = useMemo(() => images?.reverse()?.slice(0, 3), [images]);
 	const remainingImagesCount = images?.length - 3 || 0;
 	useEffect(() => {
 		const { videos, images, documents } = classifyAttachments(attachments ?? []);


### PR DESCRIPTION
Mobile app: fix wrong list image view in message mobile
Issue: https://github.com/orgs/nccasia/projects/16/views/1?filterQuery=hoang&pane=issue&itemId=115796541
Expect case:
- Show last image in list in the left in render image message.
- When list image more than 3 image, show visible 3 last image.