### PR TITLE
Mobile app: fix topic discussion cache and keyboard mobile

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/ChatBox.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/ChatBox.tsx
@@ -14,6 +14,7 @@ interface IChatBoxProps {
 	};
 	directMessageId?: string;
 	isPublic: boolean;
+	topicChannelId?: string;
 }
 export const ChatBox = memo((props: IChatBoxProps) => {
 	const [canSendMessage] = usePermissionChecker([EOverriddenPermission.sendMessage], props.channelId);

--- a/apps/mobile/src/app/screens/home/homedrawer/ChatBoxMain.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/ChatBoxMain.tsx
@@ -20,6 +20,7 @@ interface IChatBoxProps {
 	directMessageId?: string;
 	canSendMessage?: boolean;
 	isPublic: boolean;
+	topicChannelId?: string;
 }
 
 export const ChatBoxMain = memo((props: IChatBoxProps) => {
@@ -121,6 +122,7 @@ export const ChatBoxMain = memo((props: IChatBoxProps) => {
 					hiddenIcon={props?.hiddenIcon}
 					messageAction={props?.messageAction}
 					isPublic={props?.isPublic}
+					topicChannelId={props?.topicChannelId}
 				/>
 			)}
 		</View>

--- a/apps/mobile/src/app/screens/home/homedrawer/components/ChatBox/ChatBoxBottomBar/ChatBoxTyping.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/ChatBox/ChatBoxBottomBar/ChatBoxTyping.tsx
@@ -18,64 +18,67 @@ interface IChatInputProps {
 	channelId: string;
 	isPublic: boolean;
 	anonymousMode: boolean;
+	topicChannelId?: string;
 }
 
-export const ChatBoxTyping = memo(({ textChange, mode = 2, channelId = '', isPublic = false, anonymousMode = false }: IChatInputProps) => {
-	const dispatch = useAppDispatch();
-	const currentClanId = useSelector(selectCurrentClanId);
-	const userProfile = useSelector(selectAllAccount);
-	const userClanProfile = useAppSelector((state) => selectMemberClanByUserId2(state, userProfile?.user?.id));
+export const ChatBoxTyping = memo(
+	({ textChange, mode = 2, channelId = '', isPublic = false, anonymousMode = false, topicChannelId = '' }: IChatInputProps) => {
+		const dispatch = useAppDispatch();
+		const currentClanId = useSelector(selectCurrentClanId);
+		const userProfile = useSelector(selectAllAccount);
+		const userClanProfile = useAppSelector((state) => selectMemberClanByUserId2(state, userProfile?.user?.id));
 
-	const handleTyping = async () => {
-		if (anonymousMode) return;
-		dispatch(
-			messagesActions.sendTypingUser({
-				clanId: currentClanId || '',
-				channelId,
-				mode,
-				isPublic,
-				username: userClanProfile?.clan_nick || userProfile?.user?.display_name || userProfile?.user?.username
-			})
-		);
-	};
-
-	const handleDirectMessageTyping = async () => {
-		await Promise.all([
+		const handleTyping = async () => {
+			if (anonymousMode || !!topicChannelId) return;
 			dispatch(
 				messagesActions.sendTypingUser({
-					clanId: '0',
-					channelId: channelId,
-					mode: mode,
-					isPublic: false,
-					username: userProfile?.user?.display_name || userProfile?.user?.username
+					clanId: currentClanId || '',
+					channelId,
+					mode,
+					isPublic,
+					username: userClanProfile?.clan_nick || userProfile?.user?.display_name || userProfile?.user?.username
 				})
-			)
-		]);
-	};
+			);
+		};
 
-	const handleTypingDebounced = useThrottledCallback(handleTyping, 1000);
-	const handleDirectMessageTypingDebounced = useThrottledCallback(handleDirectMessageTyping, 1000);
+		const handleDirectMessageTyping = async () => {
+			await Promise.all([
+				dispatch(
+					messagesActions.sendTypingUser({
+						clanId: '0',
+						channelId: channelId,
+						mode: mode,
+						isPublic: false,
+						username: userProfile?.user?.display_name || userProfile?.user?.username
+					})
+				)
+			]);
+		};
 
-	const handleTypingMessage = async () => {
-		switch (mode) {
-			case ChannelStreamMode.STREAM_MODE_CHANNEL:
-			case ChannelStreamMode.STREAM_MODE_THREAD:
-				await handleTypingDebounced();
-				break;
-			case ChannelStreamMode.STREAM_MODE_DM:
-			case ChannelStreamMode.STREAM_MODE_GROUP:
-				await handleDirectMessageTypingDebounced();
-				break;
-			default:
-				break;
-		}
-	};
+		const handleTypingDebounced = useThrottledCallback(handleTyping, 1000);
+		const handleDirectMessageTypingDebounced = useThrottledCallback(handleDirectMessageTyping, 1000);
 
-	useEffect(() => {
-		if (textChange) {
-			handleTypingMessage();
-		}
-	}, [textChange]);
+		const handleTypingMessage = async () => {
+			switch (mode) {
+				case ChannelStreamMode.STREAM_MODE_CHANNEL:
+				case ChannelStreamMode.STREAM_MODE_THREAD:
+					await handleTypingDebounced();
+					break;
+				case ChannelStreamMode.STREAM_MODE_DM:
+				case ChannelStreamMode.STREAM_MODE_GROUP:
+					await handleDirectMessageTypingDebounced();
+					break;
+				default:
+					break;
+			}
+		};
 
-	return <View />;
-});
+		useEffect(() => {
+			if (textChange) {
+				handleTypingMessage();
+			}
+		}, [textChange]);
+
+		return <View />;
+	}
+);

--- a/apps/mobile/src/app/screens/home/homedrawer/components/ChatBox/ChatBoxBottomBar/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/ChatBox/ChatBoxBottomBar/index.tsx
@@ -94,6 +94,7 @@ interface IChatInputProps {
 	messageAction?: EMessageActionType;
 	onDeleteMessageActionNeedToResolve?: () => void;
 	isPublic: boolean;
+	topicChannelId?: string;
 }
 
 interface IEphemeralTargetUserInfo {
@@ -109,7 +110,8 @@ export const ChatBoxBottomBar = memo(
 		messageActionNeedToResolve,
 		messageAction,
 		onDeleteMessageActionNeedToResolve,
-		isPublic = false
+		isPublic = false,
+		topicChannelId = ''
 	}: IChatInputProps) => {
 		const { themeValue } = useTheme();
 		const dispatch = useAppDispatch();
@@ -176,14 +178,14 @@ export const ChatBoxBottomBar = memo(
 			const allCachedMessage = load(STORAGE_KEY_TEMPORARY_INPUT_MESSAGES) || {};
 			save(STORAGE_KEY_TEMPORARY_INPUT_MESSAGES, {
 				...allCachedMessage,
-				[channelId]: text
+				[topicChannelId || channelId]: text
 			});
 		};
 
 		const setMessageFromCache = async () => {
 			const allCachedMessage = load(STORAGE_KEY_TEMPORARY_INPUT_MESSAGES) || {};
-			handleTextInputChange(allCachedMessage?.[channelId] || '');
-			textValueInputRef.current = convertMentionsToText(allCachedMessage?.[channelId] || '');
+			handleTextInputChange(allCachedMessage?.[topicChannelId || channelId] || '');
+			textValueInputRef.current = convertMentionsToText(allCachedMessage?.[topicChannelId || channelId] || '');
 		};
 
 		const handleEventAfterEmojiPicked = useCallback(
@@ -261,8 +263,8 @@ export const ChatBoxBottomBar = memo(
 			mentionsOnMessage.current = [];
 			hashtagsOnMessage.current = [];
 			onDeleteMessageActionNeedToResolve();
-			resetCachedChatbox(channelId);
-			resetCachedMessageActionNeedToResolve(channelId);
+			resetCachedChatbox(topicChannelId || channelId);
+			resetCachedMessageActionNeedToResolve(topicChannelId || channelId);
 			dispatch(
 				emojiSuggestionActions.setSuggestionEmojiObjPicked({
 					shortName: '',
@@ -589,7 +591,7 @@ export const ChatBoxBottomBar = memo(
 				textValueInputRef.current = '';
 			});
 			const addEmojiPickedListener = DeviceEventEmitter.addListener(ActionEmitEvent.ADD_EMOJI_PICKED, (emoji) => {
-				if (emoji?.channelId === channelId) {
+				if (emoji?.channelId === channelId || emoji?.channelId === topicChannelId) {
 					handleEventAfterEmojiPicked(emoji.shortName);
 				}
 			});
@@ -629,7 +631,7 @@ export const ChatBoxBottomBar = memo(
 						/>
 					)}
 				</View>
-				<AttachmentPreview channelId={channelId} />
+				<AttachmentPreview channelId={topicChannelId || channelId} />
 				<ChatBoxListener mode={mode} />
 				<View style={styles.containerInput}>
 					<ChatMessageLeftArea
@@ -705,6 +707,7 @@ export const ChatBoxBottomBar = memo(
 							clearInputAfterSendMessage={onSendSuccess}
 							anonymousMode={anonymousMode}
 							ephemeralTargetUserId={ephemeralTargetUserInfo?.id}
+							currentTopicId={topicChannelId}
 						/>
 					</View>
 				</View>

--- a/apps/mobile/src/app/screens/home/homedrawer/components/ChatBox/ChatMessageSending/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/ChatBox/ChatMessageSending/index.tsx
@@ -12,7 +12,6 @@ import {
 	selectAllRolesClan,
 	selectAttachmentByChannelId,
 	selectChannelById,
-	selectCurrentTopicId,
 	selectCurrentTopicInitMessage,
 	selectDmGroupCurrent,
 	selectIsShowCreateTopic,
@@ -69,6 +68,7 @@ interface IChatMessageSendingProps {
 	voiceLinkRoomOnMessage?: MutableRefObject<ILinkVoiceRoomOnMessage[]>;
 	anonymousMode?: boolean;
 	ephemeralTargetUserId?: string;
+	currentTopicId?: string;
 }
 const isPayloadEmpty = (payload: IMessageSendPayload): boolean => {
 	return (
@@ -98,13 +98,14 @@ export const ChatMessageSending = memo(
 		markdownsOnMessage,
 		voiceLinkRoomOnMessage,
 		anonymousMode = false,
-		ephemeralTargetUserId
+		ephemeralTargetUserId,
+		currentTopicId = ''
 	}: IChatMessageSendingProps) => {
 		const { themeValue } = useTheme();
 		const dispatch = useAppDispatch();
 		const styles = style(themeValue);
 		const store = getStore();
-		const attachmentFilteredByChannelId = useAppSelector((state) => selectAttachmentByChannelId(state, channelId));
+		const attachmentFilteredByChannelId = useAppSelector((state) => selectAttachmentByChannelId(state, currentTopicId || channelId));
 		const currentChannel = useAppSelector((state) => selectChannelById(state, channelId || ''));
 		const currentDmGroup = useSelector(selectDmGroupCurrent(channelId));
 		const { membersOfChild, membersOfParent, addMemberToThread, joinningToThread } = useChannelMembers({
@@ -115,7 +116,6 @@ export const ChatMessageSending = memo(
 		const userId = useMemo(() => {
 			return load(STORAGE_MY_USER_ID);
 		}, []);
-		const currentTopicId = useSelector(selectCurrentTopicId);
 		const valueTopic = useSelector(selectCurrentTopicInitMessage);
 		const isCreateTopic = useSelector(selectIsShowCreateTopic);
 		const channelOrDirect =
@@ -235,7 +235,7 @@ export const ChatMessageSending = memo(
 						: priorityDisplayName;
 				const payloadEphemeral = {
 					receiverId: ephemeralTargetUserId,
-					channelId: channelId,
+					channelId: currentTopicId || channelId,
 					clanId: currentChannel?.clan_id || '',
 					mode: mode,
 					isPublic: isPublic,
@@ -279,7 +279,7 @@ export const ChatMessageSending = memo(
 			dispatch(emojiSuggestionActions.setSuggestionEmojiPicked(''));
 			dispatch(
 				referencesActions.setAtachmentAfterUpload({
-					channelId,
+					channelId: currentTopicId || channelId,
 					files: []
 				})
 			);

--- a/apps/mobile/src/app/screens/home/homedrawer/components/EmojiPicker/EmojiSelectorContainer/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/EmojiPicker/EmojiSelectorContainer/index.tsx
@@ -55,9 +55,9 @@ export default function EmojiSelectorContainer({
 		const currentChannelId = selectCurrentChannelId(store.getState() as any);
 		const currentTopicId = selectCurrentTopicId(store.getState() as any);
 
-		const channel_id = currentTopicId ? currentTopicId : currentChannelId;
+		const channelId = currentTopicId ? currentTopicId : currentChannelId;
 
-		return currentDirectId ? currentDirectId : channel_id;
+		return currentDirectId ? currentDirectId : channelId;
 	}, []);
 
 	const getEmojisByCategories = useMemo(

--- a/apps/mobile/src/app/screens/home/homedrawer/components/EmojiPicker/EmojiSelectorContainer/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/EmojiPicker/EmojiSelectorContainer/index.tsx
@@ -12,7 +12,7 @@ import {
 	SmilingFaceIcon
 } from '@mezon/mobile-components';
 import { size, useTheme } from '@mezon/mobile-ui';
-import { emojiSuggestionActions, getStore, selectCurrentChannelId, selectDmGroupCurrentId } from '@mezon/store-mobile';
+import { emojiSuggestionActions, getStore, selectCurrentChannelId, selectCurrentTopicId, selectDmGroupCurrentId } from '@mezon/store-mobile';
 import { FOR_SALE_CATE, IEmoji, RECENT_EMOJI_CATEGORY } from '@mezon/utils';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -53,8 +53,11 @@ export default function EmojiSelectorContainer({
 	const channelId = useMemo(() => {
 		const currentDirectId = selectDmGroupCurrentId(store.getState());
 		const currentChannelId = selectCurrentChannelId(store.getState() as any);
+		const currentTopicId = selectCurrentTopicId(store.getState() as any);
 
-		return currentDirectId ? currentDirectId : currentChannelId;
+		const channel_id = currentTopicId ? currentTopicId : currentChannelId;
+
+		return currentDirectId ? currentDirectId : channel_id;
 	}, []);
 
 	const getEmojisByCategories = useMemo(

--- a/apps/mobile/src/app/screens/home/homedrawer/components/TopicDiscussion/TopicDiscussion.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/TopicDiscussion/TopicDiscussion.tsx
@@ -1,10 +1,11 @@
+import { ActionEmitEvent } from '@mezon/mobile-components';
 import { ThemeModeBase, useTheme } from '@mezon/mobile-ui';
 import { messagesActions, selectCurrentChannel, selectCurrentClanId, selectCurrentTopicId, topicsActions, useAppDispatch } from '@mezon/store-mobile';
 import { checkIsThread, isPublicChannel } from '@mezon/utils';
 import { useNavigation } from '@react-navigation/native';
-import { ChannelStreamMode, ChannelType } from 'mezon-js';
+import { ChannelStreamMode } from 'mezon-js';
 import React, { useCallback, useEffect } from 'react';
-import { Platform, StatusBar, View } from 'react-native';
+import { DeviceEventEmitter, Platform, StatusBar, View } from 'react-native';
 import { PanGestureHandler } from 'react-native-gesture-handler';
 import { KeyboardAvoidingView } from 'react-native-keyboard-controller';
 import { useSelector } from 'react-redux';
@@ -59,9 +60,19 @@ export default function TopicDiscussion() {
 	}, []);
 
 	useEffect(() => {
+		DeviceEventEmitter.emit(ActionEmitEvent.SHOW_KEYBOARD, null);
+		DeviceEventEmitter.emit(ActionEmitEvent.ON_PANEL_KEYBOARD_BOTTOM_SHEET, {
+			isShow: false,
+			mode: ''
+		});
 		return () => {
 			dispatch(topicsActions.setCurrentTopicId(''));
 			dispatch(topicsActions.setIsShowCreateTopic(false));
+			DeviceEventEmitter.emit(ActionEmitEvent.SHOW_KEYBOARD, null);
+			DeviceEventEmitter.emit(ActionEmitEvent.ON_PANEL_KEYBOARD_BOTTOM_SHEET, {
+				isShow: false,
+				mode: ''
+			});
 		};
 	}, [currentChannel?.channel_id, dispatch]);
 
@@ -107,11 +118,12 @@ export default function TopicDiscussion() {
 					channelId={currentChannel?.channel_id}
 					mode={checkIsThread(currentChannel) ? ChannelStreamMode.STREAM_MODE_THREAD : ChannelStreamMode.STREAM_MODE_CHANNEL}
 					hiddenIcon={{
-						threadIcon: currentChannel?.type === ChannelType.CHANNEL_TYPE_THREAD
+						threadIcon: true
 					}}
 					isPublic={isPublicChannel(currentChannel)}
+					topicChannelId={currentTopicId}
 				/>
-				<PanelKeyboard currentChannelId={currentChannel?.channel_id} currentClanId={currentChannel?.clan_id} />
+				<PanelKeyboard currentChannelId={currentTopicId} currentClanId={currentChannel?.clan_id} />
 			</KeyboardAvoidingView>
 		</View>
 	);

--- a/apps/mobile/src/app/screens/home/homedrawer/components/TopicDiscussion/TopicDiscussion.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/TopicDiscussion/TopicDiscussion.tsx
@@ -123,7 +123,7 @@ export default function TopicDiscussion() {
 					isPublic={isPublicChannel(currentChannel)}
 					topicChannelId={currentTopicId}
 				/>
-				<PanelKeyboard currentChannelId={currentTopicId} currentClanId={currentChannel?.clan_id} />
+				<PanelKeyboard currentChannelId={currentTopicId || currentChannel?.channel_id} currentClanId={currentChannel?.clan_id} />
 			</KeyboardAvoidingView>
 		</View>
 	);


### PR DESCRIPTION
Mobile app: fix topic discussion cache and keyboard mobile
Expect case:
- Pick image or emoji and typing chat in chatbox home default not cache in topic discussion chatbox.
- When in and out topic discussion, dismiss keyboard and attachment or emoji picker bottomsheet.
- Clear message action value when open or close topic discussion UI.


https://github.com/user-attachments/assets/0108be4a-25dc-43b8-9a4a-2637fc0b7f4b

