### PR TITLE
Mobile app: fix cache message reply sticker gif mobile.

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/ChatBoxMain.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/ChatBoxMain.tsx
@@ -44,6 +44,7 @@ export const ChatBoxMain = memo((props: IChatBoxProps) => {
 			if (value?.type === EMessageActionType.EditMessage) {
 				saveMessageActionNeedToResolve(value);
 			} else {
+				if (!value?.targetMessage?.channel_id) return;
 				resetCachedMessageActionNeedToResolve(value?.targetMessage?.channel_id);
 			}
 		});
@@ -68,6 +69,7 @@ export const ChatBoxMain = memo((props: IChatBoxProps) => {
 	};
 	const deleteMessageActionNeedToResolve = useCallback(() => {
 		setMessageActionNeedToResolve(null);
+		DeviceEventEmitter.emit(ActionEmitEvent.SHOW_KEYBOARD, null);
 	}, []);
 
 	return (

--- a/apps/mobile/src/app/screens/home/homedrawer/components/ChatBox/ChatBoxBottomBar/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/ChatBox/ChatBoxBottomBar/index.tsx
@@ -270,6 +270,7 @@ export const ChatBoxBottomBar = memo(
 					isReset: true
 				})
 			);
+			DeviceEventEmitter.emit(ActionEmitEvent.SHOW_KEYBOARD, null);
 		}, [dispatch, onDeleteMessageActionNeedToResolve, channelId]);
 
 		const handleKeyboardBottomSheetMode = useCallback((mode: IModeKeyboardPicker) => {


### PR DESCRIPTION
Mobile app: fix cache message reply sticker gif mobile.
Issue: https://github.com/orgs/nccasia/projects/16/views/1?filterQuery=hoang&pane=issue&itemId=118617112
Expect case:
- After send a reply message, send sticker will not reply.
- After cancel a reply message, send sticker will not reply.


https://github.com/user-attachments/assets/aaae39d8-ea84-4214-b343-6461cc254e5d

