### PR TITLE
250930-MOBILE-Fix zoom in screen share not focus content and wrong position when end pinch

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/components/ChannelVoice/RoomView/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/ChannelVoice/RoomView/index.tsx
@@ -177,7 +177,7 @@ const RoomView = ({
 		return (
 			<View style={{ width: '100%', flex: 1, alignItems: 'center' }}>
 				<View style={{ height: '100%', width: '100%' }}>
-					<ResumableZoom onTap={() => setIsHiddenControl((prevState) => !prevState)}>
+					<ResumableZoom onTap={() => setIsHiddenControl((prevState) => !prevState)} allowPinchPanning={false}>
 						<View style={{ height: '100%', width: marginWidth }}>
 							<VideoTrack
 								trackRef={focusedScreenShare}


### PR DESCRIPTION
250930-MOBILE-Fix zoom in screen share not focus content and wrong position when end pinch.
Issue: https://github.com/mezonai/mezon/issues/9560
