### PR TITLE
Mobile app: fix render heading text in reply message mobile

### DIFF
--- a/apps/mobile/src/app/screens/messages/DMListItemLastMessage/index.tsx
+++ b/apps/mobile/src/app/screens/messages/DMListItemLastMessage/index.tsx
@@ -67,13 +67,23 @@ export const DmListItemLastMessage = (props: { content: IExtendedMessage; styleT
 		let endIndex = formatEmojiInText.indexOf(EMOJI_KEY, startIndex);
 
 		if (isHeadingText(formatEmojiInText)) {
-			const headingMatch = formatEmojiInText?.match(/^#{1,6}\s*([^\s]+)/);
-			const headingContent = headingMatch ? headingMatch[1] : '';
-			parts.push(
-				<Text key="heading" style={[styles.message, props?.styleText && props?.styleText, { fontWeight: 'bold' }]}>
-					{headingContent}
-				</Text>
-			);
+			const headingMatch = formatEmojiInText?.match(/^#{1,6}\s*([^\n[\]@#:\u{1F600}-\u{1F64F}]+)/u);
+			if (headingMatch) {
+				let headingContent = headingMatch[1];
+				const forbiddenRegex = /```[^`]+?```|(?<!`)`[^`\n]+?`(?!`)/g;
+				const firstForbiddenMatch = forbiddenRegex.exec(headingContent);
+				if (firstForbiddenMatch) {
+					headingContent = headingContent?.slice(0, firstForbiddenMatch?.index);
+				}
+
+				if (headingContent.length > 0) {
+					parts.push(
+						<Text key="heading" style={[styles.message, props?.styleText && props?.styleText, { fontWeight: 'bold' }]}>
+							{headingContent}
+						</Text>
+					);
+				}
+			}
 			return parts;
 		}
 


### PR DESCRIPTION
Mobile app: fix render heading text in reply message mobile.
Issue: https://github.com/mezonai/mezon/issues/8490
Expect case:
- show heading in reply with fontWeight bold.
- content heading in reply is heading content in original message.


https://github.com/user-attachments/assets/4f5d23fe-148c-4cd5-9976-b1265084b594

