### PR TITLE
250917-web/desktop-fix: stop screen sharing when switching voice channels

### DIFF
--- a/apps/chat/src/app/pages/channel/ChannelVoice.tsx
+++ b/apps/chat/src/app/pages/channel/ChannelVoice.tsx
@@ -61,6 +61,9 @@ const ChannelVoice = memo(
 
 		const handleJoinRoom = async () => {
 			dispatch(voiceActions.setOpenPopOut(false));
+			dispatch(voiceActions.setShowScreen(false));
+			dispatch(voiceActions.setStreamScreen(null));
+			dispatch(voiceActions.setShowMicrophone(false));
 			const store = getStore();
 			const currentClan = selectCurrentClan(store.getState());
 			if (!currentClan || !currentChannel?.meeting_code) return;


### PR DESCRIPTION
Task : [Desktop/Website] Screen Sharing continues to play after switching voice channels
[#9479](https://github.com/mezonai/mezon/issues/9479)

Demo : https://drive.google.com/file/d/1YWCg5b3pLUlOwBImBsAzWCO63h6NDBSh/view?usp=sharing