### PR TITLE
Mobile app: fix toggle switch channel permission setting mobile

### DIFF
--- a/apps/mobile/src/app/componentUI/MezonSwitch/index.tsx
+++ b/apps/mobile/src/app/componentUI/MezonSwitch/index.tsx
@@ -1,7 +1,6 @@
 import { baseColor, useTheme } from '@mezon/mobile-ui';
 import React, { ReactNode, useEffect, useState } from 'react';
-import { SwitchProps, View } from 'react-native';
-import { Pressable } from 'react-native-gesture-handler';
+import { SwitchProps, TouchableOpacity, View } from 'react-native';
 import { IconCDN } from '../../constants/icon_cdn';
 import MezonIconCDN from '../MezonIconCDN';
 import { style } from './styles';
@@ -28,7 +27,8 @@ export const MezonSwitch = ({ value, onValueChange, iconYesNo, iconOn, iconOff, 
 	};
 
 	return (
-		<Pressable
+		<TouchableOpacity
+			activeOpacity={1}
 			style={[styles.switchContainer, isEnabled ? styles.switchContainerEnabled : {}, disabled ? styles.disabled : {}]}
 			onPress={toggleSwitch}
 			disabled={disabled}
@@ -46,7 +46,7 @@ export const MezonSwitch = ({ value, onValueChange, iconYesNo, iconOn, iconOff, 
 					iconOff
 				)}
 			</View>
-		</Pressable>
+		</TouchableOpacity>
 	);
 };
 

--- a/apps/mobile/src/app/screens/channelPermissionSetting/BasicView/index.tsx
+++ b/apps/mobile/src/app/screens/channelPermissionSetting/BasicView/index.tsx
@@ -3,6 +3,7 @@ import { useAuth, useCheckOwnerForUser } from '@mezon/core';
 import { ActionEmitEvent } from '@mezon/mobile-components';
 import { Colors, Text, size, useTheme } from '@mezon/mobile-ui';
 import {
+	appActions,
 	channelsActions,
 	fetchUserChannels,
 	rolesClanActions,
@@ -19,7 +20,6 @@ import { useTranslation } from 'react-i18next';
 import { DeviceEventEmitter, TouchableOpacity, View } from 'react-native';
 import Toast from 'react-native-toast-message';
 import { useSelector } from 'react-redux';
-import MezonConfirm from '../../../componentUI/MezonConfirm';
 import MezonIconCDN from '../../../componentUI/MezonIconCDN';
 import MezonSwitch from '../../../componentUI/MezonSwitch';
 import { IconCDN } from '../../../constants/icon_cdn';
@@ -75,29 +75,10 @@ export const BasicView = memo(({ channel }: IBasicViewProps) => {
 		];
 	}, [availableMemberList, availableRoleList, t]);
 
-	const onPrivateChannelChange = useCallback(
-		(value: boolean) => {
-			setIsChannelPublic(!value);
-			const data = {
-				children: (
-					<MezonConfirm
-						onConfirm={() => updateChannel(!value)}
-						title={
-							value ? t('channelPermission.warningModal.privateChannelTitle') : t('channelPermission.warningModal.publicChannelTitle')
-						}
-						confirmText={t('channelPermission.warningModal.confirm')}
-						content={
-							value
-								? t('channelPermission.warningModal.privateChannelContent', { channelLabel: channel?.channel_label })
-								: t('channelPermission.warningModal.publicChannelContent', { channelLabel: channel?.channel_label })
-						}
-					/>
-				)
-			};
-			DeviceEventEmitter.emit(ActionEmitEvent.ON_TRIGGER_MODAL, { isDismiss: false, data });
-		},
-		[t, channel?.channel_label]
-	);
+	const onPrivateChannelChange = useCallback((value: boolean) => {
+		setIsChannelPublic(!value);
+		updateChannel(!value);
+	}, []);
 
 	const openBottomSheet = () => {
 		bottomSheetRef.current?.present();
@@ -105,31 +86,39 @@ export const BasicView = memo(({ channel }: IBasicViewProps) => {
 
 	const updateChannel = useCallback(
 		async (privateChannel: boolean) => {
-			DeviceEventEmitter.emit(ActionEmitEvent.ON_TRIGGER_MODAL, { isDismiss: true });
+			try {
+				DeviceEventEmitter.emit(ActionEmitEvent.ON_TRIGGER_MODAL, { isDismiss: true });
+				dispatch(appActions.setLoadingMainMobile(true));
 
-			const response = await dispatch(
-				channelsActions.updateChannelPrivate({
-					channel_id: channel.id,
-					channel_private: privateChannel ? 1 : 0,
-					user_ids: [userId],
-					role_ids: []
-				})
-			);
-			const isError = ERequestStatus.Rejected === response?.meta?.requestStatus;
-			if (isError) {
-				setIsChannelPublic(isPublicChannel(channel));
-			}
-			Toast.show({
-				type: 'success',
-				props: {
-					text2: isError ? t('channelPermission.toast.failed') : t('channelPermission.toast.success'),
-					leadingIcon: isError ? (
-						<MezonIconCDN icon={IconCDN.closeIcon} color={Colors.red} />
-					) : (
-						<MezonIconCDN icon={IconCDN.checkmarkLargeIcon} color={Colors.green} />
-					)
+				const response = await dispatch(
+					channelsActions.updateChannelPrivate({
+						channel_id: channel.id,
+						channel_private: privateChannel ? 1 : 0,
+						user_ids: [userId],
+						role_ids: []
+					})
+				);
+				const isError = ERequestStatus.Rejected === response?.meta?.requestStatus;
+				if (isError) {
+					throw new Error();
+				} else {
+					Toast.show({
+						type: 'success',
+						props: {
+							text2: t('channelPermission.toast.success'),
+							leadingIcon: <MezonIconCDN icon={IconCDN.checkmarkLargeIcon} color={Colors.green} />
+						}
+					});
 				}
-			});
+			} catch (error) {
+				setIsChannelPublic(isPublicChannel(channel));
+				Toast.show({
+					type: 'error',
+					text1: t('channelPermission.toast.failed')
+				});
+			} finally {
+				dispatch(appActions.setLoadingMainMobile(false));
+			}
 		},
 		[channel, userId, t]
 	);


### PR DESCRIPTION
Mobile app: fix toggle switch channel permission setting mobile.
Issue: https://github.com/orgs/nccasia/projects/16/views/1?filterQuery=hoang&pane=issue&itemId=117534809
Expect case:
- Press switch or panel switch in private channel, show modal confirm change to public, update channel to public and hide add member panel button.
- Press switch or panel switch in public channel, show modal confirm change to private, update channel to private and show add member panel button.
- Press switch will not toggle opacity in panel switch.

https://github.com/user-attachments/assets/ff9f8be8-1829-4fe4-b5cf-469c74a26be9

