### PR TITLE
Mobile app: feat allow mention here direct message group mobile

### DIFF
--- a/apps/mobile/src/app/hooks/useUserMentionList.ts
+++ b/apps/mobile/src/app/hooks/useUserMentionList.ts
@@ -71,6 +71,8 @@ function UseMentionList({ channelID, channelMode }: UserMentionListProps): Menti
 
 		if (channelMode === ChannelStreamMode.STREAM_MODE_CHANNEL || channelMode === ChannelStreamMode.STREAM_MODE_THREAD) {
 			return [...sortedMentionList, ...roleMentions, hardcodedUser];
+		} else if (channelMode === ChannelStreamMode.STREAM_MODE_GROUP) {
+			return [...sortedMentionList, hardcodedUser];
 		} else {
 			return [...sortedMentionList];
 		}


### PR DESCRIPTION
Mobile app: feat allow mention here direct message group mobile.
Issue: https://github.com/orgs/nccasia/projects/16/views/1?filterQuery=hoang&pane=issue&itemId=113034402
Expect case:
- In channel, thread, show list mention user, role and here.
- In direct message group, show list mention user and here.
- In direct message with user, show list mention user