### PR TITLE
Mobile app: fix lost avatar update role permission mobile

### DIFF
--- a/apps/mobile/src/app/screens/serverRoles/SetupPermissions/index.tsx
+++ b/apps/mobile/src/app/screens/serverRoles/SetupPermissions/index.tsx
@@ -88,8 +88,7 @@ export const SetupPermissions = ({ navigation, route }: MenuClanScreenProps<Setu
 				[],
 				listAddPermissions,
 				[],
-				removePermissionList,
-				''
+				removePermissionList
 			);
 			if (response?.ok !== undefined && response?.ok === false) {
 				throw new Error('failed');


### PR DESCRIPTION
Mobile app: fix lost avatar update role permission mobile
Issue: https://github.com/mezonai/mezon/issues/8368
Expect case: Update permission not reset role icon to default.


https://github.com/user-attachments/assets/bed058b8-eaf8-4356-84b7-17e4c494f320

