### PR TITLE
Mobile app: fix image not group when over amount mobile

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/components/MessageAttachment/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/MessageAttachment/index.tsx
@@ -2,7 +2,7 @@ import { ActionEmitEvent } from '@mezon/mobile-components';
 import { useTheme } from '@mezon/mobile-ui';
 import { attachmentActions } from '@mezon/store';
 import { useAppDispatch } from '@mezon/store-mobile';
-import { notImplementForGifOrStickerSendFromPanel } from '@mezon/utils';
+import { fileTypeImage, notImplementForGifOrStickerSendFromPanel } from '@mezon/utils';
 import { ApiMessageAttachment } from 'mezon-js/api.gen';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { DeviceEventEmitter, View } from 'react-native';
@@ -27,7 +27,7 @@ const classifyAttachments = (attachments: ApiMessageAttachment[]) => {
 	attachments.forEach((attachment) => {
 		if (attachment.filetype?.indexOf('video/mp4') !== -1 && !attachment.url?.includes('tenor.com')) {
 			videos.push(attachment);
-		} else if (attachment.filetype?.indexOf('image/png') !== -1 || attachment.filetype?.indexOf('image/jpeg') !== -1) {
+		} else if (fileTypeImage.includes(attachment?.filetype)) {
 			images.push(attachment);
 		} else {
 			documents.push(attachment);
@@ -44,8 +44,8 @@ export const MessageAttachment = React.memo(({ attachments, onLongPressImage, cl
 	const [videos, setVideos] = useState<ApiMessageAttachment[]>([]);
 	const [images, setImages] = useState<ApiMessageAttachment[]>([]);
 	const [documents, setDocuments] = useState<ApiMessageAttachment[]>([]);
-	const visibleImages = useMemo(() => images?.reverse()?.slice(0, 3), [images]);
-	const remainingImagesCount = images?.length - 3 || 0;
+	const visibleImages = useMemo(() => images?.reverse()?.slice(0, images?.length > 4 ? 3 : 4), [images]);
+	const remainingImagesCount = useMemo(() => images?.length - visibleImages?.length || 0, [images, visibleImages]);
 	useEffect(() => {
 		const { videos, images, documents } = classifyAttachments(attachments ?? []);
 		setVideos(videos);


### PR DESCRIPTION
Mobile app: fix image not group when over amount mobile
Expect case:
- When have from 1-4 image, show all image.
- When have over 4 image, show visible 3 image and group others with count.
- List check Image have all image type.
![image](https://github.com/user-attachments/assets/d6589e98-0b5e-4c24-ab72-03446b961444)

https://github.com/user-attachments/assets/b2e6f8b1-9388-4bae-98b0-b0232620dbcb

