### PR TITLE
Mobile app: fix can't leave private channel mobile

### DIFF
--- a/apps/mobile/src/app/components/ChannelSetting/ChannelSetting.tsx
+++ b/apps/mobile/src/app/components/ChannelSetting/ChannelSetting.tsx
@@ -1,13 +1,12 @@
 import { BottomSheetModal } from '@gorhom/bottom-sheet';
 import { usePermissionChecker } from '@mezon/core';
-import { ActionEmitEvent, CheckIcon, getUpdateOrAddClanChannelCache, isEqual, save, STORAGE_DATA_CLAN_CHANNEL_CACHE } from '@mezon/mobile-components';
+import { ActionEmitEvent, CheckIcon, isEqual } from '@mezon/mobile-components';
 import { Colors, useTheme } from '@mezon/mobile-ui';
 import {
 	appActions,
-	channelsActions,
 	channelUsersActions,
+	channelsActions,
 	fetchSystemMessageByClanId,
-	getStoreAsync,
 	selectAllChannels,
 	selectChannelById,
 	selectClanSystemMessage,
@@ -16,7 +15,7 @@ import {
 	useAppDispatch,
 	useAppSelector
 } from '@mezon/store-mobile';
-import { checkIsThread, EOverriddenPermission, EPermission } from '@mezon/utils';
+import { EOverriddenPermission, EPermission, checkIsThread } from '@mezon/utils';
 import { ChannelType } from 'mezon-js';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -211,7 +210,7 @@ export function ChannelSetting({ navigation, route }: MenuChannelScreenProps<Scr
 					textStyle: { color: 'red' },
 					onPress: () => handlePressDeleteChannel(),
 					icon: <MezonIconCDN icon={IconCDN.trashIcon} color={Colors.textRed} />,
-					isShow: isChannel ? isCanManageChannel : (isCanManageThread || channel?.creator_id === currentUserId)
+					isShow: isChannel ? isCanManageChannel : isCanManageThread || channel?.creator_id === currentUserId
 				},
 				{
 					title: isChannel ? t('fields.channelDelete.leave') : t('fields.threadLeave.leave'),
@@ -301,17 +300,6 @@ export function ChannelSetting({ navigation, route }: MenuChannelScreenProps<Scr
 			dispatch(appActions.setLoadingMainMobile(false));
 		}
 	}, [channel?.channel_id, channel?.clan_id, channel?.parent_id, currentSystemMessage?.channel_id]);
-
-	const handleJoinChannel = useCallback(async () => {
-		const channelId = isChannel ? currentSystemMessage?.channel_id : channel?.parent_id || '';
-		const clanId = channel?.clan_id || '';
-		const dataSave = getUpdateOrAddClanChannelCache(clanId, channelId);
-		const store = await getStoreAsync();
-		requestAnimationFrame(async () => {
-			store.dispatch(channelsActions.joinChannel({ clanId: clanId ?? '', channelId: channelId, noFetchMembers: false }));
-		});
-		save(STORAGE_DATA_CLAN_CHANNEL_CACHE, dataSave);
-	}, [isChannel, currentSystemMessage?.channel_id, channel?.clan_id, channel?.parent_id]);
 
 	const handleConfirmLeaveThread = useCallback(async () => {
 		try {

--- a/apps/mobile/src/app/components/ChannelSetting/ChannelSetting.tsx
+++ b/apps/mobile/src/app/components/ChannelSetting/ChannelSetting.tsx
@@ -343,7 +343,6 @@ export function ChannelSetting({ navigation, route }: MenuChannelScreenProps<Scr
 			}
 
 			navigation.navigate(APP_SCREEN.HOME);
-			handleJoinChannel();
 		} catch (error) {
 			Toast.show({ type: 'error', text1: t('confirm.leave.error', { error }) });
 		} finally {

--- a/apps/mobile/src/app/screens/home/homedrawer/components/ChannelMenu/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/ChannelMenu/index.tsx
@@ -3,10 +3,7 @@ import { useMarkAsRead, usePermissionChecker } from '@mezon/core';
 import {
 	ActionEmitEvent,
 	ENotificationActive,
-	ENotificationChannelId,
-	STORAGE_DATA_CLAN_CHANNEL_CACHE,
-	getUpdateOrAddClanChannelCache,
-	save
+	ENotificationChannelId
 } from '@mezon/mobile-components';
 import { Colors, baseColor, size, useTheme } from '@mezon/mobile-ui';
 import {
@@ -14,7 +11,6 @@ import {
 	channelUsersActions,
 	channelsActions,
 	fetchSystemMessageByClanId,
-	getStoreAsync,
 	listChannelRenderAction,
 	notificationSettingActions,
 	selectAllChannelsFavorite,
@@ -175,17 +171,6 @@ export default function ChannelMenu({ channel }: IChannelMenuProps) {
 		dispatch(notificationSettingActions.setMuteNotificationSetting(body));
 	};
 
-	const handleJoinChannel = async () => {
-		const channelId = currentSystemMessage.channel_id || '';
-		const clanId = channel?.clan_id || '';
-		const dataSave = getUpdateOrAddClanChannelCache(clanId, channelId);
-		const store = await getStoreAsync();
-		requestAnimationFrame(async () => {
-			store.dispatch(channelsActions.joinChannel({ clanId: clanId ?? '', channelId: channelId, noFetchMembers: false }));
-		});
-		save(STORAGE_DATA_CLAN_CHANNEL_CACHE, dataSave);
-	};
-
 	const handleConfirmLeaveChannel = useCallback(async () => {
 		try {
 			DeviceEventEmitter.emit(ActionEmitEvent.ON_TRIGGER_MODAL, { isDismiss: true });
@@ -202,8 +187,6 @@ export default function ChannelMenu({ channel }: IChannelMenuProps) {
 				throw new Error(response?.meta?.requestStatus);
 			}
 			navigation.navigate(APP_SCREEN.HOME);
-			await sleep(500);
-			handleJoinChannel();
 		} catch (error) {
 			Toast.show({ type: 'error', text1: t('modalConFirmLeaveChannel.error', { error }) });
 		} finally {

--- a/apps/mobile/src/app/screens/home/homedrawer/components/ChannelMenu/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/ChannelMenu/index.tsx
@@ -1,11 +1,20 @@
 import { useBottomSheetModal } from '@gorhom/bottom-sheet';
 import { useMarkAsRead, usePermissionChecker } from '@mezon/core';
-import { ActionEmitEvent, ENotificationActive, ENotificationChannelId } from '@mezon/mobile-components';
+import {
+	ActionEmitEvent,
+	ENotificationActive,
+	ENotificationChannelId,
+	STORAGE_DATA_CLAN_CHANNEL_CACHE,
+	getUpdateOrAddClanChannelCache,
+	save
+} from '@mezon/mobile-components';
 import { Colors, baseColor, size, useTheme } from '@mezon/mobile-ui';
 import {
 	appActions,
+	channelUsersActions,
 	channelsActions,
 	fetchSystemMessageByClanId,
+	getStoreAsync,
 	listChannelRenderAction,
 	notificationSettingActions,
 	selectAllChannelsFavorite,
@@ -166,6 +175,56 @@ export default function ChannelMenu({ channel }: IChannelMenuProps) {
 		dispatch(notificationSettingActions.setMuteNotificationSetting(body));
 	};
 
+	const handleJoinChannel = async () => {
+		const channelId = currentSystemMessage.channel_id || '';
+		const clanId = channel?.clan_id || '';
+		const dataSave = getUpdateOrAddClanChannelCache(clanId, channelId);
+		const store = await getStoreAsync();
+		requestAnimationFrame(async () => {
+			store.dispatch(channelsActions.joinChannel({ clanId: clanId ?? '', channelId: channelId, noFetchMembers: false }));
+		});
+		save(STORAGE_DATA_CLAN_CHANNEL_CACHE, dataSave);
+	};
+
+	const handleConfirmLeaveChannel = useCallback(async () => {
+		try {
+			DeviceEventEmitter.emit(ActionEmitEvent.ON_TRIGGER_MODAL, { isDismiss: true });
+			DeviceEventEmitter.emit(ActionEmitEvent.ON_TRIGGER_BOTTOM_SHEET, { isDismiss: true });
+			dispatch(appActions.setLoadingMainMobile(true));
+			const body = {
+				channelId: channel.id,
+				userId: currentUserId,
+				channelType: channel.type,
+				clanId: channel.clan_id
+			};
+			const response = await dispatch(channelUsersActions.removeChannelUsers(body));
+			if (response?.meta?.requestStatus === 'rejected') {
+				throw new Error(response?.meta?.requestStatus);
+			}
+			navigation.navigate(APP_SCREEN.HOME);
+			await sleep(500);
+			handleJoinChannel();
+		} catch (error) {
+			Toast.show({ type: 'error', text1: t('modalConFirmLeaveChannel.error', { error }) });
+		} finally {
+			dispatch(appActions.setLoadingMainMobile(false));
+		}
+	}, [channel?.channel_private, channel?.clan_id, channel?.id, channel?.type, currentUserId]);
+
+	const handlePressLeaveChannel = () => {
+		const data = {
+			children: (
+				<MezonConfirm
+					onConfirm={handleConfirmLeaveChannel}
+					title={t('modalConFirmLeaveChannel.title')}
+					confirmText={t('modalConFirmLeaveChannel.yesButton')}
+					content={t('modalConFirmLeaveChannel.textConfirm')}
+				/>
+			)
+		};
+		DeviceEventEmitter.emit(ActionEmitEvent.ON_TRIGGER_MODAL, { isDismiss: false, data });
+	};
+
 	const notificationMenu: IMezonMenuItemProps[] = [
 		{
 			title: isChannel
@@ -262,6 +321,15 @@ export default function ChannelMenu({ channel }: IChannelMenuProps) {
 				color: Colors.textRed
 			},
 			isShow: isCanManageChannel
+		},
+		{
+			title: t('menu.organizationMenu.leaveChannel'),
+			icon: <MezonIconCDN icon={IconCDN.leaveGroupIcon} color={Colors.textRed} />,
+			onPress: handlePressLeaveChannel,
+			textStyle: {
+				color: Colors.textRed
+			},
+			isShow: channel?.creator_id !== currentUserId && channel?.channel_private === 1
 		}
 	];
 
@@ -313,7 +381,7 @@ export default function ChannelMenu({ channel }: IChannelMenuProps) {
 					}
 				});
 			},
-			isShow: channel?.creator_id === currentUserId
+			isShow: channel?.creator_id === currentUserId || isCanManageThread
 		},
 		{
 			title: t('menu.manageThreadMenu.deleteThread'),
@@ -336,7 +404,7 @@ export default function ChannelMenu({ channel }: IChannelMenuProps) {
 			textStyle: {
 				color: Colors.textRed
 			},
-			isShow: channel?.creator_id === currentUserId
+			isShow: channel?.creator_id === currentUserId || isCanManageThread
 		}
 		// {
 		// 	title: t('menu.manageThreadMenu.copyLink'),

--- a/libs/translations/src/languages/en/channelMenu.json
+++ b/libs/translations/src/languages/en/channelMenu.json
@@ -30,7 +30,8 @@
             "title": "",
             "edit": "Edit Channel",
             "deleteChannel": "Delete Channel",
-            "duplicateChannel": "Duplicate Category"
+            "duplicateChannel": "Duplicate Category",
+            "leaveChannel": "Leave Channel"
         },
         "devMode": {
             "title": "Development Mode",
@@ -66,6 +67,12 @@
       "title": "Leave Thread",
       "yesButton": "Leave Thread",
       "textConfirm": "Are you sure you want to Leave Thread ? You can't receive message from thread when leave this thread"
+    },
+    "modalConFirmLeaveChannel": {
+      "title": "Leave Channel",
+      "yesButton": "Leave Channel",
+      "textConfirm": "Are you sure you want to Leave Channel ? You can't receive message from channel when leave this channel",
+      "error": "Leave channel failed: {{error}}"
     },
     "btnBadgeCount": "New",
     "favoriteChannel":"FAVORITE CHANNEL"

--- a/libs/translations/src/languages/vi/channelMenu.json
+++ b/libs/translations/src/languages/vi/channelMenu.json
@@ -31,7 +31,8 @@
           "title": "",
           "edit": "Chỉnh sửa kênh",
           "deleteChannel": "Xóa kênh",
-          "duplicateChannel": "Nhân bản kênh"
+          "duplicateChannel": "Nhân bản kênh",
+          "leaveChannel": "Rời kênh"
       },
       "devMode": {
           "title": "Chế độ phát triển",
@@ -67,6 +68,12 @@
     "title": "Rời chủ đề",
     "yesButton": "Rời chủ đề",
     "textConfirm": "Bạn có chắc chắn muốn rời khỏi chủ đề này không? Bạn sẽ không thể nhận được tin nhắn từ chuỗi này khi đã rời khỏi."
+  },
+  "modalConFirmLeaveChannel": {
+    "title": "Rời kênh",
+    "yesButton": "Rời kênh",
+    "textConfirm": "Bạn có chắc chắn muốn rời khỏi kênh này không? Bạn sẽ không thể nhận được tin nhắn từ kênh này khi đã rời khỏi.",
+    "error": "Rời kênh lỗi: {{error}}"
   },
   "btnBadgeCount": "Mới",
   "favoriteChannel": "KÊNH YÊU THÍCH"


### PR DESCRIPTION
Mobile app: fix can't leave private channel mobile.
Issue: https://github.com/orgs/nccasia/projects/16/views/1?filterQuery=hoang&pane=issue&itemId=119172794.
Expect case:
- If have permission to manage thread or channel, show delete thread or channel option channel menu.
- Show option delete channel on manage channel permission, channel setting.
- Allows to leave private channel.
- After leave channel, remove user from channel and all child thread, join welcome channel.


https://github.com/user-attachments/assets/a8e82c9f-3334-48e9-b4bf-8669eff1193d


https://github.com/user-attachments/assets/de49e36c-26cd-4402-a57d-e2fd4f9e4658


https://github.com/user-attachments/assets/15cfb358-2290-4fbd-ace3-f21fa01c83ec

