### PR TITLE
Mobile app: fix role color and clan name clan member mobile

### DIFF
--- a/apps/mobile/src/app/components/ClanSettings/Member/UserItem/UserItem.tsx
+++ b/apps/mobile/src/app/components/ClanSettings/Member/UserItem/UserItem.tsx
@@ -7,6 +7,7 @@ import { Pressable, Text, View } from 'react-native';
 import MezonIconCDN from '../../../../../../src/app/componentUI/MezonIconCDN';
 import { IconCDN } from '../../../../../../src/app/constants/icon_cdn';
 import MezonAvatar from '../../../../componentUI/MezonAvatar';
+import ImageNative from '../../../ImageNative';
 import { style } from './styles';
 
 interface IUserItem {
@@ -45,14 +46,15 @@ export function UserItem({ userID, onMemberSelect }: IUserItem) {
 				<MezonAvatar avatarUrl={user?.user?.avatar_url || ''} username={user?.user?.username} />
 				<View style={[styles.rightContent]}>
 					<View style={styles.content}>
-						<Text style={styles.displayName}>{user?.user?.display_name || ''}</Text>
+						<Text style={styles.displayName}>{user?.clan_nick || user?.user?.display_name || ''}</Text>
 						<Text style={styles.username}>{user?.user?.username || ''}</Text>
 
 						<View style={styles.roleWrapper}>
 							{clanUserRole?.length > 0 &&
 								clanUserRole.map((role, index) => (
 									<View key={'role_' + role.title + index.toString()} style={styles.roleContainer}>
-										<View style={styles.roleCircle}></View>
+										<View style={[styles.roleCircle, role?.color && { backgroundColor: role?.color }]}></View>
+										{role?.role_icon && <ImageNative url={role?.role_icon} style={styles.roleIcon} />}
 										<Text style={styles.roleTitle}>{role.title}</Text>
 									</View>
 								))}

--- a/apps/mobile/src/app/components/ClanSettings/Member/UserItem/styles.ts
+++ b/apps/mobile/src/app/components/ClanSettings/Member/UserItem/styles.ts
@@ -54,12 +54,16 @@ export const style = (colors: Attributes) =>
 			backgroundColor: Colors.bgToggleOnBtn
 		},
 		icon: {
-			width: 30,
-			height: 20,
+			width: size.s_30,
+			height: size.s_20,
 			flexBasis: 20
 		},
 		content: {
 			flexBasis: size.s_10,
 			flexGrow: 1
+		},
+		roleIcon: {
+			height: size.s_10,
+			width: size.s_10
 		}
 	});


### PR DESCRIPTION
Mobile app: fix role color and clan name clan member mobile.
Issue: https://github.com/orgs/nccasia/projects/16/views/1?filterQuery=hoang&pane=issue&itemId=119309278
Expect UI:
- Show color circle with true role color.
- Show role icon.
- Show user display name with clan nick with more priority than display name.

<img width="386" height="532" alt="image" src="https://github.com/user-attachments/assets/adadfdf8-60ea-4a45-9130-e730b01340db" />
