### PR TITLE
Mobile app: fix youtube player ui scale tablet mobile

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/components/RenderTextMarkdown/components/RenderYoutubeVideo/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/RenderTextMarkdown/components/RenderYoutubeVideo/index.tsx
@@ -16,6 +16,8 @@ const RenderYoutubeVideo = ({ videoKey, videoId, contentInElement, onPress, onLo
 	const [isVideoReady, setIsVideoReady] = useState<boolean>(false);
 	const { width, height } = useWindowDimensions();
 	const isLandscape = width > height;
+	const playerWidth = isLandscape ? width * 0.4 : width * 0.8;
+	const playerHeight = (playerWidth * 9) / 16;
 
 	return (
 		<View key={videoKey}>
@@ -30,8 +32,8 @@ const RenderYoutubeVideo = ({ videoKey, videoId, contentInElement, onPress, onLo
 					</View>
 				)}
 				<YoutubePlayer
-					height={size.s_165}
-					width={isLandscape ? width * 0.4 : width * 0.8}
+					height={playerHeight}
+					width={playerWidth}
 					videoId={videoId}
 					play={false}
 					onReady={() => setIsVideoReady(true)}


### PR DESCRIPTION
Mobile app: fix youtube player ui scale tablet mobile
Issue: https://github.com/mezonai/mezon/issues/8388

<img width="389" height="839" alt="image" src="https://github.com/user-attachments/assets/93af9840-dedb-4a53-a76d-685dc9f7752e" />
<img width="1281" height="831" alt="image" src="https://github.com/user-attachments/assets/d9e7320d-c823-46aa-9d50-31ef5007d7bb" />
<img width="708" height="464" alt="image" src="https://github.com/user-attachments/assets/18b2243d-935a-4a03-8e4f-1e933e0730f4" />

https://github.com/user-attachments/assets/a5dc0f43-1cd0-4765-9c2b-4a5cbe256973


