### PR TITLE
Mobile app: feat handle copy message link channel mobile

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/components/MessageItemBS/ContainerMessageActionModal.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/MessageItemBS/ContainerMessageActionModal.tsx
@@ -375,6 +375,25 @@ export const ContainerMessageActionModal = React.memo((props: IReplyBottomSheet)
 		}
 	};
 
+	const handleActionCopyMessageLink = () => {
+		try {
+			DeviceEventEmitter.emit(ActionEmitEvent.ON_TRIGGER_BOTTOM_SHEET, { isDismiss: true });
+			let messageLinkCopy = `${process.env.NX_CHAT_APP_REDIRECT_URI}/chat/clans/${message?.clan_id}/channels/${message?.channel_id}/messages/${message?.id}`;
+			if (message?.clan_id === '0' || !message?.clan_id)
+				messageLinkCopy = `${process.env.NX_CHAT_APP_REDIRECT_URI}/chat/direct/message/${message?.channel_id}/${currentDmGroup?.type}/${message?.id}`;
+			Clipboard.setString(messageLinkCopy);
+			Toast.show({
+				type: 'success',
+				props: {
+					text2: t('toast.copyMessageLink'),
+					leadingIcon: <MezonIconCDN icon={IconCDN.copyIcon} width={size.s_20} height={size.s_20} color={Colors.bgGrayLight} />
+				}
+			});
+		} catch (error) {
+			console.error('Error copying message link:', error);
+		}
+	};
+
 	const implementAction = (type: EMessageActionType) => {
 		switch (type) {
 			case EMessageActionType.GiveACoffee:
@@ -404,9 +423,9 @@ export const ContainerMessageActionModal = React.memo((props: IReplyBottomSheet)
 			case EMessageActionType.UnPinMessage:
 				handleActionUnPinMessage();
 				break;
-			// case EMessageActionType.CopyMessageLink:
-			// 	handleActionCopyMessageLink();
-			// 	break;
+			case EMessageActionType.CopyMessageLink:
+				handleActionCopyMessageLink();
+				break;
 			case EMessageActionType.CopyMediaLink:
 				handleActionCopyMediaLink();
 				break;
@@ -509,7 +528,8 @@ export const ContainerMessageActionModal = React.memo((props: IReplyBottomSheet)
 			isHideDeleteMessage && EMessageActionType.DeleteMessage,
 			((!isMessageError && isMyMessage) || !isMyMessage) && EMessageActionType.ResendMessage,
 			(isMyMessage || isMessageSystem || isAnonymous) && EMessageActionType.GiveACoffee,
-			isHideTopicDiscussion && EMessageActionType.TopicDiscussion
+			isHideTopicDiscussion && EMessageActionType.TopicDiscussion,
+			isDM && EMessageActionType.CopyMessageLink
 		];
 
 		let availableMessageActions: IMessageAction[] = [];

--- a/apps/mobile/src/app/screens/home/homedrawer/components/RenderTextMarkdown/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/RenderTextMarkdown/index.tsx
@@ -567,7 +567,9 @@ export const RenderTextMarkdownContent = ({
 
 						if (contentHasChannelLink) {
 							const pathSegments = contentInElement?.split('/') as string[];
+							const clanIdOnlink = pathSegments?.[pathSegments?.indexOf('clans') + 1];
 							const channelIdOnLink = pathSegments?.[pathSegments?.indexOf('channels') + 1];
+							const messageIdOnLink = pathSegments?.includes('messages') ? pathSegments?.[pathSegments?.indexOf('messages') + 1] : null;
 
 							const channelsEntities = selectChannelsEntities(store.getState() as any);
 							const hashtagDmEntities = selectHashtagDmEntities(store.getState() as any);
@@ -589,11 +591,12 @@ export const RenderTextMarkdownContent = ({
 								const payloadChannel = {
 									type: Number(dataChannel?.[0] || 1),
 									id: dataChannel?.[1],
-									channel_id: dataChannel?.[1],
-									clan_id: dataChannel?.[2],
+									channel_id: channelIdOnLink,
+									clan_id: clanIdOnlink,
 									status: Number(dataChannel?.[3] || 1),
 									meeting_code: dataChannel?.[4] || '',
-									category_id: dataChannel?.[5]
+									category_id: dataChannel?.[5],
+									message_id: messageIdOnLink
 								};
 
 								textParts.push(
@@ -613,6 +616,22 @@ export const RenderTextMarkdownContent = ({
 									>
 										{renderChannelIcon(payloadChannel?.type, payloadChannel?.channel_id, themeValue)}
 										{payloadChannel?.channel_id === 'undefined' ? 'private-channel' : text}
+										{payloadChannel?.channel_id !== 'undefined' && messageIdOnLink && (
+											<Text>
+												<Feather
+													name="chevron-right"
+													size={size.s_14}
+													color={Colors.textLink}
+													style={{ marginTop: size.s_10 }}
+												/>{' '}
+												<Feather
+													name="message-circle"
+													size={size.s_14}
+													color={Colors.textLink}
+													style={{ paddingTop: size.s_10 }}
+												/>
+											</Text>
+										)}
 									</Text>
 								);
 								break;

--- a/apps/mobile/src/app/screens/home/homedrawer/constants/message.ts
+++ b/apps/mobile/src/app/screens/home/homedrawer/constants/message.ts
@@ -84,5 +84,10 @@ export const getMessageActions = (t: TFunction): IMessageAction[] => {
 			title: t('message:actions.markMessage'),
 			type: EMessageActionType.MarkMessage
 		},
+		{
+			id: 19,
+			title: t('message:actions.copyMessageLink'),
+			type: EMessageActionType.CopyMessageLink
+		}
 	];
 };


### PR DESCRIPTION
Mobile app: feat handle copy message link channel mobile.
Issue: https://github.com/orgs/nccasia/projects/16/views/1?filterQuery=hoang&pane=issue&itemId=117124115

Expect case:
- Show option channel copy message link.
- Press copy message link show sucessfully toast and copy link message to clipboard.
- Markdown message link with channel and message icon.
- Press message link message markdown jump to channel and message.

https://github.com/user-attachments/assets/75aa8db6-21ea-4230-bd65-00d76ba145a0


