### PR TITLE
Mobile app: fix can not clear cache chatbox when edit message mobile.

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/components/ChatBox/ActionMessageSelected/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/ChatBox/ActionMessageSelected/index.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { DeviceEventEmitter, Pressable, View } from 'react-native';
 import MezonIconCDN from '../../../../../../componentUI/MezonIconCDN';
 import { IconCDN } from '../../../../../../constants/icon_cdn';
-import { resetCachedMessageActionNeedToResolve } from '../../../../../../utils/helpers';
+import { resetCachedChatbox, resetCachedMessageActionNeedToResolve } from '../../../../../../utils/helpers';
 import { EMessageActionType } from '../../../enums';
 import { IMessageActionNeedToResolve } from '../../../types';
 
@@ -23,6 +23,7 @@ export const ActionMessageSelected = memo(({ messageActionNeedToResolve, onClose
 			case EMessageActionType.EditMessage:
 				onClose();
 				resetCachedMessageActionNeedToResolve(messageActionNeedToResolve?.targetMessage?.channel_id);
+				resetCachedChatbox(messageActionNeedToResolve?.targetMessage?.channel_id);
 				DeviceEventEmitter.emit(ActionEmitEvent.CLEAR_TEXT_INPUT);
 				break;
 			case EMessageActionType.Reply:

--- a/apps/mobile/src/app/screens/home/homedrawer/components/ChatBox/ChatBoxBottomBar/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/ChatBox/ChatBoxBottomBar/index.tsx
@@ -42,7 +42,7 @@ import { SlashCommandSuggestions } from '../../../../../../components/Suggestion
 import { SlashCommandMessage } from '../../../../../../components/Suggestions/SlashCommandSuggestions/SlashCommandMessage';
 import { IconCDN } from '../../../../../../constants/icon_cdn';
 import { APP_SCREEN } from '../../../../../../navigation/ScreenTypes';
-import { resetCachedMessageActionNeedToResolve } from '../../../../../../utils/helpers';
+import { resetCachedChatbox, resetCachedMessageActionNeedToResolve } from '../../../../../../utils/helpers';
 import { EMessageActionType } from '../../../enums';
 import { IMessageActionNeedToResolve } from '../../../types';
 import AttachmentPreview from '../../AttachmentPreview';
@@ -183,13 +183,6 @@ export const ChatBoxBottomBar = memo(
 			textValueInputRef.current = convertMentionsToText(allCachedMessage?.[channelId] || '');
 		};
 
-		const resetCachedText = useCallback(async () => {
-			const allCachedMessage = load(STORAGE_KEY_TEMPORARY_INPUT_MESSAGES) || {};
-			if (allCachedMessage?.[channelId]) allCachedMessage[channelId] = '';
-
-			save(STORAGE_KEY_TEMPORARY_INPUT_MESSAGES, allCachedMessage);
-		}, [channelId]);
-
 		const handleEventAfterEmojiPicked = useCallback(
 			async (shortName: string) => {
 				let textFormat;
@@ -239,7 +232,7 @@ export const ChatBoxBottomBar = memo(
 			mentionsOnMessage.current = [];
 			hashtagsOnMessage.current = [];
 			onDeleteMessageActionNeedToResolve();
-			resetCachedText();
+			resetCachedChatbox(channelId);
 			resetCachedMessageActionNeedToResolve(channelId);
 			dispatch(
 				emojiSuggestionActions.setSuggestionEmojiObjPicked({
@@ -248,7 +241,7 @@ export const ChatBoxBottomBar = memo(
 					isReset: true
 				})
 			);
-		}, [dispatch, onDeleteMessageActionNeedToResolve, resetCachedText, channelId]);
+		}, [dispatch, onDeleteMessageActionNeedToResolve, channelId]);
 
 		const handleKeyboardBottomSheetMode = useCallback((mode: IModeKeyboardPicker) => {
 			setModeKeyBoardBottomSheet(mode);

--- a/apps/mobile/src/app/utils/helpers.ts
+++ b/apps/mobile/src/app/utils/helpers.ts
@@ -1,4 +1,4 @@
-import { load, save, STORAGE_MESSAGE_ACTION_NEED_TO_RESOLVE } from '@mezon/mobile-components';
+import { load, save, STORAGE_KEY_TEMPORARY_INPUT_MESSAGES, STORAGE_MESSAGE_ACTION_NEED_TO_RESOLVE } from '@mezon/mobile-components';
 import { EmojiDataOptionals } from '@mezon/utils';
 import { safeJSONParse } from 'mezon-js';
 import { Platform } from 'react-native';
@@ -69,6 +69,12 @@ export const resetCachedMessageActionNeedToResolve = (channelId: string) => {
 	const allCachedMessage = load(STORAGE_MESSAGE_ACTION_NEED_TO_RESOLVE) || {};
 	if (allCachedMessage?.[channelId]) allCachedMessage[channelId] = null;
 	save(STORAGE_MESSAGE_ACTION_NEED_TO_RESOLVE, allCachedMessage);
+};
+
+export const resetCachedChatbox = (channelId: string) => {
+	const allCachedMessage = load(STORAGE_KEY_TEMPORARY_INPUT_MESSAGES) || {};
+	if (allCachedMessage?.[channelId]) allCachedMessage[channelId] = '';
+	save(STORAGE_KEY_TEMPORARY_INPUT_MESSAGES, allCachedMessage);
 };
 
 export const getUserStatusByMetadata = (metadata: string | { status: string; user_status: string }) => {

--- a/apps/mobile/src/app/utils/helpers.ts
+++ b/apps/mobile/src/app/utils/helpers.ts
@@ -66,15 +66,23 @@ export const validTextInputRegex = /^(?![_\-\s])[a-zA-Z0-9\p{L}\p{N}_\-\s]{1,64}
 export const linkGoogleMeet = 'https://meet.google.com/';
 
 export const resetCachedMessageActionNeedToResolve = (channelId: string) => {
-	const allCachedMessage = load(STORAGE_MESSAGE_ACTION_NEED_TO_RESOLVE) || {};
-	if (allCachedMessage?.[channelId]) allCachedMessage[channelId] = null;
-	save(STORAGE_MESSAGE_ACTION_NEED_TO_RESOLVE, allCachedMessage);
+	try {
+		const allCachedMessage = load(STORAGE_MESSAGE_ACTION_NEED_TO_RESOLVE) || {};
+		if (allCachedMessage?.[channelId]) allCachedMessage[channelId] = null;
+		save(STORAGE_MESSAGE_ACTION_NEED_TO_RESOLVE, allCachedMessage);
+	} catch (error) {
+		console.error('Failed to reset cached message action need to resolve:', error);
+	}
 };
 
 export const resetCachedChatbox = (channelId: string) => {
-	const allCachedMessage = load(STORAGE_KEY_TEMPORARY_INPUT_MESSAGES) || {};
-	if (allCachedMessage?.[channelId]) allCachedMessage[channelId] = '';
-	save(STORAGE_KEY_TEMPORARY_INPUT_MESSAGES, allCachedMessage);
+	try {
+		const allCachedMessage = load(STORAGE_KEY_TEMPORARY_INPUT_MESSAGES) || {};
+		if (allCachedMessage?.[channelId]) allCachedMessage[channelId] = '';
+		save(STORAGE_KEY_TEMPORARY_INPUT_MESSAGES, allCachedMessage);
+	} catch (error) {
+		console.error('Failed to reset cached chatbox:', error);
+	}
 };
 
 export const getUserStatusByMetadata = (metadata: string | { status: string; user_status: string }) => {


### PR DESCRIPTION
Mobile app: fix can not clear cache chatbox when edit message mobile.
Issue: https://github.com/orgs/nccasia/projects/16/views/1?filterQuery=hoang&pane=issue&itemId=117532107
Expect case:
- When press edit message, save action and input to cache, when go back and rejoin channel. load action and text.
- When press close edit message clear all cache action and text.