### PR TITLE
250929-MOBILE-Fix show error when edit duplicate name clan setting overview mobile

### DIFF
--- a/apps/mobile/src/app/components/ClanSettings/Overview/Overview.tsx
+++ b/apps/mobile/src/app/components/ClanSettings/Overview/Overview.tsx
@@ -180,7 +180,7 @@ export function ClanOverviewSetting({ navigation }: MenuClanScreenProps<ClanSett
 					setErrorMessage(t('menu.serverName.duplicateNameMessage'));
 					setIsCheckValid(false);
 					setLoading(false);
-					return;
+					throw new Error(t('menu.serverName.duplicateNameMessage'));
 				}
 			}
 

--- a/apps/mobile/src/app/components/ClanSettings/Overview/Overview.tsx
+++ b/apps/mobile/src/app/components/ClanSettings/Overview/Overview.tsx
@@ -210,6 +210,7 @@ export function ClanOverviewSetting({ navigation }: MenuClanScreenProps<ClanSett
 				type: 'info',
 				text1: t('toast.saveSuccess')
 			});
+			navigation.goBack();
 		} catch (error) {
 			Toast.show({
 				type: 'error',
@@ -218,7 +219,6 @@ export function ClanOverviewSetting({ navigation }: MenuClanScreenProps<ClanSett
 			});
 		} finally {
 			setLoading(false);
-			navigation.goBack();
 			dispatch(appActions.setLoadingMainMobile(false));
 		}
 	}


### PR DESCRIPTION
250929-MOBILE-Fix show error when edit duplicate name clan setting overview mobile
Issue: https://github.com/mezonai/mezon/issues/9726
Expect: when edited name was duplicate, show toast error

https://github.com/user-attachments/assets/648d9425-94fa-4118-97fe-bd3df8359c2d

