### PR TITLE
Mobile app: fix canvas list not show in thread mobile

### DIFF
--- a/apps/mobile/src/app/components/ThreadDetail/AssetViewer/index.tsx
+++ b/apps/mobile/src/app/components/ThreadDetail/AssetViewer/index.tsx
@@ -70,9 +70,11 @@ export const AssetsViewer = React.memo(({ channelId }: { channelId: string }) =>
 				) : tabActive === 4 ? (
 					<Canvas
 						channelId={
-							[ChannelType.CHANNEL_TYPE_DM, ChannelType.CHANNEL_TYPE_GROUP].includes(currentChannel?.type)
-								? currentChannel?.channel_id
-								: channelId
+							currentChannel?.type === ChannelType.CHANNEL_TYPE_THREAD && currentChannel?.parent_id
+								? currentChannel?.parent_id
+								: [ChannelType.CHANNEL_TYPE_DM, ChannelType.CHANNEL_TYPE_GROUP].includes(currentChannel?.type)
+									? currentChannel?.channel_id
+									: channelId
 						}
 						clanId={currentClanId}
 					/>


### PR DESCRIPTION
Mobile app: fix canvas list not show in thread mobile.
Issue: https://github.com/mezonai/mezon/issues/8518
Expect case: on press canvas in thread detail will show channel canvas list.


https://github.com/user-attachments/assets/c5162d34-641c-4dd0-b3f7-cd9e7004e371



