### PR TITLE
251003-MOBILE/WEB/DESKTOP-Fix change category duplicate channel in category and disappear in favorite channel category

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/components/ChannelList/ChannelListSection/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/ChannelList/ChannelListSection/index.tsx
@@ -59,7 +59,7 @@ const ChannelListSection = memo(({ data }: IChannelListSectionProps) => {
 						color={themeValue.text}
 						customStyle={[!categoryExpandState && { transform: [{ rotate: '-90deg' }] }]}
 					/>
-					<Text style={styles.channelListHeaderItemTitle}>{data?.category_name}</Text>
+					<Text style={styles.channelListHeaderItemTitle} numberOfLines={1}>{data?.category_name}</Text>
 				</View>
 			</TouchableOpacity>
 		</View>

--- a/apps/mobile/src/app/screens/home/homedrawer/components/ChannelList/ChannelListSection/styles.ts
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/ChannelList/ChannelListSection/styles.ts
@@ -23,6 +23,7 @@ export const style = (colors: Attributes) =>
 			textTransform: 'uppercase',
 			fontSize: size.s_13,
 			fontWeight: 'bold',
-			color: colors.text
+			color: colors.text,
+			flexShrink: 1
 		}
 	});

--- a/libs/store/src/lib/channels/listChannelRender.slice.ts
+++ b/libs/store/src/lib/channels/listChannelRender.slice.ts
@@ -182,14 +182,19 @@ export const listChannelRenderSlice = createSlice({
 			if (!state.listChannelRender[clanId]) {
 				return;
 			}
-			const oldIndexOfChannel = state.listChannelRender[clanId].findIndex((channel) => channel.id === channelId);
+			const oldIndexOfChannel = state.listChannelRender[clanId].findIndex(
+				(channel) => channel.id === channelId && channel?.category_id !== FAVORITE_CATEGORY_ID
+			);
 			const indexOfNewCategory = state.listChannelRender[clanId].findIndex((channel) => channel.id === categoryId);
 			if (oldIndexOfChannel === -1 || indexOfNewCategory === -1) {
 				return;
 			}
 
 			const newChannelWithThreads = state.listChannelRender[clanId].filter((item) => {
-				if ((item as IChannel).id === channelId || (item as IChannel).parent_id === channelId) {
+				if (
+					((item as IChannel).id === channelId || (item as IChannel).parent_id === channelId) &&
+					(item as IChannel)?.category_id !== FAVORITE_CATEGORY_ID
+				) {
 					return {
 						...item,
 						category_id: categoryId


### PR DESCRIPTION
251003-MOBILE/WEB/DESKTOP-Fix change category duplicate channel in category and disappear in favorite channel category
Issue: https://github.com/mezonai/mezon/issues/9798 https://github.com/mezonai/mezon/issues/9857
Expect case when change category with channel had mark favorite, only change order and item in parent category

https://github.com/user-attachments/assets/2ae7ccd4-bc95-4f4f-a6b1-d3c3cf741be8

