### PR TITLE
Mobile app: fix setup permission not update successful mobile

### DIFF
--- a/apps/mobile/src/app/screens/serverRoles/RoleCoLourComponent/RoleCoLourComponent.tsx
+++ b/apps/mobile/src/app/screens/serverRoles/RoleCoLourComponent/RoleCoLourComponent.tsx
@@ -13,7 +13,7 @@ import { IconCDN } from '../../../constants/icon_cdn';
 import RoleColorPicker from '../RoleColorPicker/RoleColorPicker';
 import { style } from './styles';
 
-function RoleCoLourComponent({ roleId }: { roleId: string }) {
+function RoleCoLourComponent({ roleId, disable = false }: { roleId: string; disable?: boolean }) {
 	const { themeValue } = useTheme();
 	const styles = style(themeValue);
 	const rolesClan = useSelector(selectAllRolesClan);
@@ -58,12 +58,15 @@ function RoleCoLourComponent({ roleId }: { roleId: string }) {
 
 	return (
 		<View>
-			<TouchableOpacity onPress={onPresentBS} style={styles.roleButton}>
-				<Text style={styles.textBtn}>{t('roleColorPicker.textBtnRole')}</Text>
+			<TouchableOpacity onPress={onPresentBS} style={styles.roleButton} disabled={disable}>
+				<View style={{ flexDirection: 'row', alignItems: 'center', gap: size.s_6 }}>
+					<Text style={styles.textBtn}>{t('roleColorPicker.textBtnRole')}</Text>
+					{disable && <MezonIconCDN icon={IconCDN.lockIcon} color={themeValue.textDisabled} height={size.s_16} width={size.s_16} />}
+				</View>
 				<View style={{ flexDirection: 'row', alignItems: 'center', gap: size.s_10 }}>
 					<View style={{ width: size.s_40, height: size.s_40, backgroundColor: roleColorSelected, borderRadius: size.s_6 }}></View>
 					<Text style={styles.colorText}>{activeRole?.color ?? ''}</Text>
-					<MezonIconCDN icon={IconCDN.chevronSmallRightIcon} color={themeValue.text} />
+					{!disable && <MezonIconCDN icon={IconCDN.chevronSmallRightIcon} color={themeValue.text} />}
 				</View>
 			</TouchableOpacity>
 		</View>

--- a/apps/mobile/src/app/screens/serverRoles/RoleDetail/index.tsx
+++ b/apps/mobile/src/app/screens/serverRoles/RoleDetail/index.tsx
@@ -242,8 +242,8 @@ export const RoleDetail = ({ navigation, route }: MenuClanScreenProps<RoleDetail
 				</View>
 
 				<View style={{ marginVertical: size.s_10, flex: 1 }}>
-					<RoleCoLourComponent roleId={roleId} />
-					<RoleImagePicker roleId={roleId} />
+					<RoleCoLourComponent roleId={roleId} disable={!isCanEditRole} />
+					<RoleImagePicker roleId={roleId} disable={!isCanEditRole} />
 					<View style={{ borderRadius: size.s_10, overflow: 'hidden' }}>
 						<FlatList
 							data={actionList}
@@ -256,7 +256,7 @@ export const RoleDetail = ({ navigation, route }: MenuClanScreenProps<RoleDetail
 							windowSize={2}
 							renderItem={({ item }) => {
 								return (
-									<TouchableOpacity onPress={() => handleAction(item.type)}>
+									<TouchableOpacity onPress={() => handleAction(item.type)} disabled={!isCanEditRole}>
 										<View
 											style={{
 												flexDirection: 'row',
@@ -285,7 +285,7 @@ export const RoleDetail = ({ navigation, route }: MenuClanScreenProps<RoleDetail
 												)}
 											</View>
 											<View>
-												<MezonIconCDN icon={IconCDN.chevronSmallRightIcon} color={themeValue.text} />
+												{!item?.isView && <MezonIconCDN icon={IconCDN.chevronSmallRightIcon} color={themeValue.text} />}
 											</View>
 										</View>
 									</TouchableOpacity>

--- a/apps/mobile/src/app/screens/serverRoles/RoleImagePicker/index.tsx
+++ b/apps/mobile/src/app/screens/serverRoles/RoleImagePicker/index.tsx
@@ -11,7 +11,7 @@ import MezonImagePicker from '../../../componentUI/MezonImagePicker';
 import { IconCDN } from '../../../constants/icon_cdn';
 import { style } from './styles';
 
-function RoleImagePicker({ roleId }: { roleId: string }) {
+function RoleImagePicker({ roleId, disable = false }: { roleId: string; disable?: boolean }) {
 	const { themeValue } = useTheme();
 	const styles = style(themeValue);
 	const rolesClan = useSelector(selectAllRolesClan);
@@ -56,12 +56,19 @@ function RoleImagePicker({ roleId }: { roleId: string }) {
 			<View style={styles.roleButton}>
 				<Text style={styles.textBtn}>{t('roleImagePicker')}</Text>
 				<View style={styles.tailButton}>
-					{!!activeRole?.role_icon && (
+					{!!activeRole?.role_icon && !disable && (
 						<TouchableOpacity style={styles.deleteButton} onPress={handleRemoveIcon}>
 							<Text style={styles.deleteText}>remove</Text>
 						</TouchableOpacity>
 					)}
-					<MezonImagePicker defaultValue={activeRole?.role_icon} height={size.s_50} width={size.s_50} onLoad={handleOnLoad} autoUpload />
+					<MezonImagePicker
+						defaultValue={activeRole?.role_icon}
+						height={size.s_50}
+						width={size.s_50}
+						onLoad={handleOnLoad}
+						autoUpload
+						disabled={disable}
+					/>
 				</View>
 			</View>
 		</View>

--- a/apps/mobile/src/app/screens/serverRoles/SetupPermissions/index.tsx
+++ b/apps/mobile/src/app/screens/serverRoles/SetupPermissions/index.tsx
@@ -78,18 +78,22 @@ export const SetupPermissions = ({ navigation, route }: MenuClanScreenProps<Setu
 	const handleEditPermissions = useCallback(async () => {
 		try {
 			dispatch(appActions.setLoadingMainMobile(true));
-			const removePermissionList = permissionList?.filter((permission) => !selectedPermissions.includes(permission?.id)).map((it) => it?.id);
+			const listAddPermissions = selectedPermissions?.filter((permission) => !originSelectedPermissions?.includes(permission));
+			const removePermissionList = originSelectedPermissions?.filter((id) => !selectedPermissions?.includes(id));
 			const response = await updateRole(
 				clanRole?.clan_id,
 				clanRole?.id,
 				clanRole?.title,
 				clanRole?.color || '',
 				[],
-				selectedPermissions,
+				listAddPermissions,
 				[],
-				removePermissionList
+				removePermissionList,
+				''
 			);
-			if (response) {
+			if (response?.ok !== undefined && response?.ok === false) {
+				throw new Error('failed');
+			} else {
 				Toast.show({
 					type: 'success',
 					props: {
@@ -98,8 +102,6 @@ export const SetupPermissions = ({ navigation, route }: MenuClanScreenProps<Setu
 					}
 				});
 				navigation.goBack();
-			} else {
-				throw new Error('failed');
 			}
 		} catch (error) {
 			console.error(error);
@@ -113,7 +115,18 @@ export const SetupPermissions = ({ navigation, route }: MenuClanScreenProps<Setu
 		} finally {
 			dispatch(appActions.setLoadingMainMobile(false));
 		}
-	}, [clanRole, navigation, permissionList, selectedPermissions, t, updateRole]);
+	}, [
+		clanRole?.clan_id,
+		clanRole?.color,
+		clanRole?.id,
+		clanRole?.title,
+		dispatch,
+		navigation,
+		originSelectedPermissions,
+		selectedPermissions,
+		t,
+		updateRole
+	]);
 
 	useEffect(() => {
 		navigation.setOptions({


### PR DESCRIPTION
Mobile app: fix setup permission not update successful mobile.
Issue: https://github.com/mezonai/mezon/issues/8264
Expect case:
- Just update permission which was add or remove from role.
- Show error on update fail.
- Disable button in role detail when not have permission edit role.


https://github.com/user-attachments/assets/7921a931-b1d3-4e54-af58-de4c61d143e1


https://github.com/user-attachments/assets/dc5a14d8-9189-4683-a845-f615e43704fe

