### PR TITLE
fix call log show incorrect user display name

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/MessageItem.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/MessageItem.tsx
@@ -342,6 +342,7 @@ const MessageItem = React.memo(
 												channelId={message?.channel_id}
 												senderId={message?.sender_id}
 												callLog={message?.content?.callLog}
+												username={message?.display_name || message?.username || ''}
 											/>
 										) : isSendTokenLog ? (
 											<MessageSendTokenLog messageContent={message?.content?.t} />

--- a/apps/mobile/src/app/screens/home/homedrawer/components/MessageCallLog/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/MessageCallLog/index.tsx
@@ -3,6 +3,7 @@ import { baseColor, size, useTheme } from '@mezon/mobile-ui';
 import { selectAllAccount, selectDmGroupCurrent } from '@mezon/store-mobile';
 import { IMessageCallLog, IMessageTypeCallLog } from '@mezon/utils';
 import { useNavigation } from '@react-navigation/native';
+import { ChannelType } from 'mezon-js';
 import React, { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Text, TouchableOpacity, View } from 'react-native';
@@ -15,9 +16,10 @@ interface MessageCallLogProps {
 	channelId: string;
 	senderId: string;
 	callLog: IMessageCallLog;
+	username: string;
 }
 
-export const MessageCallLog = memo(({ contentMsg, senderId, channelId, callLog }: MessageCallLogProps) => {
+export const MessageCallLog = memo(({ contentMsg, senderId, channelId, callLog, username }: MessageCallLogProps) => {
 	const { callLogType, isVideo = false } = callLog || {};
 	const { themeValue } = useTheme();
 	const navigation = useNavigation<any>();
@@ -52,8 +54,13 @@ export const MessageCallLog = memo(({ contentMsg, senderId, channelId, callLog }
 			case IMessageTypeCallLog.CANCELCALL:
 				return isMe ? t('callLog.cancel') : t('callLog.missed');
 			case IMessageTypeCallLog.FINISHCALL:
-			case IMessageTypeCallLog.STARTCALL:
 				return isMe ? t('callLog.outGoingCall') : t('callLog.incomingCall');
+			case IMessageTypeCallLog.STARTCALL:
+				return currentDmGroup?.type === ChannelType.CHANNEL_TYPE_GROUP
+					? t('callLog.startGroupCall', { username: username })
+					: isVideo
+						? t('callLog.startVideoCall', { username: username })
+						: t('callLog.startAudioCall', { username: username });
 			default:
 				return '';
 		}

--- a/libs/components/src/lib/components/CallLogMessage/CallLogMessage.tsx
+++ b/libs/components/src/lib/components/CallLogMessage/CallLogMessage.tsx
@@ -97,7 +97,7 @@ export default function CallLogMessage({ userId, username, messageId, channelId,
 
 	const { icon, text, colorClass, bgClass } = iconMap[key] || {
 		icon: <Icons.OutGoingCall defaultSize="w-6 h-6" />,
-		text: `${username} started ${callLog.isVideo ? 'a video' : 'an audio'} call`,
+		text: `${username} started ${currentDmGroup?.type === ChannelType.CHANNEL_TYPE_GROUP ? 'a group' : callLog.isVideo ? 'a video' : 'an audio'} call`,
 		colorClass: '',
 		bgClass: ''
 	};

--- a/libs/components/src/lib/components/MessageWithUser/index.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/index.tsx
@@ -331,7 +331,7 @@ function MessageWithUser({
 						{!!message?.content?.callLog?.callLogType && (
 							<CallLogMessage
 								userId={userId || ''}
-								username={user?.user?.display_name || ''}
+								username={message?.display_name || message?.username || ''}
 								channelId={message?.channel_id}
 								messageId={message?.id}
 								senderId={message?.sender_id}

--- a/libs/translations/src/languages/en/message.json
+++ b/libs/translations/src/languages/en/message.json
@@ -121,7 +121,10 @@
         "videoCall": "Video call",
         "callBack": "Call back",
         "incomingCall": "Incoming call",
-        "outGoingCall": "Outgoing call"
+        "outGoingCall": "Outgoing call",
+        "startGroupCall": "{{username}} started a group call",
+        "startAudioCall": "{{username}} started an audio call",
+        "startVideoCall": "{{username}} started a video call"
     },
     "buzz": {
         "confirmText": "Send",

--- a/libs/translations/src/languages/vi/message.json
+++ b/libs/translations/src/languages/vi/message.json
@@ -120,7 +120,10 @@
     "videoCall": "Cuộc gọi video",
     "callBack": "Gọi lại",
     "incomingCall": "Cuộc gọi đến",
-    "outGoingCall": "Cuộc gọi đi"
+    "outGoingCall": "Cuộc gọi đi",
+    "startGroupCall" : "{{username}} đã bắt đầu 1 cuộc gọi nhóm",
+    "startAudioCall" : "{{username}} đã bắt đầu 1 cuộc gọi thoại",
+    "startVideoCall" : "{{username}} đã bắt đầu 1 cuộc gọi video"
   },
   "buzz": {
     "confirmText": "Gửi",


### PR DESCRIPTION
fix call log show incorrect user display name start call.
Issue: https://github.com/mezonai/mezon/issues/8578
Expect case:
- Show display name or username of the user who start call.
- Show type of call( group, audio, video) was started.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/d8191ccc-6ca3-46c9-b30c-ff94a4f93546" />

https://github.com/user-attachments/assets/c28ba33b-08c7-4585-96ec-b350ba4e2f39


https://github.com/user-attachments/assets/2b0d096b-ba73-4ea4-9e41-8b9622dcb89b


