### PR TITLE
251001-MOBILE-Fix enter focus screen from pip mode render video in wrong position mobile

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/components/ChannelVoice/RoomView/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/ChannelVoice/RoomView/index.tsx
@@ -183,8 +183,8 @@ const RoomView = ({
 								trackRef={focusedScreenShare}
 								objectFit={'contain'}
 								style={{
-									height: isPiPMode ? size.s_100 * 1.2 : '100%',
-									width: isPiPMode ? '50%' : '100%',
+									height: '100%',
+									width: '100%',
 									alignSelf: 'center'
 								}}
 								iosPIP={{ enabled: true, startAutomatically: true, preferredSize: { width: 12, height: 8 } }}


### PR DESCRIPTION
251001-MOBILE-Fix enter focus screen from pip mode render video in wrong position mobile
Issue: https://github.com/mezonai/mezon/issues/9778