### PR TITLE
250828-MOBILE-fix optimize render last message DM mobile

### DIFF
--- a/apps/mobile/src/app/screens/messages/DMListItemLastMessage/index.tsx
+++ b/apps/mobile/src/app/screens/messages/DMListItemLastMessage/index.tsx
@@ -78,7 +78,7 @@ export const DmListItemLastMessage = (props: { content: IExtendedMessage; styleT
 
 				if (headingContent.length > 0) {
 					parts.push(
-						<Text key="heading" style={[styles.message, props?.styleText && props?.styleText, { fontWeight: 'bold' }]}>
+						<Text key="heading" numberOfLines={1} style={[styles.message, props?.styleText && props?.styleText, { fontWeight: 'bold' }]}>
 							{headingContent}
 						</Text>
 					);

--- a/apps/mobile/src/app/screens/messages/DMListItemLastMessage/index.tsx
+++ b/apps/mobile/src/app/screens/messages/DMListItemLastMessage/index.tsx
@@ -91,7 +91,11 @@ export const DmListItemLastMessage = (props: { content: IExtendedMessage; styleT
 			const textPart = formatEmojiInText.slice(startIndex, endIndex);
 			if (textPart) {
 				parts.push(
-					<Text key={`${endIndex}_${textPart}`} style={[styles.message, props?.styleText && props?.styleText]}>
+					<Text
+						numberOfLines={1}
+						key={`${endIndex}_${textPart}`}
+						style={[styles.message, props?.styleText && props?.styleText]}
+					>
 						{startIndex === 0 ? textPart?.trimStart() : textPart}
 					</Text>
 				);
@@ -103,9 +107,9 @@ export const DmListItemLastMessage = (props: { content: IExtendedMessage; styleT
 			if (endIndex !== -1) {
 				const emojiUrl = formatEmojiInText.slice(startIndex, endIndex);
 				parts.push(
-					<Text key={`${emojiUrl}_dm_item_last_${endIndex}`}>
+					<View style={styles.emojiWrap} key={`${emojiUrl}_dm_item_last_${endIndex}`}>
 						<ImageNative style={styles.emoji} url={emojiUrl} resizeMode="contain" />
-					</Text>
+					</View>
 				);
 				startIndex = endIndex + EMOJI_KEY.length;
 				endIndex = formatEmojiInText.indexOf(EMOJI_KEY, startIndex);
@@ -114,7 +118,11 @@ export const DmListItemLastMessage = (props: { content: IExtendedMessage; styleT
 
 		if (startIndex < formatEmojiInText.length) {
 			parts.push(
-				<Text key={`${endIndex}_${formatEmojiInText.slice(startIndex)}`} style={[styles.message, props?.styleText && props?.styleText]}>
+				<Text
+					numberOfLines={1}
+					key={`${endIndex}_${formatEmojiInText.slice(startIndex)}`}
+					style={[styles.message, props?.styleText && props?.styleText, { flex: 1 }]}
+				>
 					{formatEmojiInText.slice(startIndex)}
 				</Text>
 			);
@@ -123,11 +131,5 @@ export const DmListItemLastMessage = (props: { content: IExtendedMessage; styleT
 		return parts;
 	};
 
-	return (
-		<View style={styles.container}>
-			<Text numberOfLines={1} ellipsizeMode="tail" style={[styles.message, props?.styleText]}>
-				{convertTextToEmoji()}
-			</Text>
-		</View>
-	);
+	return <View style={styles.container}>{convertTextToEmoji()}</View>;
 };

--- a/apps/mobile/src/app/screens/messages/DMListItemLastMessage/styles.ts
+++ b/apps/mobile/src/app/screens/messages/DMListItemLastMessage/styles.ts
@@ -6,19 +6,22 @@ export const style = (colors: Attributes) =>
 		container: {
 			flexDirection: 'row',
 			flex: 1,
-			overflow: 'hidden',
-			height: size.s_16,
-			flexWrap: 'nowrap'
+			overflow: 'hidden'
 		},
 		message: {
 			fontSize: size.small,
 			color: colors.text,
-			lineHeight: size.s_16,
-			overflow: 'hidden',
-			width: '100%'
+			overflow: 'hidden'
 		},
 		emoji: {
 			height: size.s_12,
-			width: size.s_12
+			width: size.s_12,
+			flexShrink: 0
+		},
+		emojiWrap: {
+			height: size.s_16,
+			width: size.s_12,
+			justifyContent: 'center',
+			overflow: 'hidden',
 		}
 	});


### PR DESCRIPTION
250828-MOBILE-fix optimize render last message DM mobile
Issue: https://github.com/mezonai/mezon/issues/9064
<img width="375" height="60" alt="image" src="https://github.com/user-attachments/assets/f84dd375-fe94-4d60-8875-dc6db7a838d4" />
<img width="377" height="70" alt="image" src="https://github.com/user-attachments/assets/c2ea9347-8fe1-43ce-b1da-aba7becf076d" />
