### PR TITLE
Mobile app: fix bottom sheet join voice not stable event badge channel mobile.

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/components/ChannelList/ChannelEventBadge/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/ChannelList/ChannelEventBadge/index.tsx
@@ -25,7 +25,6 @@ export const EventBadge = memo(({ clanId, channelId }: EventBadgeProps) => {
 			const urlVoice = `${linkGoogleMeet}${channelVoice?.meeting_code}`;
 			await Linking.openURL(urlVoice);
 		} else if (channelVoice?.meeting_code && channelVoice?.type === ChannelType.CHANNEL_TYPE_MEZON_VOICE) {
-			DeviceEventEmitter.emit(ActionEmitEvent.ON_TRIGGER_BOTTOM_SHEET, { isDismiss: true });
 			const data = {
 				snapPoints: ['45%'],
 				children: <JoinChannelVoiceBS channel={channelVoice} />


### PR DESCRIPTION
Mobile app: fix bottom sheet join voice not stable event badge channel mobile.
Issue: https://github.com/mezonai/mezon/issues/8502
Expect case: don't close bottom sheet join channel voice when click to event badge on channel item.


https://github.com/user-attachments/assets/c2abb847-8902-444e-9816-638500cbe03c

