### PR TITLE
250925-WEB/DESKTOP-fix: clear 'In Voice' status when user leaves voice channel in side member list

### DIFF
--- a/libs/store/src/lib/voice/voice.slice.ts
+++ b/libs/store/src/lib/voice/voice.slice.ts
@@ -188,7 +188,7 @@ export const voiceSlice = createSlice({
 		remove: (state, action: PayloadAction<VoiceLeavedEvent>) => {
 			const voice = action.payload;
 			voiceAdapter.removeOne(state, voice.id);
-			if (state.listInVoiceStatus[voice?.id]) {
+			if (state.listInVoiceStatus[voice.voice_user_id]) {
 				delete state.listInVoiceStatus[voice.voice_user_id];
 			}
 		},


### PR DESCRIPTION
Task : [Desktop/Website] User still appears as 'In Voice' in side member list After leaving voice channel
[#9632](https://github.com/mezonai/mezon/issues/9632)

Demo : 

https://github.com/user-attachments/assets/f7c4c23a-8ef0-4b6a-9c74-d637fc559e2b

