### PR TITLE
250923-DESKTOP-Fix/modal share screen dm call

### DIFF
--- a/libs/components/src/lib/components/VoiceChannel/ControlBar/ControlBar.tsx
+++ b/libs/components/src/lib/components/VoiceChannel/ControlBar/ControlBar.tsx
@@ -233,15 +233,26 @@ const ControlBar = ({
 		};
 	}, [stream]);
 
-	const handleOpenScreenSelection = useCallback(() => {
+	const handleOpenScreenSelection = useCallback(async () => {
 		if (isDesktop) {
+			if (typeof document !== 'undefined' && document.fullscreenElement) {
+				try {
+					await document.exitFullscreen();
+				} catch (_e) {
+					void 0;
+				}
+				dispatch(voiceActions.setFullScreen(false));
+			} else if (isFullScreen) {
+				onFullScreen?.();
+			}
+
 			if (!showScreen) {
 				dispatch(voiceActions.setShowSelectScreenModal(true));
 			} else {
 				dispatch(voiceActions.setShowScreen(false));
 			}
 		}
-	}, [isDesktop, openScreenSelection, showScreen]);
+	}, [dispatch, isDesktop, isFullScreen, onFullScreen, showScreen]);
 
 	const onScreenShare = useCallback(
 		async (enabled: boolean, isUserInitiated: boolean) => {


### PR DESCRIPTION
Task : [Desktop/Website] Modal share screen is hidden in DM group call
[#9455](https://github.com/mezonai/mezon/issues/9455) 


Demo : 

https://github.com/user-attachments/assets/be0dc910-1daa-4622-b052-4b56c165268b

