### PR TITLE
Mobile app: fix markdown heading in reply message mobile

### DIFF
--- a/apps/mobile/src/app/screens/messages/DMListItemLastMessage/index.tsx
+++ b/apps/mobile/src/app/screens/messages/DMListItemLastMessage/index.tsx
@@ -1,4 +1,4 @@
-import { size, useTheme } from '@mezon/mobile-ui';
+import { useTheme } from '@mezon/mobile-ui';
 import { ETokenMessage, IExtendedMessage, getSrcEmoji } from '@mezon/utils';
 import React, { useMemo } from 'react';
 import { Text, View } from 'react-native';
@@ -70,7 +70,7 @@ export const DmListItemLastMessage = (props: { content: IExtendedMessage; styleT
 			const headingMatch = formatEmojiInText?.match(/^#{1,6}\s*([^\s]+)/);
 			const headingContent = headingMatch ? headingMatch[1] : '';
 			parts.push(
-				<Text key="heading" style={[styles.message, props?.styleText && props?.styleText, { fontWeight: 'bold', fontSize: size.medium }]}>
+				<Text key="heading" style={[styles.message, props?.styleText && props?.styleText, { fontWeight: 'bold' }]}>
 					{headingContent}
 				</Text>
 			);

--- a/apps/mobile/src/app/screens/messages/DMListItemLastMessage/index.tsx
+++ b/apps/mobile/src/app/screens/messages/DMListItemLastMessage/index.tsx
@@ -1,4 +1,4 @@
-import { useTheme } from '@mezon/mobile-ui';
+import { size, useTheme } from '@mezon/mobile-ui';
 import { ETokenMessage, IExtendedMessage, getSrcEmoji } from '@mezon/utils';
 import React, { useMemo } from 'react';
 import { Text, View } from 'react-native';
@@ -24,6 +24,12 @@ const EmojiMarkup = ({ shortname, emojiid }: IEmojiMarkup) => {
 		return shortname;
 	}
 	return `${EMOJI_KEY}${srcEmoji}${EMOJI_KEY}`;
+};
+
+const isHeadingText = (text?: string) => {
+	if (!text) return false;
+	const headingMatchRegex = /^(#{1,6})\s+(.+)$/;
+	return headingMatchRegex?.test(text?.trim());
 };
 
 const EMOJI_KEY = '[ICON_EMOJI]';
@@ -59,6 +65,17 @@ export const DmListItemLastMessage = (props: { content: IExtendedMessage; styleT
 		const parts = [];
 		let startIndex = 0;
 		let endIndex = formatEmojiInText.indexOf(EMOJI_KEY, startIndex);
+
+		if (isHeadingText(formatEmojiInText)) {
+			const headingMatch = formatEmojiInText?.match(/^#{1,6}\s*([^\s]+)/);
+			const headingContent = headingMatch ? headingMatch[1] : '';
+			parts.push(
+				<Text key="heading" style={[styles.message, props?.styleText && props?.styleText, { fontWeight: 'bold', fontSize: size.medium }]}>
+					{headingContent}
+				</Text>
+			);
+			return parts;
+		}
 
 		while (endIndex !== -1) {
 			const textPart = formatEmojiInText.slice(startIndex, endIndex);


### PR DESCRIPTION
Mobile app: fix markdown heading in reply message mobile.
Issue: https://github.com/mezonai/mezon/issues/8490
Expect case: when text in reply match heading first content elemen, show heading text with medium size and bold.


https://github.com/user-attachments/assets/49de3f24-f2a9-411e-96a0-5272bef51af2

