### PR TITLE
Mobile app: fix empty message markdown pre mobile

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/components/ChatBox/ChatBoxBottomBar/useProcessedContent.ts
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/ChatBox/ChatBoxBottomBar/useProcessedContent.ts
@@ -137,7 +137,7 @@ const processText = (inputString: string, emojiObjPicked: any) => {
 			if (i < inputString.length && inputString.substring(i, i + tripleBacktick.length) === tripleBacktick) {
 				i += tripleBacktick.length;
 				const endindex = i;
-				if (markdown.trim().length > 0) {
+				if (markdown?.length > 0) {
 					markdowns.push({ type: EBacktickType.TRIPLE, s: startindex, e: endindex });
 				}
 			}

--- a/libs/mobile-components/src/lib/helper/mentions/index.ts
+++ b/libs/mobile-components/src/lib/helper/mentions/index.ts
@@ -99,6 +99,9 @@ export const createFormattedString = (data: IExtendedMessage) => {
 				emojiPicked?.push({ ...element, shortName: contentInElement });
 				formatContentDraft += contentInElement;
 				break;
+			case ETokenMessage.MARKDOWNS:
+				formatContentDraft += '```' + contentInElement?.replace(/^```|```$/g, '') + '```';
+				break;
 			default:
 				formatContentDraft += contentInElement;
 				break;


### PR DESCRIPTION
Mobile app: fix empty message markdown pre mobile.
Issue: https://github.com/orgs/nccasia/projects/16/views/1?filterQuery=hoang&pane=issue&itemId=116015497
Expect case:
- Allow send empty content in markdown pre.
- Show markdown with empty content send from web, desktop.
- Show markdown with empty content send from mobile.
- Show full markdown symbol when edit in chatbox mobile.