### PR TITLE
Mobile app: fix direct message show wrong sender display name mobile

### DIFF
--- a/apps/mobile/src/app/screens/messages/DmListItem.tsx
+++ b/apps/mobile/src/app/screens/messages/DmListItem.tsx
@@ -51,10 +51,12 @@ export const DmListItem = React.memo((props: { id: string }) => {
 	const otherMemberList = useMemo(() => {
 		const userIdList = directMessage.user_id;
 		const usernameList = directMessage?.usernames || [];
+		const displayNameList = directMessage?.display_names || [];
 
 		return usernameList?.map((username, index) => ({
 			userId: userIdList?.[index],
-			username: username
+			username: username,
+			displayName: displayNameList?.[index]
 		}));
 	}, [directMessage]);
 
@@ -69,7 +71,7 @@ export const DmListItem = React.memo((props: { id: string }) => {
 
 		const lastMessageSender = otherMemberList?.find?.((it) => it?.userId === senderId);
 		if (lastMessageSender?.username) {
-			return `${lastMessageSender.username}: `;
+			return `${lastMessageSender?.displayName || lastMessageSender?.username}: `;
 		}
 
 		return '';
@@ -115,7 +117,6 @@ export const DmListItem = React.memo((props: { id: string }) => {
 					<DmListItemLastMessage
 						content={typeof content === 'object' ? content : safeJSONParse(content || '{}')}
 						styleText={{ color: isUnReadChannel && !isYourAccount ? themeValue.white : themeValue.textDisabled }}
-						// code={directMessage.last_sent_message?.content}
 					/>
 				)}
 			</View>


### PR DESCRIPTION
Mobile app: fix direct message show wrong sender display name mobile
Issue: https://github.com/mezonai/mezon/issues/8672
Expect: show sender display name more priority than username.

<img width="390" height="57" alt="image" src="https://github.com/user-attachments/assets/1ba2e0dd-fb35-48b8-bcfb-acae0800a9ca" />
<img width="388" height="862" alt="image" src="https://github.com/user-attachments/assets/b9952093-e9c7-42ca-9983-2b666eabc59f" />
