### PR TITLE
Fix: improve app exit behavior on macOS to keep active application

### DIFF
--- a/apps/desktop/src/app/app.ts
+++ b/apps/desktop/src/app/app.ts
@@ -190,11 +190,17 @@ export default class App {
 
 		// Emitted when the window is closed.
 		App.mainWindow.on('close', (event) => {
+			if (process.platform === 'win32' && !isQuitting) {
+				app.exit(0);
+				return;
+			}
+
 			if (forceQuit.isEnabled) {
 				app.exit(0);
 				forceQuit.disable();
 				return;
 			}
+
 			event.preventDefault();
 			App.mainWindow.hide();
 		});

--- a/apps/desktop/src/app/app.ts
+++ b/apps/desktop/src/app/app.ts
@@ -190,19 +190,16 @@ export default class App {
 
 		// Emitted when the window is closed.
 		App.mainWindow.on('close', (event) => {
-			if (process.platform === 'win32' && !isQuitting) {
-				app.exit(0);
+			if (process.platform === 'darwin' && !isQuitting) {
+				event.preventDefault();
+				App.mainWindow.hide();
 				return;
 			}
 
 			if (forceQuit.isEnabled) {
 				app.exit(0);
 				forceQuit.disable();
-				return;
 			}
-
-			event.preventDefault();
-			App.mainWindow.hide();
 		});
 
 		App.application.on('before-quit', async () => {

--- a/apps/desktop/src/app/app.ts
+++ b/apps/desktop/src/app/app.ts
@@ -193,7 +193,10 @@ export default class App {
 			if (forceQuit.isEnabled) {
 				app.exit(0);
 				forceQuit.disable();
+				return;
 			}
+			event.preventDefault();
+			App.mainWindow.hide();
 		});
 
 		App.application.on('before-quit', async () => {
@@ -202,6 +205,7 @@ export default class App {
 			} catch (error) {
 				console.error('Update check failed:', error);
 			}
+			forceQuit.enable();
 			tray.destroy();
 			App.application.exit();
 		});


### PR DESCRIPTION
- Fixed application was killed when it's windows closed.
- Keep app active in background on soft-quit action
**DEMO:**
![Screen Recording 2025-08-12 at 09 19 11 (1)](https://github.com/user-attachments/assets/c6e2284e-abf5-4a65-9fb2-d88586fefe8d)
