### PR TITLE
250828-MOBILE-Fix render edited text wrong position mobile

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/components/RenderTextMarkdown/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/RenderTextMarkdown/index.tsx
@@ -692,6 +692,14 @@ export const RenderTextMarkdownContent = ({
 		textParts.push(renderTextPalainContain(themeValue, embedNotificationMessage, lastIndex, isUnReadChannel, isLastMessage, isBuzzMessage, true));
 	}
 
+	if (isEdited && textParts?.length && !markdownBlackParts?.length) {
+		textParts.push(
+			<Text key={`edited-${textParts}`} style={(themeValue ? markdownStyles(themeValue).editedText : {})}>
+				{` ${translate('edited')}`}
+			</Text>
+		);
+	}
+
 	return (
 		<View
 			style={{
@@ -723,7 +731,7 @@ export const RenderTextMarkdownContent = ({
 					{textParts?.length > 0 && <Text key={`textParts${t}_${lastIndex}`}>{textParts}</Text>}
 					{markdownBlackParts?.length > 0 && markdownBlackParts.map((item) => item)}
 				</View>
-				{isEdited && (
+				{isEdited && markdownBlackParts?.length && (
 					<View>
 						<Text key={`edited-${textParts}`} style={themeValue ? markdownStyles(themeValue).editedText : {}}>
 							{translate('edited')}

--- a/apps/mobile/src/app/screens/home/homedrawer/components/RenderTextMarkdown/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/RenderTextMarkdown/index.tsx
@@ -692,7 +692,7 @@ export const RenderTextMarkdownContent = ({
 		textParts.push(renderTextPalainContain(themeValue, embedNotificationMessage, lastIndex, isUnReadChannel, isLastMessage, isBuzzMessage, true));
 	}
 
-	if (isEdited && textParts?.length && !markdownBlackParts?.length) {
+	if (isEdited && textParts?.length > 0 && !markdownBlackParts?.length) {
 		textParts.push(
 			<Text key={`edited-${textParts}`} style={(themeValue ? markdownStyles(themeValue).editedText : {})}>
 				{` ${translate('edited')}`}
@@ -731,7 +731,7 @@ export const RenderTextMarkdownContent = ({
 					{textParts?.length > 0 && <Text key={`textParts${t}_${lastIndex}`}>{textParts}</Text>}
 					{markdownBlackParts?.length > 0 && markdownBlackParts.map((item) => item)}
 				</View>
-				{isEdited && markdownBlackParts?.length && (
+				{isEdited && markdownBlackParts?.length > 0 && (
 					<View>
 						<Text key={`edited-${textParts}`} style={themeValue ? markdownStyles(themeValue).editedText : {}}>
 							{translate('edited')}


### PR DESCRIPTION
250828-MOBILE-Fix render edited text wrong position mobile
Issue: https://github.com/mezonai/mezon/issues/9066
<img width="399" height="149" alt="image" src="https://github.com/user-attachments/assets/4008468a-209c-4244-8ba1-e002c13c4dd4" />
Expect: render (edited) as Text element.
<img width="352" height="122" alt="image" src="https://github.com/user-attachments/assets/dc110db6-7aaa-4645-8e74-bf579d8f05f6" />

https://github.com/user-attachments/assets/2c8d2a77-200b-4488-9deb-14562ffb49cb


