### PR TITLE
250904-MOBILE-fix-message-delete-channel-in-vietnamese

### DIFF
--- a/libs/translations/src/languages/vi/channelSetting.json
+++ b/libs/translations/src/languages/vi/channelSetting.json
@@ -76,14 +76,14 @@
     },
     "confirm": {
         "delete": {
-            "content": "Bạn có chắc chắn muốn xóa kênh #{channelName} không? Hành động này không thể khôi phục.",
+            "content": "Bạn có chắc chắn muốn xóa kênh #{{channelName}} không? Hành động này không thể khôi phục.",
             "confirmText": "Xóa",
             "title": "Xóa kênh",
             "systemChannel": "Không thể xóa kênh hệ thống",
             "error": "Xóa kênh lỗi: {{error}}"
         },
         "leave": {
-            "content": "Bạn có chắc chắn muốn rời kênh #{channelName} không? Hành động này không thể khôi phục.",
+            "content": "Bạn có chắc chắn muốn rời kênh #{{channelName}} không? Hành động này không thể khôi phục.",
             "confirmText": "Rời",
             "title": "Rời kênh"
         },


### PR DESCRIPTION
[[Mobile App] Channel name is not displayed when deleting a channel](https://github.com/mezonai/mezon/issues/9153)

<img width="428" height="946" alt="image" src="https://github.com/user-attachments/assets/19e18fce-5aa4-4bf0-b2f6-7ce21fe85104" />
