### PR TITLE
Mobile app: feat handle show speaking user and re sort list participants mezon meet

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/components/ChannelVoice/ParticipantScreen/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/ChannelVoice/ParticipantScreen/index.tsx
@@ -4,7 +4,7 @@ import { size, useTheme } from '@mezon/mobile-ui';
 import { selectIsPiPMode, selectMemberClanByUserName, useAppSelector } from '@mezon/store-mobile';
 import { Track } from 'livekit-client';
 import React, { useMemo } from 'react';
-import { Platform, ScrollView, Text, TouchableOpacity, View } from 'react-native';
+import { ScrollView, Text, TouchableOpacity, View } from 'react-native';
 import MezonIconCDN from '../../../../../../../../src/app/componentUI/MezonIconCDN';
 import { IconCDN } from '../../../../../../../../src/app/constants/icon_cdn';
 import MezonAvatar from '../../../../../../componentUI/MezonAvatar';
@@ -81,7 +81,8 @@ const ParticipantItem = ({ participant, tracks, setFocusedScreenShare, isGridLay
 						isPiPMode && { height: size.s_60 * 2, width: '45%', marginHorizontal: size.s_4 },
 						{
 							flexDirection: 'column'
-						}
+						},
+						participant?.isSpeaking && { borderWidth: 1, borderColor: themeValue.textLink }
 					]}
 				>
 					<VideoTrack
@@ -109,7 +110,8 @@ const ParticipantItem = ({ participant, tracks, setFocusedScreenShare, isGridLay
 						isPiPMode && { height: size.s_60 * 2, width: '45%', marginHorizontal: size.s_4 },
 						{
 							flexDirection: 'column'
-						}
+						},
+						participant?.isSpeaking && { borderWidth: 1, borderColor: themeValue.textLink }
 					]}
 				>
 					<View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'center', marginBottom: size.s_10 }}>


### PR DESCRIPTION
Mobile app: feat handle show speaking user and re sort list participants mezon meet
Issue: https://github.com/mezonai/mezon/issues/8313
Expect case:
- While member in meet more than a number of partipant, current set is 8, sort list when have someone speaking.
- Show who is speaking with participant item border.
- Always show screen share in the first item.


https://github.com/user-attachments/assets/f2fd39e0-20af-47b0-86b5-4267753374ef

