### PR TITLE
250908-MOBILE/WEB-Fix not sync mute channel and direct message mobile

### DIFF
--- a/libs/components/src/lib/contexts/DirectMessageContextMenu/useNotificationSettings.ts
+++ b/libs/components/src/lib/contexts/DirectMessageContextMenu/useNotificationSettings.ts
@@ -90,23 +90,14 @@ export function useNotificationSettings({ channelId, notificationSettings, getCh
 		const hasActiveMuteTime =
 			!isDefaultSetting && notificationSettings?.time_mute ? new Date(notificationSettings.time_mute) > new Date() : false;
 		const shouldShowUnmute = isCurrentlyMuted || hasActiveMuteTime;
-		const shouldShowMute = !isCurrentlyMuted && !hasActiveMuteTime;
 
-		if (shouldShowUnmute) {
-			setNameChildren(`UnMute`);
-		} else if (shouldShowMute) {
-			setNameChildren(`Mute`);
-		} else {
-			setNameChildren(`Mute`);
-		}
+		setNameChildren(shouldShowUnmute ? `UnMute` : `Mute`);
 
-		if (hasActiveMuteTime && notificationSettings?.time_mute) {
-			const timeMute = new Date(notificationSettings.time_mute);
-			const formattedDate = format(timeMute, 'dd/MM, HH:mm');
-			setMutedUntilText(`Muted until ${formattedDate}`);
-		} else {
-			setMutedUntilText('');
-		}
+		setMutedUntilText(
+			hasActiveMuteTime && notificationSettings?.time_mute
+				? `Muted until ${format(new Date(notificationSettings.time_mute), 'dd/MM, HH:mm')}`
+				: ''
+		);
 	}, [notificationSettings, dispatch, getChannelId]);
 
 	return {

--- a/libs/store/src/lib/notificationSetting/notificationSettingChannel.slice.ts
+++ b/libs/store/src/lib/notificationSetting/notificationSettingChannel.slice.ts
@@ -245,6 +245,12 @@ export const notificationSettingSlice = createSlice({
 				...action.payload
 			};
 			NotificationSettingsAdapter.upsertOne(state, notificationEntity);
+			if (state?.byChannels?.[channel_id]) {
+				state.byChannels[channel_id].notificationSetting = notificationEntity as any;
+				state.byChannels[channel_id].cache = createCacheMetadata();
+			} else {
+				state.byChannels[channel_id] = getInitialChannelState();
+			}
 		},
 		removeNotiSetting: (state, action: PayloadAction<string>) => {
 			const channelId = action.payload;


### PR DESCRIPTION
250908-MOBILE/WEB-Fix not sync mute channel and direct message mobile
Issue: https://github.com/mezonai/mezon/issues/9183
Expect sync mute option for channel and direct message in mobile and web.