### PR TITLE
Mobile app tablet: fix navigation channel and dm from toast notification mobile

### DIFF
--- a/apps/mobile/src/app/navigation/Authentication/AuthenticationLoader.tsx
+++ b/apps/mobile/src/app/navigation/Authentication/AuthenticationLoader.tsx
@@ -41,6 +41,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import MezonConfirm from '../../componentUI/MezonConfirm';
 import LoadingModal from '../../components/LoadingModal/LoadingModal';
 import { useCheckUpdatedVersion } from '../../hooks/useCheckUpdatedVersion';
+import useTabletLandscape from '../../hooks/useTabletLandscape';
 import { Sharing } from '../../screens/settings/Sharing';
 import { clanAndChannelIdLinkRegex, clanDirectMessageLinkRegex } from '../../utils/helpers';
 import { isShowNotification, navigateToNotification } from '../../utils/pushNotificationHelpers';
@@ -52,6 +53,7 @@ export const AuthenticationLoader = () => {
 	const { userProfile } = useAuth();
 	const currentClan = useSelector(selectCurrentClan);
 	const mezon = useMezon();
+	const isTabletLandscape = useTabletLandscape();
 	const currentChannel = useSelector(selectCurrentChannel);
 	const currentDmGroupId = useSelector(selectDmGroupCurrentId);
 	const isLoadingMain = useSelector(selectLoadingMainMobile);
@@ -270,7 +272,7 @@ export const AuthenticationLoader = () => {
 							DeviceEventEmitter.emit(ActionEmitEvent.ON_TRIGGER_BOTTOM_SHEET, { isDismiss: true });
 							DeviceEventEmitter.emit(ActionEmitEvent.ON_TRIGGER_MODAL, { isDismiss: true });
 							requestAnimationFrame(async () => {
-								await navigateToNotification(store, remoteMessage, navigation);
+								await navigateToNotification(store, remoteMessage, navigation, isTabletLandscape);
 							});
 						}
 					});

--- a/apps/mobile/src/app/utils/pushNotificationHelpers.ts
+++ b/apps/mobile/src/app/utils/pushNotificationHelpers.ts
@@ -387,9 +387,13 @@ export const navigateToNotification = async (store: any, notification: any, navi
 				);
 			}
 			if (navigation) {
-				navigation.navigate(APP_SCREEN.BOTTOM_BAR as never);
-				if (channelId !== '0' && !!channelId) {
-					navigation.navigate(APP_SCREEN.HOME_DEFAULT as never);
+				if (isTabletLandscape) {
+					navigation.navigate(APP_SCREEN.HOME as never);
+				} else {
+					navigation.navigate(APP_SCREEN.BOTTOM_BAR as never);
+					if (channelId !== '0' && !!channelId) {
+						navigation.navigate(APP_SCREEN.HOME_DEFAULT as never);
+					}
 				}
 			}
 			if (clanId) {


### PR DESCRIPTION
Mobile app tablet: fix navigation channel and dm from toast notification mobile.
Issue: https://github.com/mezonai/mezon/issues/8593
Expect case:
- when jump to message in clan switch to home screen tablet.
- when jump to message in direct message, switch to message screen detail tablet.


https://github.com/user-attachments/assets/5798cef8-0e8c-4f26-9806-635d57b61623

