### PR TITLE
250820-MOBILE-Fix prevent action for message system item mobile

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/MessageItem.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/MessageItem.tsx
@@ -226,7 +226,7 @@ const MessageItem = React.memo(
 		}, []);
 
 		const handleLongPressMessage = useCallback(() => {
-			if (preventAction) return;
+			if (preventAction || isMessageSystem) return;
 			dispatch(setSelectedMessage(message));
 			const data = {
 				snapPoints: ['55%', '85%'],
@@ -261,7 +261,7 @@ const MessageItem = React.memo(
 		return (
 			<Swipeable
 				ref={swipeRef}
-				enabled={!preventAction}
+				enabled={!preventAction && !isMessageSystem}
 				dragOffsetFromLeftEdge={500}
 				dragOffsetFromRightEdge={12}
 				renderRightActions={renderRightActions}


### PR DESCRIPTION
250820-MOBILE-Fix prevent action for message system item mobile.
Issue: https://github.com/mezonai/mezon/issues/8883
Expect case:
- Long press message system will not open message menu.
- Swipe from right to left not trigger reply message system.


https://github.com/user-attachments/assets/38ee5880-724e-4892-8c40-9dc32cd6a376

