### PR TITLE
Mobile app: fix edit message type bold can not fill to chatbox mobile

### DIFF
--- a/libs/mobile-components/src/lib/helper/mentions/index.ts
+++ b/libs/mobile-components/src/lib/helper/mentions/index.ts
@@ -125,7 +125,6 @@ export const createFormattedString = (data: IExtendedMessage) => {
 };
 
 export const formatContentEditMessage = (message: IMessageWithUser) => {
-	console.log('log => message', message);
 	const processedContentMentionsDraft = {
 		t: message?.content?.t,
 		hg: message?.content?.hg,

--- a/libs/mobile-components/src/lib/helper/mentions/index.ts
+++ b/libs/mobile-components/src/lib/helper/mentions/index.ts
@@ -101,10 +101,16 @@ export const createFormattedString = (data: IExtendedMessage) => {
 				formatContentDraft += contentInElement;
 				break;
 			case ETokenMessage.MARKDOWNS:
-				if (element?.type === EBacktickType.LINKYOUTUBE || element?.type === EBacktickType.LINK) {
+				if (element?.type === EBacktickType.LINKYOUTUBE || element?.type === EBacktickType.LINK || element?.type === EBacktickType.VOICE_LINK) {
 					formatContentDraft += contentInElement?.replace(/^```|```$/g, '');
-				} else {
+				} else if (element?.type === EBacktickType.PRE || element?.type === EBacktickType.TRIPLE) {
 					formatContentDraft += '```' + contentInElement?.replace(/^```|```$/g, '') + '```';
+				} else if (element?.type === EBacktickType.BOLD) {
+					formatContentDraft += `**${contentInElement}**`;
+				} else if (element?.type === EBacktickType.CODE || element?.type === EBacktickType.SINGLE) {
+					formatContentDraft += '`' + contentInElement?.replace(/^`|`$/g, '') + '`';
+				} else {
+					formatContentDraft += contentInElement;
 				}
 				break;
 			default:
@@ -119,6 +125,7 @@ export const createFormattedString = (data: IExtendedMessage) => {
 };
 
 export const formatContentEditMessage = (message: IMessageWithUser) => {
+	console.log('log => message', message);
 	const processedContentMentionsDraft = {
 		t: message?.content?.t,
 		hg: message?.content?.hg,


### PR DESCRIPTION
Mobile app: fix edit message type bold can not fill to chatbox mobile.
Issue: https://github.com/mezonai/mezon/issues/8663
Expect case:
- when edit bold message show bold marker in chat box.
- when edit code message show single code marker in chat box.
- when edit codeblock message show triple code marker in chat box.


https://github.com/user-attachments/assets/34433e61-e06b-46bc-a19b-804046bd4fe2

