### PR TITLE
250903-MOBILE-fix-prevent-create-category-if-has-not-permission

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/components/ClanMenu/ClanMenu/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/ClanMenu/ClanMenu/index.tsx
@@ -81,7 +81,8 @@ export default function ClanMenu() {
 				DeviceEventEmitter.emit(ActionEmitEvent.ON_TRIGGER_BOTTOM_SHEET, { isDismiss: true });
 				navigation.navigate(APP_SCREEN.MENU_CLAN.STACK, { screen: APP_SCREEN.MENU_CLAN.CREATE_CATEGORY });
 			},
-			title: t('menu.organizationMenu.createCategory')
+			title: t('menu.organizationMenu.createCategory'),
+			isShow: isCanEditRole
 		},
 		{
 			onPress: () => {


### PR DESCRIPTION
[[Mobile App] Still show Create Category with role non-manage clan](https://github.com/mezonai/mezon/issues/9131)