### PR TITLE
250905-MOBILE-fix order list image in message mobile

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/components/MessageAttachment/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/MessageAttachment/index.tsx
@@ -55,7 +55,7 @@ export const MessageAttachment = React.memo(({ attachments, onLongPressImage, cl
 	const [videos, setVideos] = useState<ApiMessageAttachment[]>([]);
 	const [images, setImages] = useState<ApiMessageAttachment[]>([]);
 	const [documents, setDocuments] = useState<ApiMessageAttachment[]>([]);
-	const visibleImages = useMemo(() => images?.reverse()?.slice(0, images?.length > 4 ? 3 : 4), [images]);
+	const visibleImages = useMemo(() => images?.slice(0, images?.length > 4 ? 3 : 4), [images]);
 	const remainingImagesCount = useMemo(() => images?.length - visibleImages?.length || 0, [images, visibleImages]);
 
 	useEffect(() => {


### PR DESCRIPTION
250905-MOBILE-fix order list image in message mobile
Issue: https://github.com/mezonai/mezon/issues/9187
<img width="827" height="435" alt="image" src="https://github.com/user-attachments/assets/d77885ed-fe12-4eb3-806e-e9653032e940" />
<img width="388" height="322" alt="image" src="https://github.com/user-attachments/assets/771bb568-c328-4382-80ad-6be438ae4135" />
