### PR TITLE
Mobile app: fix clan setting missing toggle audit log mobile

### DIFF
--- a/libs/translations/src/languages/en/clanOverviewSetting.json
+++ b/libs/translations/src/languages/en/clanOverviewSetting.json
@@ -4,7 +4,8 @@
     },
     "toast": {
         "saveSuccess": "Save Successfully",
-        "notBlank": "Cannot be left blank"
+        "notBlank": "Cannot be left blank",
+        "saveError": "Error when saving"
     },
     "menu": {
         "serverName": {
@@ -28,7 +29,8 @@
             "welcomeRandom": "Send a random welcome messages when someone joins this clan",
             "welcomeSticker": "Prompt members to reply to welcome messages with a sticker",
             "boostMessage": "Send a messages when someone boosts this clan",
-            "setupTips": "Send helpful tips for clan setup"
+            "setupTips": "Send helpful tips for clan setup",
+            "hideAuditLog": "Send a log when an action is applied to the clan"
         },
         "deleteServer": {
             "title": "Delete Clan",

--- a/libs/translations/src/languages/vi/clanOverviewSetting.json
+++ b/libs/translations/src/languages/vi/clanOverviewSetting.json
@@ -4,7 +4,8 @@
   },
   "toast": {
     "saveSuccess": "Lưu thành công",
-    "notBlank": "Không được để trống"
+    "notBlank": "Không được để trống",
+    "saveError": "Lỗi xảy ra khi lưu"
 },
   "menu": {
     "serverName": {
@@ -28,7 +29,8 @@
       "welcomeRandom": "Gửi tin nhắn chào mừng ngẫu nhiên khi ai đó tham gia vào clan này",
       "welcomeSticker": "Yêu cầu thành viên trả lời tin nhắn chào mừng bằng nhãn dán",
       "boostMessage": "Gửi tin nhắn khi ai đó tăng cấp clan này",
-      "setupTips": "Gửi các mẹo hữu ích để thiết lập clan"
+      "setupTips": "Gửi các mẹo hữu ích để thiết lập clan",
+      "hideAuditLog": "Gửi nhật ký khi có hành động được thực hiện với clan"
     },
     "deleteServer": {
       "title": "Xóa clan",


### PR DESCRIPTION
Mobile app: fix clan setting missing toggle audit log mobile.
https://github.com/orgs/nccasia/projects/16/views/1?filterQuery=hoang&pane=issue&itemId=119080559
Expect case: 
- Show audit log option toggle in system message setting.
- On press save setting overview, show loading, toast info upload and back to clan setting.


https://github.com/user-attachments/assets/235f4333-59e1-4df0-9160-576dae4a96ef

