### PR TITLE
Mobile app: fix direct message display wrong new message and time in DM list mobile

### DIFF
--- a/libs/store/src/lib/direct/direct.slice.ts
+++ b/libs/store/src/lib/direct/direct.slice.ts
@@ -646,13 +646,23 @@ export const directSlice = createSlice({
 			const data = action.payload;
 			const currentData = state.entities[data.channel_id || ''];
 			if (currentData) {
+				let changes;
+				if (data?.update_time_seconds && data?.last_sent_message) {
+					changes = {
+						...currentData,
+						last_sent_message: data?.last_sent_message,
+						update_time_seconds: data?.update_time_seconds
+					};
+				} else {
+					changes = {
+						...data,
+						...currentData
+					};
+				}
+
 				directAdapter.updateOne(state, {
 					id: data.channel_id || '',
-					changes: {
-						...currentData,
-						last_sent_message: data.last_sent_message,
-						update_time_seconds: data.update_time_seconds
-					}
+					changes
 				});
 			}
 		}

--- a/libs/store/src/lib/direct/direct.slice.ts
+++ b/libs/store/src/lib/direct/direct.slice.ts
@@ -649,8 +649,9 @@ export const directSlice = createSlice({
 				directAdapter.updateOne(state, {
 					id: data.channel_id || '',
 					changes: {
-						...data,
-						...currentData
+						...currentData,
+						last_sent_message: data.last_sent_message,
+						update_time_seconds: data.update_time_seconds
 					}
 				});
 			}


### PR DESCRIPTION
Mobile app: fix direct message display wrong new message and time in DM list mobile.
Issue: https://github.com/mezonai/mezon/issues/8470
Expect case:
- Show correct last message when have new message and list DM update.
- Show correct time of last message.


https://github.com/user-attachments/assets/ceecd03b-3c5e-4837-924f-f71ff6f3740b

