### PR TITLE
250827-WEB/DESKTOP-fix Wrong enter new line in event description

### DIFF
--- a/libs/components/src/lib/components/ChannelList/EventChannelModal/ModalCreate/itemEventManagement.tsx
+++ b/libs/components/src/lib/components/ChannelList/EventChannelModal/ModalCreate/itemEventManagement.tsx
@@ -223,7 +223,7 @@ const ItemEventManagement = (props: ItemEventManagementProps) => {
 				<div className="flex justify-between gap-4 select-text">
 					<div className={`${isReviewEvent || !logoRight ? 'w-full' : 'w-3/5'}`}>
 						<p className="hover:underline font-bold  text-base">{topic}</p>
-						<div className="break-all max-h-[75px] eventDescriptionTruncate">
+						<div className="break-all max-h-[75px] eventDescriptionTruncate whitespace-pre-wrap">
 							{isReviewEvent ? reviewDescription : event?.description}
 						</div>
 					</div>


### PR DESCRIPTION
Task : [[Desktop] Wrong enter new line in event description](https://github.com/mezonai/mezon/issues/8999)
#8999 

Demo 

https://github.com/user-attachments/assets/4ca2dd1a-10de-407c-b3d8-e8fbb065915f

