### PR TITLE
20250911-MOBILE-fix-bug-keyboard-overlap-emoji-modal

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/components/ChannelVoice/HeaderRoomView/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/ChannelVoice/HeaderRoomView/index.tsx
@@ -130,7 +130,7 @@ const HeaderRoomView = memo(({ channelId, onPressMinimizeRoom, isGroupCall = fal
 
 	const handleOpenEmojiPicker = () => {
 		const data = {
-			snapPoints: ['45%', '75%'],
+			snapPoints: ['75%'],
 			children: (
 				<ContainerMessageActionModal
 					message={undefined}


### PR DESCRIPTION
[[Mobile App] Keyboard overlaps emoji search bar in VOICE ROOM](https://github.com/mezonai/mezon/issues/9380)
<img width="333" height="776" alt="image" src="https://github.com/user-attachments/assets/1fad674a-5102-40c7-be0c-67df7dc1740b" />


