### PR TITLE
251001-WEB/DESKTOP-Fix(thread channel)/context menu close after mute

### DIFF
--- a/libs/components/src/lib/components/PanelChannel/index.tsx
+++ b/libs/components/src/lib/components/PanelChannel/index.tsx
@@ -422,6 +422,7 @@ const PanelChannel = ({ coords, channel, openSetting, setIsShowPanelChannel, onD
 	const handleOpenMenuNoti = useCallback((visible: boolean) => {
 		menuOpenNoti.current = visible;
 	}, []);
+
 	return (
 		<div
 			ref={panelRef}
@@ -466,7 +467,7 @@ const PanelChannel = ({ coords, channel, openSetting, setIsShowPanelChannel, onD
 								onVisibleChange={handleOpenMenuMute}
 							>
 								<div>
-									<ItemPanel children={nameChildren} dropdown="change here" onClick={() => muteOrUnMuteChannel(0)} />
+									<ItemPanel children={nameChildren} dropdown="change here" />
 								</div>
 							</Menu>
 						) : (
@@ -524,7 +525,7 @@ const PanelChannel = ({ coords, channel, openSetting, setIsShowPanelChannel, onD
 								onVisibleChange={handleOpenMenuMute}
 							>
 								<div>
-									<ItemPanel children={nameChildren} dropdown="change here" onClick={() => muteOrUnMuteChannel(0)} />
+									<ItemPanel children={nameChildren} dropdown="change here" />
 								</div>
 							</Menu>
 						) : (


### PR DESCRIPTION
Task : [Desktop/Website] Cannot close context menu after muting channel/thread
[#9820](https://github.com/mezonai/mezon/issues/9820)

Demo : 

https://github.com/user-attachments/assets/61cdd290-da36-45f5-b25d-0e4241fa2e08

