### PR TITLE
251003-MOBILE-Fix show option edit and delete category when not have permission mobile

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/components/CategoryMenu/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/CategoryMenu/index.tsx
@@ -48,7 +48,7 @@ export default function CategoryMenu({ category }: ICategoryMenuProps) {
 	const styles = style(themeValue);
 	const currentClan = useSelector(selectCurrentClan);
 	const currentChanelId = useSelector(selectCurrentChannelId);
-	const [isCanManageChannel] = usePermissionChecker([EPermission.manageChannel], currentChanelId ?? '');
+	const [isCanManageChannel, isCanManageClan] = usePermissionChecker([EPermission.manageChannel, EPermission.manageClan], currentChanelId ?? '');
 	const navigation = useNavigation<AppStackScreenProps<StackMenuClanScreen>['navigation']>();
 	const { handleMarkAsReadCategory, statusMarkAsReadCategory } = useMarkAsRead();
 	const { dismiss } = useBottomSheetModal();
@@ -175,7 +175,7 @@ export default function CategoryMenu({ category }: ICategoryMenuProps) {
 				});
 			},
 			icon: <MezonIconCDN icon={IconCDN.settingIcon} color={themeValue.textStrong} />,
-			isShow: isCanManageChannel
+			isShow: isCanManageClan
 		},
 		{
 			title: t('menu.organizationMenu.createChannel'),
@@ -195,7 +195,7 @@ export default function CategoryMenu({ category }: ICategoryMenuProps) {
 			title: t('menu.organizationMenu.delete'),
 			onPress: handleDelete,
 			icon: <MezonIconCDN icon={IconCDN.closeLargeIcon} color={baseColor.redStrong} />,
-			isShow: isCanManageChannel,
+			isShow: isCanManageClan,
 			textStyle: {
 				color: baseColor.redStrong
 			}


### PR DESCRIPTION
251003-MOBILE-Fix show option edit and delete category when not have permission mobile
Issue: https://github.com/mezonai/mezon/issues/9838
Expect: Only show option delete and edit category when user have manage Clan permission or greater 
<img width="388" height="496" alt="image" src="https://github.com/user-attachments/assets/95a2a7c3-8b46-4c99-a44d-9171db57e1a3" />
