### PR TITLE
250813-MOBILE-Fix effect long press image mobile

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/MessageItem.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/MessageItem.tsx
@@ -14,7 +14,7 @@ import {
 } from '@mezon/store-mobile';
 import { ETypeLinkMedia, ID_MENTION_HERE, TypeMessage, isValidEmojiData } from '@mezon/utils';
 import { ChannelStreamMode, safeJSONParse } from 'mezon-js';
-import { ApiMessageMention } from 'mezon-js/api.gen';
+import { ApiMessageAttachment, ApiMessageMention } from 'mezon-js/api.gen';
 import React, { useCallback, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { DeviceEventEmitter, Platform, Pressable, Text, View } from 'react-native';
@@ -169,15 +169,22 @@ const MessageItem = React.memo(
 
 		const isSendTokenLog = message?.code === TypeMessage.SendToken;
 
-		const onLongPressImage = useCallback(() => {
-			if (preventAction) return;
-			dispatch(setSelectedMessage(message));
-			const data = {
-				snapPoints: ['55%', '85%'],
-				children: <ContainerMessageActionModal message={message} mode={mode} senderDisplayName={senderDisplayName} />
-			};
-			DeviceEventEmitter.emit(ActionEmitEvent.ON_TRIGGER_BOTTOM_SHEET, { isDismiss: false, data });
-		}, [dispatch, message, mode, preventAction, senderDisplayName]);
+		const onLongPressImage = useCallback(
+			(image?: ApiMessageAttachment) => {
+				if (preventAction) return;
+				dispatch(setSelectedMessage(message));
+				let targetMessage = message;
+				if (image) {
+					targetMessage = { ...message, attachments: [image] };
+				}
+				const data = {
+					snapPoints: ['55%', '85%'],
+					children: <ContainerMessageActionModal message={targetMessage} mode={mode} senderDisplayName={senderDisplayName} />
+				};
+				DeviceEventEmitter.emit(ActionEmitEvent.ON_TRIGGER_BOTTOM_SHEET, { isDismiss: false, data });
+			},
+			[dispatch, message, mode, preventAction, senderDisplayName]
+		);
 
 		const onPressInfoUser = useCallback(async () => {
 			if (preventAction) return;
@@ -274,10 +281,10 @@ const MessageItem = React.memo(
 						isHighlight && styles.highlightMessageMention,
 						isEphemeralMessage && styles.ephemeralMessage,
 						Platform.OS === 'ios' &&
-						pressed && {
-							backgroundColor: themeValue.secondaryWeight,
-							opacity: 0.8
-						}
+							pressed && {
+								backgroundColor: themeValue.secondaryWeight,
+								opacity: 0.8
+							}
 					]}
 				>
 					{!isMessageSystem && !message?.content?.fwd && (
@@ -440,17 +447,17 @@ const MessageItem = React.memo(
 	(prevProps, nextProps) => {
 		return (
 			prevProps?.message?.id +
-			prevProps?.message?.update_time +
-			prevProps?.previousMessage?.id +
-			prevProps?.message?.code +
-			prevProps?.isHighlight +
-			prevProps?.message?.reactions ===
+				prevProps?.message?.update_time +
+				prevProps?.previousMessage?.id +
+				prevProps?.message?.code +
+				prevProps?.isHighlight +
+				prevProps?.message?.reactions ===
 			nextProps?.message?.id +
-			nextProps?.message?.update_time +
-			nextProps?.previousMessage?.id +
-			nextProps?.message?.code +
-			nextProps?.isHighlight +
-			nextProps?.message?.reactions
+				nextProps?.message?.update_time +
+				nextProps?.previousMessage?.id +
+				nextProps?.message?.code +
+				nextProps?.isHighlight +
+				nextProps?.message?.reactions
 		);
 	}
 );

--- a/apps/mobile/src/app/screens/home/homedrawer/components/MessageAttachment/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/MessageAttachment/index.tsx
@@ -14,7 +14,7 @@ import { style } from './styles';
 
 interface IProps {
 	attachments: ApiMessageAttachment[];
-	onLongPressImage?: () => void;
+	onLongPressImage?: (image?: ApiMessageAttachment) => void;
 	clanId: string;
 	channelId: string;
 }
@@ -98,7 +98,7 @@ export const MessageAttachment = React.memo(({ attachments, onLongPressImage, cl
 			const checkIsVideo = isVideo(document?.url?.toLowerCase());
 
 			if (checkIsVideo) {
-				return <RenderVideoChat key={`${document?.url}_${index}`} videoURL={document.url} onLongPress={onLongPressImage} />;
+				return <RenderVideoChat key={`${document?.url}_${index}`} videoURL={document.url} onLongPress={() => onLongPressImage(document)} />;
 			}
 
 			return (
@@ -115,7 +115,9 @@ export const MessageAttachment = React.memo(({ attachments, onLongPressImage, cl
 	return (
 		<View>
 			{videos?.length > 0 &&
-				videos.map((video, index) => <RenderVideoChat key={`${video?.url}_${index}`} videoURL={video?.url} onLongPress={onLongPressImage} />)}
+				videos.map((video, index) => (
+					<RenderVideoChat key={`${video?.url}_${index}`} videoURL={video?.url} onLongPress={() => onLongPressImage(video)} />
+				))}
 			<View style={styles.gridContainer}>
 				{visibleImages?.length > 0 &&
 					visibleImages?.map((image, index) => {

--- a/apps/mobile/src/app/screens/home/homedrawer/components/RenderImageChat/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/RenderImageChat/index.tsx
@@ -1,6 +1,7 @@
 import { Metrics, size, useTheme } from '@mezon/mobile-ui';
 import { EMimeTypes, createImgproxyUrl } from '@mezon/utils';
 import * as Sentry from '@sentry/react-native';
+import { ApiMessageAttachment } from 'mezon-js/api.gen';
 import React, { useCallback, useMemo, useState } from 'react';
 import { Dimensions, Text, TouchableOpacity, View } from 'react-native';
 import FastImage from 'react-native-fast-image';
@@ -25,7 +26,7 @@ type RenderImageProps = {
 	index?: number;
 	disable?: boolean;
 	onPress: (image: ImageProps) => void;
-	onLongPress?: () => void;
+	onLongPress?: (image?: ApiMessageAttachment) => void;
 	isMultiple?: boolean;
 	remainingImagesCount?: number;
 	isTablet?: boolean;
@@ -237,13 +238,19 @@ const ImageRenderer = React.memo(
 
 		const containerStyle = [styles.imageMessageRender, imageStyle];
 
+		const handleLongPressImage = () => {
+			if (!remainingImagesCount) {
+				onLongPress?.(image);
+			}
+		};
+
 		return (
 			<TouchableOpacity
 				disabled={isUploading || disable}
-				activeOpacity={0.8}
+				activeOpacity={0.3}
 				key={`${index}-${retryAttempt}`} // Add retry attempt to force re-render
 				onPress={() => onPress(image)}
-				onLongPress={onLongPress}
+				onLongPress={handleLongPressImage}
 				style={containerStyle}
 			>
 				{imageProxyObj?.isProxyImage ? (
@@ -283,3 +290,4 @@ const ImageRenderer = React.memo(
 );
 
 export { RenderImageChat };
+


### PR DESCRIPTION
250813-MOBILE-Fix effect long press image mobile.
Issue: https://github.com/mezonai/mezon/issues/8728
Expect case:
- Make image long press active more opacity.
- When save media on long press message option, just download selected media.


https://github.com/user-attachments/assets/80df4ed2-815f-410b-9041-3ab5a9228b60


https://github.com/user-attachments/assets/4a236b6f-818e-43db-ab26-8eacae142e63

