### PR TITLE
Mobile app: fix spacing too large between messages mobile

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/components/RenderTextMarkdown/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/RenderTextMarkdown/index.tsx
@@ -725,13 +725,13 @@ export const RenderTextMarkdownContent = ({
 					{textParts?.length > 0 && <Text key={`textParts${t}_${lastIndex}`}>{textParts}</Text>}
 					{markdownBlackParts?.length > 0 && markdownBlackParts.map((item) => item)}
 				</View>
-				<View>
-					{isEdited && (
+				{isEdited && (
+					<View>
 						<Text key={`edited-${textParts}`} style={themeValue ? markdownStyles(themeValue).editedText : {}}>
 							{translate('edited')}
 						</Text>
-					)}
-				</View>
+					</View>
+				)}
 			</View>
 		</View>
 	);


### PR DESCRIPTION
Mobile app: fix spacing too large between messages mobile.
Expect case:
- One line message has small spacing with other message.
- Multiline message has small spacing with other message.
- Text edited show correctly with message. 