### PR TITLE
251001-MOBILE-Fix delete channel not close modal call mobile

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/components/ChannelVoice/RoomView/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/ChannelVoice/RoomView/index.tsx
@@ -71,6 +71,8 @@ const RoomViewListener = memo(
 					return t('disconnectModal.content.removed');
 				case DisconnectReason.DUPLICATE_IDENTITY:
 					return t('disconnectModal.content.duplicate');
+				case DisconnectReason.ROOM_DELETED:
+					return t('disconnectModal.content.deleted');
 				default:
 					return t('disconnectModal.content.default');
 			}
@@ -78,7 +80,11 @@ const RoomViewListener = memo(
 
 		const handleDisconnected = useCallback(
 			async (reason?: DisconnectReason) => {
-				if (reason === DisconnectReason.PARTICIPANT_REMOVED || reason === DisconnectReason.DUPLICATE_IDENTITY) {
+				if (
+					reason === DisconnectReason.PARTICIPANT_REMOVED ||
+					reason === DisconnectReason.DUPLICATE_IDENTITY ||
+					reason === DisconnectReason.ROOM_DELETED
+				) {
 					DeviceEventEmitter.emit(ActionEmitEvent.ON_OPEN_MEZON_MEET, {
 						isEndCall: true,
 						clanId,

--- a/libs/translations/src/languages/en/channelVoice.json
+++ b/libs/translations/src/languages/en/channelVoice.json
@@ -33,7 +33,8 @@
         "content": {
             "removed": "You have been removed from the voice channel",
             "duplicate": "You have been disconnected due to another join",
-            "default": "You have been disconnected from the voice channel"
+            "default": "You have been disconnected from the voice channel",
+            "deleted": "The voice channel has been deleted"
         },
         "confirm": "Confirm"
     }

--- a/libs/translations/src/languages/vi/channelVoice.json
+++ b/libs/translations/src/languages/vi/channelVoice.json
@@ -33,7 +33,8 @@
         "content": {
             "removed": "Bạn đã bị xóa khỏi kênh thoại",
             "duplicate": "Bạn đã bị ngắt kết nối do tham gia ở nơi khác",
-            "default": "Bạn đã bị ngắt kết nối khỏi kênh thoại"
+            "default": "Bạn đã bị ngắt kết nối khỏi kênh thoại",
+            "deleted": "Kênh thoại đã bị xóa"
         },
         "confirm": "Xác nhận"
     }


### PR DESCRIPTION
251001-MOBILE-Fix delete channel not close modal call mobile
Issue: https://github.com/mezonai/mezon/issues/9793
Expect: close modal call when channel voice had deleted.