### PR TITLE
20250909-MOBILE-fix-the-time-left-clan-event

### DIFF
--- a/apps/mobile/src/app/components/Event/EventTime/EventTime.tsx
+++ b/apps/mobile/src/app/components/Event/EventTime/EventTime.tsx
@@ -14,9 +14,10 @@ import { style } from './styles';
 interface IEventTimeProps {
 	event: EventManagementEntity;
 	eventStatus: number;
+	minutes: number;
 }
 
-export function EventTime({ event, eventStatus }: IEventTimeProps) {
+export function EventTime({ event, eventStatus, minutes }: IEventTimeProps) {
 	const { themeValue } = useTheme();
 	const styles = style(themeValue);
 	const { t } = useTranslation(['eventCreator']);
@@ -28,7 +29,7 @@ export function EventTime({ event, eventStatus }: IEventTimeProps) {
 		switch (eventStatus) {
 			case EEventStatus?.UPCOMING:
 				color = baseColor.blurple;
-				text = t('eventDetail.tenMinutesLeft');
+				text = t('eventDetail.tenMinutesLeft', { minutes });
 				break;
 			case EEventStatus.ONGOING:
 				color = baseColor.green;

--- a/libs/translations/src/languages/en/eventCreator.json
+++ b/libs/translations/src/languages/en/eventCreator.json
@@ -98,7 +98,7 @@
     },
     "eventDetail": {
         "eventIsTaking": "Event is taking place!",
-        "tenMinutesLeft": "10 minutes left. Join in!"
+        "tenMinutesLeft": "{{minutes}} minutes left. Join in!"
     },
     "selectUser": "Select channel to create event"
 }

--- a/libs/translations/src/languages/vi/eventCreator.json
+++ b/libs/translations/src/languages/vi/eventCreator.json
@@ -98,7 +98,7 @@
     },
     "eventDetail": {
         "eventIsTaking": "Sự kiện đang diễn ra!",
-        "tenMinutesLeft": "Còn 10 phút. Tham gia ngay!"
+        "tenMinutesLeft": "Còn {{minutes}} phút. Tham gia ngay!"
     },
     "selectUser": "Chọn channel để tạo sự kiện"
 }


### PR DESCRIPTION
[[Mobile App] The countdown timer event is reflected incorrectly with mobile time](https://github.com/mezonai/mezon/issues/9288)

<img width="398" height="913" alt="image" src="https://github.com/user-attachments/assets/7ed56cde-9db8-4681-8cde-7d80e6511ebf" />
