### PR TITLE
Fix: fix ui flick while hover attachment items, check permission for deleting attachment

### DIFF
--- a/libs/components/src/lib/components/DeleteMessageModal/ModalDeleteMess.tsx
+++ b/libs/components/src/lib/components/DeleteMessageModal/ModalDeleteMess.tsx
@@ -114,17 +114,19 @@ const ModalDeleteMess = (props: ModalDeleteMessProps) => {
 			onKeyUp={handleEnter as any}
 			tabIndex={0}
 		>
-			<div className="w-fit h-fit rounded-lg flex-col justify-start items-start gap-3 inline-flex overflow-hidden">
-				<div className="">
-					<div className="p-4 pb-0">
-						<h3 className="font-bold pb-4">{isRemoveAttachmentNoContent ? 'Remove Attachment' : 'Delete Message'}</h3>
-						<p>
+			<div className="w-fit h-fit bg-theme-primary rounded-lg flex flex-col justify-start items-start overflow-hidden">
+				<div className="w-full">
+					<div className="p-4 pb-0 bg-theme-primary text-center">
+						<h3 className="font-bold pb-2 text-xl text-theme-primary">
+							{isRemoveAttachmentNoContent ? 'Remove Attachment' : 'Delete Message'}
+						</h3>
+						<p className="text-theme-primary">
 							{isRemoveAttachmentNoContent
 								? 'Do you want to remove the attachment on this message?'
 								: 'Do you want to delete this message?'}
 						</p>
 					</div>
-					<div className="p-4 max-w-[720px] max-h-[50vh] overflow-y-auto hide-scrollbar truncate bg-theme-setting-primary">
+					<div className="p-4 max-w-[720px] max-h-[50vh] overflow-y-auto hide-scrollbar bg-theme-secondary pointer-events-none [&_.attachment-actions]:!hidden [&_button]:!hidden">
 						<ColorRoleProvider>
 							{isMessageSystem ? (
 								<MessageWithSystem message={mess as IMessageWithUser} isTopic={!!isTopic} />
@@ -140,11 +142,12 @@ const ModalDeleteMess = (props: ModalDeleteMessProps) => {
 									isMention={true}
 									isShowFull={true}
 									user={currentClanUser}
+									isSearchMessage={true}
 								/>
 							)}
 						</ColorRoleProvider>
 					</div>
-					<div className="w-full p-4 flex justify-end gap-x-4 border-t border-theme-primary bg-theme-setting-nav">
+					<div className="w-full p-4 flex justify-end gap-x-4 border-t border-theme-border bg-theme-primary">
 						<button
 							onClick={closeModal}
 							className="px-4 py-2 hover:underline rounded disabled:cursor-not-allowed disabled:hover:no-underline disabled:opacity-85 text-theme-primary"
@@ -154,10 +157,10 @@ const ModalDeleteMess = (props: ModalDeleteMessProps) => {
 						</button>
 						<button
 							onClick={handleAction}
-							className="px-4 py-2 bg-[#DA363C] rounded hover:bg-opacity-85 text-white disabled:cursor-not-allowed disabled:opacity-85 disabled:hover:opacity-85 flex"
+							className="px-4 py-2 bg-[#DA363C] rounded hover:bg-opacity-85 text-white disabled:cursor-not-allowed disabled:opacity-85 disabled:hover:opacity-85 flex items-center gap-1"
 							disabled={isLoading}
 						>
-							{isRemoveAttachmentNoContent ? 'Remove ' : 'Delete '}
+							{isRemoveAttachmentNoContent ? 'Remove' : 'Delete'}
 							{isLoading && <Icons.IconLoadingTyping />}
 						</button>
 					</div>

--- a/libs/components/src/lib/components/MessageWithUser/MessageLinkFile.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/MessageLinkFile.tsx
@@ -1,10 +1,10 @@
-import { selectTheme } from '@mezon/store';
+import { selectCurrentUserId, selectTheme } from '@mezon/store';
 import { Icons } from '@mezon/ui';
-import { DOWNLOAD_FILE, EFailAttachment, electronBridge, IMessageWithUser } from '@mezon/utils';
+import { DOWNLOAD_FILE, EFailAttachment, IMessageWithUser, electronBridge } from '@mezon/utils';
 import isElectron from 'is-electron';
 import { ChannelStreamMode } from 'mezon-js';
 import { ApiMessageAttachment } from 'mezon-js/api.gen';
-import { lazy, Suspense, useState } from 'react';
+import { Suspense, lazy, useState } from 'react';
 import { useModal } from 'react-modal-hook';
 import { useSelector } from 'react-redux';
 import { ModalDeleteMess, RenderAttachmentThumbnail } from '../../components';
@@ -95,6 +95,8 @@ function MessageLinkFile({ attachmentData, mode, message }: MessageImage) {
 	};
 
 	const appearanceTheme = useSelector(selectTheme);
+	const currentUserId = useSelector(selectCurrentUserId);
+	const isOwner = message?.sender_id === currentUserId;
 
 	const createPDFHeader = (closePopup: () => void, maximizeToggle: () => void) => {
 		return isPDF ? <PDFHeader filename={attachmentData.filename || 'Document'} onClose={closePopup} onMaximize={maximizeToggle} /> : undefined;
@@ -176,19 +178,21 @@ function MessageLinkFile({ attachmentData, mode, message }: MessageImage) {
 								>
 									<Icons.Download defaultSize="w-4 h-4" />
 								</button>
-								<button
-									onClick={handleOpenRemoveAttachementModal}
-									className="rounded-md w-8 h-8 flex justify-center items-center cursor-pointer   bg-secondary-button-hover border-theme-primary text-theme-primary-hover text-theme-primary"
-									title="Remove"
-								>
-									<Icons.TrashIcon className="w-4 h-4 " />
-								</button>
+								{isOwner && (
+									<button
+										onClick={handleOpenRemoveAttachementModal}
+										className="rounded-md w-8 h-8 flex justify-center items-center cursor-pointer   bg-secondary-button-hover border-theme-primary text-theme-primary-hover text-theme-primary"
+										title="Remove"
+									>
+										<Icons.TrashIcon className="w-4 h-4 " />
+									</button>
+								)}
 							</div>
 						)}
 						{isPDF && (
 							<button
 								onClick={openPDFViewer}
-									className="px-3 py-1 text-sm rounded transition-all duration-200  btn-primary btn-primary-hover"
+								className="px-3 py-1 text-sm rounded transition-all duration-200  btn-primary btn-primary-hover"
 								title="View PDF"
 							>
 								View


### PR DESCRIPTION
- Fix UI flick while user hover the attachment items in deleting message modal
- Fix theme UI for deleting message modal
- Check permission to hide delete button on message with attachment

**BEFORE:** 
![ScreenRecording2025-07-21at16 24 06-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/7eb0251f-bb6d-4668-bbf4-a3bf332948fc)

**AFTER:**
<img width="634" height="427" alt="Screenshot 2025-07-21 at 16 27 12" src="https://github.com/user-attachments/assets/0a2873fe-c95e-4d8e-a758-1828fc30acc5" />

<img width="1000" height="319" alt="Screenshot 2025-07-21 at 16 25 35" src="https://github.com/user-attachments/assets/dc961883-33d5-428a-8893-104138f1a25c" />
