### PR TITLE
250912-MOBILE-Fix WEBP gif not play animation mobile

### DIFF
--- a/apps/mobile/android/app/build.gradle
+++ b/apps/mobile/android/app/build.gradle
@@ -159,12 +159,13 @@ dependencies {
     implementation 'com.google.firebase:firebase-messaging:23.4.1'
     implementation 'com.squareup.picasso:picasso:2.71828'
     implementation "com.airbnb.android:lottie:5.1.1"
-    implementation 'com.github.bumptech.glide:glide:4.12.0'
+    implementation 'com.github.bumptech.glide:glide:4.16.0'
     implementation("com.facebook.react:hermes-engine:+")
-    kapt 'com.github.bumptech.glide:compiler:4.12.0'
+    kapt 'com.github.bumptech.glide:compiler:4.16.0'
     implementation 'com.google.firebase:firebase-analytics:21.4.0'
     implementation "androidx.core:core-splashscreen:1.0.1"
     implementation 'me.leolin:ShortcutBadger:1.1.22@aar'
+    implementation "com.github.zjupure:webpdecoder:2.7.4.16.0"
 
     implementation 'com.facebook.fresco:animated-gif:3.6.0'
 

--- a/apps/mobile/android/app/src/main/java/com/mobile/CustomImageView.kt
+++ b/apps/mobile/android/app/src/main/java/com/mobile/CustomImageView.kt
@@ -70,22 +70,22 @@ class CustomImageView(context: Context) : RelativeLayout(context) {
             .transition(DrawableTransitionOptions.withCrossFade(500))
             .listener(object : RequestListener<Drawable> {
                 override fun onLoadFailed(
-                    e: GlideException?,
-                    model: Any?,
-                    target: Target<Drawable>?,
-                    isFirstResource: Boolean
-                ): Boolean {
+					e: GlideException?,
+					model: Any?,
+					target: Target<Drawable>,
+					isFirstResource: Boolean
+				): Boolean {
                     loadingIcon.visibility = View.GONE
                     return false
                 }
 
                 override fun onResourceReady(
-                    resource: Drawable?,
-                    model: Any?,
-                    target: Target<Drawable>?,
-                    dataSource: DataSource?,
-                    isFirstResource: Boolean
-                ): Boolean {
+					resource: Drawable,
+					model: Any,
+					target: Target<Drawable>?,
+					dataSource: DataSource,
+					isFirstResource: Boolean
+				): Boolean {
                     loadingIcon.visibility = View.GONE
                     imageView.alpha = 1f
                     return false


### PR DESCRIPTION
250912-MOBILE-Fix WEBP gif not play animation mobile
Issue: https://github.com/mezonai/mezon/issues/9403

https://github.com/user-attachments/assets/6d581e75-5725-4c0d-b8f9-d7bcc0b8707d

