### PR TITLE
250815-MOBILE-Fix UI direct message preview show space first mobile

### DIFF
--- a/apps/mobile/src/app/screens/messages/DMListItemLastMessage/index.tsx
+++ b/apps/mobile/src/app/screens/messages/DMListItemLastMessage/index.tsx
@@ -92,7 +92,7 @@ export const DmListItemLastMessage = (props: { content: IExtendedMessage; styleT
 			if (textPart) {
 				parts.push(
 					<Text key={`${endIndex}_${textPart}`} style={[styles.message, props?.styleText && props?.styleText]}>
-						{textPart}
+						{startIndex === 0 ? textPart?.trimStart() : textPart}
 					</Text>
 				);
 			}

--- a/apps/mobile/src/app/screens/messages/DMListItemLastMessage/styles.ts
+++ b/apps/mobile/src/app/screens/messages/DMListItemLastMessage/styles.ts
@@ -9,7 +9,7 @@ export const style = (colors: Attributes) =>
 			overflow: 'hidden'
 		},
 		dmMessageContainer: {
-			flex: 1
+			flexShrink: 1
 		},
 		message: {
 			fontSize: size.small,
@@ -17,6 +17,7 @@ export const style = (colors: Attributes) =>
 		},
 		emoji: {
 			height: size.s_12,
-			width: size.s_12
+			width: size.s_12,
+			alignSelf: 'baseline'
 		}
 	});


### PR DESCRIPTION
250815-MOBILE-Fix UI direct message preview show space first mobile
Issue: https://github.com/mezonai/mezon/issues/8759
Expect case: trim message with space character at beginning.

<img width="388" height="82" alt="image" src="https://github.com/user-attachments/assets/778b959c-8f55-4caf-8f51-fb7aa944a547" />
<img width="379" height="69" alt="image" src="https://github.com/user-attachments/assets/61934742-b002-4830-9e25-c3e89de92b2d" />
