### PR TITLE
Mobile App: fix bug UI crop image screen overlapping on Android 15

### DIFF
--- a/apps/mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/android/app/src/main/AndroidManifest.xml
@@ -188,6 +188,12 @@
               <data android:mimeType="*/*" />
           </intent-filter>
       </activity>
+      <activity
+        android:name="com.yalantis.ucrop.UCropActivity"
+        android:screenOrientation="nosensor"
+        android:windowLayoutInDisplayCutoutMode="never"
+        android:theme="@style/Ecift.CropTheme"
+        tools:replace="android:theme" />
       <uses-library android:name="org.apache.http.legacy" android:required="false"/>
       <meta-data
         android:name="com.google.firebase.messaging.default_notification_icon"

--- a/apps/mobile/android/app/src/main/res/values/styles.xml
+++ b/apps/mobile/android/app/src/main/res/values/styles.xml
@@ -21,4 +21,9 @@
         <item name="android:textColorHighlight">@color/primary_light</item>
         <item name="android:textColorPrimaryInverse">@color/primary_light</item>
     </style>
+    <style name="Ecift.CropTheme" parent="Theme.AppCompat.Light.NoActionBar">
+        <item name="colorPrimary">#000000</item>
+        <item name="colorAccent">#FF4081</item>
+        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+    </style>
 </resources>


### PR DESCRIPTION
issue: https://github.com/mezonai/mezon/issues/8320
<img width="921" height="2048" alt="image" src="https://github.com/user-attachments/assets/c285e7a0-7297-4096-a749-eceb9ec01bf5" />
