### PR TITLE
Mobile app: fix download image in embed message option mobile

### DIFF
--- a/apps/mobile/src/app/components/ChannelSetting/ChannelSetting.tsx
+++ b/apps/mobile/src/app/components/ChannelSetting/ChannelSetting.tsx
@@ -266,12 +266,15 @@ export function ChannelSetting({ navigation, route }: MenuChannelScreenProps<Scr
 				return;
 			}
 
-			await dispatch(
+			const response = await dispatch(
 				channelsActions.deleteChannel({
 					channelId: channel?.channel_id,
 					clanId: channel?.clan_id
 				})
 			);
+			if (response?.meta?.requestStatus === 'rejected') {
+				throw response?.error?.message;
+			}
 			navigation.navigate(APP_SCREEN.HOME);
 			if (channel?.parent_id !== '0') {
 				await dispatch(

--- a/apps/mobile/src/app/screens/home/homedrawer/components/ChannelMenu/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/ChannelMenu/index.tsx
@@ -383,7 +383,12 @@ export default function ChannelMenu({ channel }: IChannelMenuProps) {
 			if (channel?.channel_id === currentSystemMessage?.channel_id) {
 				Toast.show({ type: 'error', text1: t('modalConfirm.channel.systemChannel') });
 			} else {
-				await dispatch(channelsActions.deleteChannel({ channelId: channel?.channel_id || '', clanId: channel?.clan_id || '' }));
+				const response = await dispatch(
+					channelsActions.deleteChannel({ channelId: channel?.channel_id || '', clanId: channel?.clan_id || '' })
+				);
+				if (response?.meta?.requestStatus === 'rejected') {
+					throw response?.error?.message;
+				}
 			}
 		} catch (error) {
 			Toast.show({ type: 'error', text1: t('modalConfirm.channel.error', { error }) });

--- a/apps/mobile/src/app/screens/home/homedrawer/components/MessageItemBS/ContainerMessageActionModal.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/MessageItemBS/ContainerMessageActionModal.tsx
@@ -317,7 +317,7 @@ export const ContainerMessageActionModal = React.memo((props: IReplyBottomSheet)
 	};
 
 	const handleActionSaveImage = async () => {
-		const media = message?.attachments;
+		const media = message?.attachments?.length > 0 ? message?.attachments : message?.content?.embed?.map((item) => item?.image);
 		dispatch(appActions.setLoadingMainMobile(true));
 		if (media && media.length > 0) {
 			const promises = media?.map(downloadAndSaveMedia);
@@ -523,8 +523,9 @@ export const ContainerMessageActionModal = React.memo((props: IReplyBottomSheet)
 			);
 		}
 		const mediaList =
-			message?.attachments?.length > 0 &&
-			message.attachments?.every((att) => att?.filetype?.includes('image') || att?.filetype?.includes('video'))
+			(message?.attachments?.length > 0 &&
+				message.attachments?.every((att) => att?.filetype?.includes('image') || att?.filetype?.includes('video'))) ||
+			message?.content?.embed?.some((embed) => embed?.image)
 				? []
 				: [EMessageActionType.SaveImage, EMessageActionType.CopyMediaLink];
 


### PR DESCRIPTION
Mobile app: fix download image in embed message option mobile
Expect case:
- Press in image in message press down load in modal or message option can download image.
- Show save media option when embed message has image.
- Down load sucessfully image from embed message in modal and message option.

https://github.com/user-attachments/assets/3aad41fe-c78c-4088-b807-11086f9df645

