### PR TITLE
Mobile app: fix channel setting notification not change mobile

### DIFF
--- a/apps/mobile/src/app/components/MuteThreadDetailModal/index.tsx
+++ b/apps/mobile/src/app/components/MuteThreadDetailModal/index.tsx
@@ -137,7 +137,7 @@ const MuteThreadDetailModal = ({ route }: MuteThreadDetailModalProps) => {
 	const openBottomSheet = () => {
 		const data = {
 			heightFitContent: true,
-			children: <NotificationSetting />
+			children: <NotificationSetting channel={currentChannel}/>
 		};
 		DeviceEventEmitter.emit(ActionEmitEvent.ON_TRIGGER_BOTTOM_SHEET, { isDismiss: false, data });
 	};

--- a/apps/mobile/src/app/components/NotificationSetting/index.tsx
+++ b/apps/mobile/src/app/components/NotificationSetting/index.tsx
@@ -1,20 +1,21 @@
 import { IOptionsNotification, notifyLabels } from '@mezon/mobile-components';
 import { useTheme } from '@mezon/mobile-ui';
 import {
+	appActions,
 	notificationSettingActions,
 	selectCurrentChannelId,
 	selectCurrentClanId,
 	selectDefaultNotificationCategory,
 	selectDefaultNotificationClan,
-	selectNotifiReactMessage,
 	selectNotifiSettingsEntitiesById,
 	useAppDispatch,
 	useAppSelector
 } from '@mezon/store-mobile';
-import { ChannelThreads, ENotificationTypes } from '@mezon/utils';
+import { ChannelThreads, ENotificationTypes, sleep } from '@mezon/utils';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Text, View } from 'react-native';
+import Toast from 'react-native-toast-message';
 import { useSelector } from 'react-redux';
 import FilterCheckbox from './FilterCheckbox/FilterCheckbox';
 import { style } from './NotificationSetting.styles';
@@ -53,7 +54,6 @@ export default function NotificationSetting({ channel }: { channel?: ChannelThre
 	const currentChannelId = useSelector(selectCurrentChannelId);
 	const [radioBox, setRadioBox] = useState<IOptionsNotification[]>(optionNotifySetting);
 	const currentClanId = useSelector(selectCurrentClanId);
-	const notifyReactMessage = useSelector(selectNotifiReactMessage);
 	const getNotificationChannelSelected = useAppSelector((state) => selectNotifiSettingsEntitiesById(state, channel?.id || currentChannelId || ''));
 	const defaultNotificationCategory = useAppSelector((state) => selectDefaultNotificationCategory(state, channel?.category_id as string));
 	const defaultNotificationClan = useSelector(selectDefaultNotificationClan);
@@ -64,7 +64,7 @@ export default function NotificationSetting({ channel }: { channel?: ChannelThre
 			return;
 		}
 		setRadioBox(radioBox.map((item) => item && { ...item, isChecked: getNotificationChannelSelected?.notification_setting_type === item.value }));
-	}, [notifyReactMessage, getNotificationChannelSelected]);
+	}, [getNotificationChannelSelected]);
 
 	useEffect(() => {
 		if (defaultNotificationCategory?.notification_setting_type) {
@@ -74,29 +74,44 @@ export default function NotificationSetting({ channel }: { channel?: ChannelThre
 		}
 	}, [getNotificationChannelSelected, defaultNotificationCategory, defaultNotificationClan]);
 
-	const handleRadioBoxPress = (checked: boolean, id: number) => {
+	const handleRadioBoxPress = async (checked: boolean, id: number) => {
 		const notifyOptionSelected = radioBox.map((item) => item && { ...item, isChecked: item.id === id });
 		setRadioBox(notifyOptionSelected);
 		if (notifyOptionSelected?.length) {
 			const notifyOptionSettingSelected = notifyOptionSelected.find((option) => option.isChecked);
-			if (
-				[ENotificationTypes.ALL_MESSAGE, ENotificationTypes.MENTION_MESSAGE, ENotificationTypes.NOTHING_MESSAGE].includes(
-					notifyOptionSettingSelected?.value
-				)
-			) {
-				const body = {
-					channel_id: channel?.channel_id || currentChannelId || '',
-					notification_type: notifyOptionSettingSelected?.value || 0,
-					clan_id: currentClanId || ''
-				};
-				dispatch(notificationSettingActions.setNotificationSetting(body));
-			} else {
-				dispatch(
-					notificationSettingActions.deleteNotiChannelSetting({
+			try {
+				dispatch(appActions.setLoadingMainMobile(true));
+				if (
+					[ENotificationTypes.ALL_MESSAGE, ENotificationTypes.MENTION_MESSAGE, ENotificationTypes.NOTHING_MESSAGE].includes(
+						notifyOptionSettingSelected?.value
+					)
+				) {
+					const body = {
 						channel_id: channel?.channel_id || currentChannelId || '',
+						notification_type: notifyOptionSettingSelected?.value || 0,
 						clan_id: currentClanId || ''
-					})
-				);
+					};
+					const res = await dispatch(notificationSettingActions.setNotificationSetting(body));
+					if (res?.meta?.requestStatus === 'rejected') {
+						throw res?.meta?.requestStatus;
+					}
+				} else {
+					const res = await dispatch(
+						notificationSettingActions.deleteNotiChannelSetting({
+							channel_id: channel?.channel_id || currentChannelId || '',
+							clan_id: currentClanId || ''
+						})
+					);
+					if (res?.meta?.requestStatus === 'rejected') {
+						throw res?.meta?.requestStatus;
+					}
+				}
+			} catch (error) {
+				Toast.show({ type: 'error', text1: t('toast.error', { error: error }) });
+				await sleep(100);
+				setRadioBox(radioBox);
+			} finally {
+				dispatch(appActions.setLoadingMainMobile(false));
 			}
 		}
 	};

--- a/libs/translations/src/languages/en/notificationSetting.json
+++ b/libs/translations/src/languages/en/notificationSetting.json
@@ -26,5 +26,8 @@
       "untilTurnItBackOn": "Until turn it back on"
     },
     "description": "You are receiving notifications from all messages in this clan, but you can override it here"
+  },
+  "toast": {
+    "error": "Error update notification: {{error}}"
   }
 }

--- a/libs/translations/src/languages/vi/notificationSetting.json
+++ b/libs/translations/src/languages/vi/notificationSetting.json
@@ -26,5 +26,8 @@
       "untilTurnItBackOn": "Cho đến khi bật lại"
     },
     "description": "Bạn đang nhận được thông báo từ tất cả tin nhắn trong clan này, nhưng bạn có thể thay đổi cài đặt tại đây"
+  },
+  "toast": {
+    "error": "Cập nhật thông báo lỗi: {{error}}"
   }
 }


### PR DESCRIPTION
Mobile app: fix channel setting notification not change mobile.
Issue: https://github.com/orgs/nccasia/projects/16/views/1?filterQuery=hoang&pane=issue&itemId=119069336
Expect case:
- Update notification setting sync change between notification option in channel menu and mute thread detail.
- Loading when call update setting.
- Show toast and return option when update failed.


https://github.com/user-attachments/assets/52f27a86-8f1f-4831-9ec0-2be8f15fd04b


https://github.com/user-attachments/assets/b4a7db68-488a-4b02-917b-f6efc4868812

