### PR TITLE
Mobile app: fix can not create private channel and change channel type mobile

### DIFF
--- a/apps/mobile/src/app/components/ChannelCreator/ChannelCreator.tsx
+++ b/apps/mobile/src/app/components/ChannelCreator/ChannelCreator.tsx
@@ -56,7 +56,7 @@ export function ChannelCreator({ navigation, route }: MenuClanScreenProps<Create
 				</Pressable>
 			)
 		});
-	}, [channelName, navigation, t, themeValue.text]);
+	}, [channelName, navigation, t, themeValue.text, isChannelPrivate, channelType]);
 
 	async function handleCreateChannel() {
 		if (!validInput(channelName)) return;


### PR DESCRIPTION
Mobile app: fix can not create private channel and change channel type mobile.
Issue: https://github.com/mezonai/mezon/issues/8220
Expect case:
- Open create channel, enter name then choose type or toggle private, when submit will send all data.


https://github.com/user-attachments/assets/65f973d2-7e91-4a08-85ae-bab387bf3be8

