### PR TITLE
250909-Mobile-fix-bug-loading-when-create-thread-fail

### DIFF
--- a/apps/mobile/src/app/components/ThreadDetail/CreateThreadForm/index.tsx
+++ b/apps/mobile/src/app/components/ThreadDetail/CreateThreadForm/index.tsx
@@ -156,6 +156,8 @@ export default function CreateThreadForm({ navigation, route }: MenuThreadScreen
 					} catch (error) {
 						dispatch(appActions.setLoadingMainMobile(false));
 						console.error('Error creating thread:', error);
+					} finally {
+						dispatch(appActions.setLoadingMainMobile(false));
 					}
 				} else {
 					await sendMessageThread(content, mentions, attachments, references, threadCurrentChannel);


### PR DESCRIPTION
[Mobile App: show bottomsheet warning noti when create thread](https://github.com/mezonai/mezon/issues/9249)