### PR TITLE
250911-MOBILE-Fix status of switch chat box mobile

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/PanelKeyboard.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/PanelKeyboard.tsx
@@ -19,6 +19,8 @@ const PanelKeyboard = React.memo((props: IProps) => {
 	const bottomPickerRef = useRef<BottomSheetModal>(null);
 	const [messageActionNeedToResolve, setMessageActionNeedToResolve] = useState<IMessageActionNeedToResolve | null>(null);
 
+	console.log('typeKeyboardBottomSheet', typeKeyboardBottomSheet);
+
 	const onShowKeyboardBottomSheet = useCallback(async (isShow: boolean, type?: string) => {
 		const keyboardHeight = Platform.OS === 'ios' ? 365 : 300;
 		if (isShow) {
@@ -65,6 +67,7 @@ const PanelKeyboard = React.memo((props: IProps) => {
 		if (index === -1) {
 			setHeightKeyboardShow(0);
 			setTypeKeyboardBottomSheet('text');
+			DeviceEventEmitter.emit(ActionEmitEvent.ON_PANEL_KEYBOARD_BOTTOM_SHEET, { isShow: false, mode: '' });
 		}
 	};
 

--- a/apps/mobile/src/app/screens/home/homedrawer/PanelKeyboard.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/PanelKeyboard.tsx
@@ -19,8 +19,6 @@ const PanelKeyboard = React.memo((props: IProps) => {
 	const bottomPickerRef = useRef<BottomSheetModal>(null);
 	const [messageActionNeedToResolve, setMessageActionNeedToResolve] = useState<IMessageActionNeedToResolve | null>(null);
 
-	console.log('typeKeyboardBottomSheet', typeKeyboardBottomSheet);
-
 	const onShowKeyboardBottomSheet = useCallback(async (isShow: boolean, type?: string) => {
 		const keyboardHeight = Platform.OS === 'ios' ? 365 : 300;
 		if (isShow) {

--- a/apps/mobile/src/app/screens/home/homedrawer/components/ChatBox/ChatBoxBottomBar/style.ts
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/ChatBox/ChatBoxBottomBar/style.ts
@@ -6,6 +6,10 @@ export const style = (colors: Attributes) =>
 			paddingHorizontal: size.s_2,
 			overflow: 'visible'
 		},
+		wrapper: {
+			flexDirection: 'row',
+			zIndex: 10
+		},
 		btnIcon: {
 			width: size.s_40,
 			height: size.s_40,

--- a/apps/mobile/src/app/screens/home/homedrawer/components/ChatBox/ChatMessageLeftArea/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/ChatBox/ChatMessageLeftArea/index.tsx
@@ -35,13 +35,15 @@ export const ChatMessageLeftArea = memo(
 				}
 			}));
 
+			const handleCreateThread = () => {
+				handleKeyboardBottomSheetMode('');
+				navigation.navigate(APP_SCREEN.MENU_THREAD.STACK, {
+					screen: APP_SCREEN.MENU_THREAD.CREATE_THREAD
+				});
+			};
+
 			return (
-				<View
-					style={{
-						flexDirection: 'row',
-						zIndex: 10
-					}}
-				>
+				<View style={styles.wrapper}>
 					{isAvailableSending && !isShowAttachControl ? (
 						<TouchableOpacity style={[styles.btnIcon]} onPress={() => setIsShowAttachControl(!isShowAttachControl)}>
 							<MezonIconCDN icon={IconCDN.chevronSmallLeftIcon} width={size.s_22} height={size.s_22} color={themeValue.textStrong} />
@@ -50,14 +52,7 @@ export const ChatMessageLeftArea = memo(
 						<Fragment>
 							<AttachmentSwitcher onChange={handleKeyboardBottomSheetMode} mode={modeKeyBoardBottomSheet} />
 							{isShowCreateThread && (
-								<TouchableOpacity
-									style={[styles.btnIcon, { marginLeft: size.s_6 }]}
-									onPress={() =>
-										navigation.navigate(APP_SCREEN.MENU_THREAD.STACK, {
-											screen: APP_SCREEN.MENU_THREAD.CREATE_THREAD
-										})
-									}
-								>
+								<TouchableOpacity style={[styles.btnIcon, { marginLeft: size.s_6 }]} onPress={handleCreateThread}>
 									<MezonIconCDN icon={IconCDN.threadPlusIcon} width={size.s_22} height={size.s_22} color={themeValue.textStrong} />
 								</TouchableOpacity>
 							)}

--- a/apps/mobile/src/app/screens/home/homedrawer/components/EmojiPicker/EmojiSwitcher/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/EmojiPicker/EmojiSwitcher/index.tsx
@@ -1,6 +1,7 @@
+import { ActionEmitEvent } from '@mezon/mobile-components';
 import { size, useTheme } from '@mezon/mobile-ui';
 import React, { memo, useEffect, useState } from 'react';
-import { TouchableOpacity, View } from 'react-native';
+import { DeviceEventEmitter, TouchableOpacity, View } from 'react-native';
 import MezonIconCDN from '../../../../../../componentUI/MezonIconCDN';
 import { IconCDN } from '../../../../../../constants/icon_cdn';
 
@@ -24,8 +25,18 @@ function EmojiSwitcher({ mode: _mode, onChange }: IProps) {
 	};
 
 	useEffect(() => {
-		setMode(_mode);
-	}, [_mode]);
+		const eventListener = DeviceEventEmitter.addListener(ActionEmitEvent.ON_PANEL_KEYBOARD_BOTTOM_SHEET, ({ isShow = false, mode = '' }) => {
+			if (!isShow) {
+				setMode('text');
+			} else {
+				setMode(mode);
+			}
+		});
+
+		return () => {
+			eventListener.remove();
+		};
+	}, []);
 
 	return (
 		<View>


### PR DESCRIPTION
250911-MOBILE-Fix status of switch chat box mobile
Issue: https://github.com/mezonai/mezon/issues/9300
Expect case:
- On press in button with switch status icon and show or hide bottom sheet emoji or attachment
- Change Icon when bottom sheet close by trigger others mode or swipe to close.
- Close emoji and attachment panel when trigger voice message or open create thread.


https://github.com/user-attachments/assets/8d213079-c459-459e-89b1-88f51f391778

