### PR TITLE
Mobile app: fix first message topic can not select emoji mobile

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/components/ChatBox/ChatBoxBottomBar/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/ChatBox/ChatBoxBottomBar/index.tsx
@@ -601,7 +601,7 @@ export const ChatBoxBottomBar = memo(
 				clearTextInputListener.remove();
 				addEmojiPickedListener.remove();
 			};
-		}, [channelId, handleEventAfterEmojiPicked]);
+		}, [channelId, handleEventAfterEmojiPicked, topicChannelId]);
 
 		return (
 			<View style={styles.container}>


### PR DESCRIPTION
Mobile app: fix first message topic can not select emoji mobile.
Issue: https://github.com/mezonai/mezon/issues/8531
Expect case: pick emoji will fill that emoji to input in topic after send first message.


https://github.com/user-attachments/assets/a175d705-8866-4daa-95b1-5849218134a9

