### PR TITLE
250814-MOBILE-Fix edit message bold not render true format mobile

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/components/ChatBox/ChatMessageSending/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/ChatBox/ChatMessageSending/index.tsx
@@ -136,7 +136,7 @@ export const ChatMessageSending = memo(
 			return text
 				?.replace?.(/@\[(.*?)\]/g, '@$1')
 				?.replace?.(/<#(.*?)>/g, '#$1')
-				?.replace?.(/\*\*(.*?)\*\*/g, '$1');
+				?.replace(/\*\*([\s\S]*?)\*\*/g, '$1');
 		};
 
 		const onEditMessage = useCallback(

--- a/apps/mobile/src/app/screens/home/homedrawer/components/RenderTextMarkdown/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/RenderTextMarkdown/index.tsx
@@ -685,7 +685,7 @@ export const RenderTextMarkdownContent = ({
 		textParts.push(
 			renderTextPalainContain(
 				themeValue,
-				t?.slice(lastIndex).replace(/^\n|\n$/, ''),
+				t?.slice(lastIndex)?.replace(!textParts?.length ? /^\n|\n$/g : '', ''),
 				lastIndex,
 				isUnReadChannel,
 				isLastMessage,
@@ -693,7 +693,7 @@ export const RenderTextMarkdownContent = ({
 				true
 			)
 		);
-	} else {
+	} else if (embedNotificationMessage) {
 		textParts.push(
 			renderTextPalainContain(
 				themeValue,


### PR DESCRIPTION
250814-MOBILE-Fix edit message bold not render true format mobile.
Issue: https://github.com/mezonai/mezon/issues/8733
Expect case:
- Send message bold show true format in mobile and desktop/web when enter new line.
- Text after markdown not remove endline.


https://github.com/user-attachments/assets/b65283a0-66ea-41a4-9b53-f06ade0bc43a

