### PR TITLE
Mobile app: fix markdown render overlap UI some device mobile

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/components/RenderTextMarkdown/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/RenderTextMarkdown/index.tsx
@@ -198,29 +198,10 @@ export const markdownStyles = (
 		},
 		blockSpacing: {
 			paddingVertical: size.s_4,
-			width: '100%'
+			width: '99.9%'
 		}
 	});
 };
-
-const styleMessageReply = (colors: Attributes) =>
-	StyleSheet.create({
-		body: {
-			color: colors.text,
-			fontSize: size.small
-		},
-		textVoiceChannel: {
-			fontSize: size.small,
-			color: colors.textDisabled,
-			lineHeight: size.s_20
-		},
-		mention: {
-			fontSize: size.small,
-			color: colors.textLink,
-			backgroundColor: colors.midnightBlue,
-			lineHeight: size.s_20
-		}
-	});
 
 export type IMarkdownProps = {
 	content: IExtendedMessage;


### PR DESCRIPTION
Mobile app: fix markdown render overlap UI some device mobile.
Issue: https://github.com/mezonai/mezon/issues/8371
Expect UI: render text after codeblock with no unnecessary spacing.

<img width="606" height="1280" alt="image" src="https://github.com/user-attachments/assets/4da02b47-5f29-47b3-8725-50f017f0571a" />
<img width="1280" height="769" alt="image" src="https://github.com/user-attachments/assets/70ec9660-c9fe-4163-a7ba-4fd3eeea7e88" />
