### PR TITLE
Mobile app: fix list suggestion member mention render wrong size mobile

### DIFF
--- a/apps/mobile/src/app/components/Suggestions/index.tsx
+++ b/apps/mobile/src/app/components/Suggestions/index.tsx
@@ -68,7 +68,7 @@ const Suggestions: FC<MentionSuggestionsProps> = memo(({ keyword, onSelect, list
 					</Pressable>
 				);
 			}}
-			keyExtractor={(_, index) => `${index}_mention_suggestion`}
+			keyExtractor={(item, index) => `${item?.id}_${index}_mention_suggestion`}
 			onEndReachedThreshold={0.1}
 			keyboardShouldPersistTaps="handled"
 			windowSize={5}
@@ -237,3 +237,4 @@ const EmojiSuggestion: FC<IEmojiSuggestionProps> = memo(({ keyword, onSelect }) 
 });
 
 export { EmojiSuggestion, HashtagSuggestions, Suggestions };
+


### PR DESCRIPTION
Mobile app: fix list suggestion member mention render wrong size mobile.
Expect case:
- When @ mention with no keyword, show here mention in last, render correct size item.
- When @ mention with keyword, show sorted list, render correct size item.