### PR TITLE
Mobile app: fix cannot save image embed message menu mobile

### DIFF
--- a/apps/mobile/src/app/hooks/useImage.ts
+++ b/apps/mobile/src/app/hooks/useImage.ts
@@ -24,7 +24,7 @@ export function useImage() {
 				} else {
 					const response = await RNFetchBlob.config({
 						fileCache: true,
-						appendExt: type
+						appendExt: type || 'png'
 					}).fetch('GET', imageUrl);
 
 					if (response.info().status === 200) {

--- a/apps/mobile/src/app/screens/home/homedrawer/components/MessageItemBS/ContainerMessageActionModal.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/MessageItemBS/ContainerMessageActionModal.tsx
@@ -301,15 +301,15 @@ export const ContainerMessageActionModal = React.memo((props: IReplyBottomSheet)
 	};
 
 	const downloadAndSaveMedia = async (media) => {
-		const url = media.url;
+		const url = media?.url;
 		const filetype = media?.filetype;
 
-		const type = filetype.split('/');
+		const type = filetype?.split?.('/');
 		try {
-			const filePath = await downloadImage(url, type[1]);
+			const filePath = await downloadImage(url, type?.[1]);
 
 			if (filePath) {
-				await saveImageToCameraRoll('file://' + filePath, type[0]);
+				await saveImageToCameraRoll('file://' + filePath, type?.[0], true);
 			}
 		} catch (error) {
 			console.error(`Error downloading or saving media from URL: ${url}`, error);
@@ -317,14 +317,19 @@ export const ContainerMessageActionModal = React.memo((props: IReplyBottomSheet)
 	};
 
 	const handleActionSaveImage = async () => {
-		const media = message?.attachments?.length > 0 ? message?.attachments : message?.content?.embed?.map((item) => item?.image);
-		dispatch(appActions.setLoadingMainMobile(true));
-		if (media && media.length > 0) {
-			const promises = media?.map(downloadAndSaveMedia);
-			await Promise.all(promises);
+		try {
+			const media = message?.attachments?.length > 0 ? message?.attachments : message?.content?.embed?.map((item) => item?.image);
+			dispatch(appActions.setLoadingMainMobile(true));
+			if (media && media.length > 0) {
+				const promises = media?.map(downloadAndSaveMedia);
+				await Promise.all(promises);
+			}
+		} catch (error) {
+			console.error('Error saving image:', error);
+		} finally {
+			dispatch(appActions.setLoadingMainMobile(false));
+			onClose();
 		}
-		dispatch(appActions.setLoadingMainMobile(false));
-		onClose();
 	};
 
 	const handleActionReportMessage = () => {


### PR DESCRIPTION
Mobile app: fix cannot save image embed message menu mobile.
Issue: https://github.com/orgs/nccasia/projects/16/views/1?filterQuery=hoang&pane=issue&itemId=119427632
Expect case:
- Save Embed message Image from message option menu and, modal image header.
- Stop loading when download successful or have error.
- Show Successful toast when download sucessfully.

https://github.com/user-attachments/assets/a8ad7c9e-ff54-4f2f-b398-92a4e54da2f5

