### PR TITLE
251008-MOBILE-Feature share invite link to external apps mobile

### DIFF
--- a/libs/translations/src/languages/en/inviteToChannel.json
+++ b/libs/translations/src/languages/en/inviteToChannel.json
@@ -31,5 +31,10 @@
         "downloadError": "Error downloading QR code",
         "shareError": "Error sharing QR code",
         "clanDefaultName": "Clan"
+    },
+    "share": {
+        "title": "Share",
+        "message": "Join Mezon with me: ",
+        "error": "Error sharing invite link: {{error}}"
     }
 }

--- a/libs/translations/src/languages/vi/inviteToChannel.json
+++ b/libs/translations/src/languages/vi/inviteToChannel.json
@@ -31,5 +31,10 @@
     "downloadError": "Lỗi khi tải mã QR",
     "shareError": "Lỗi khi chia sẻ mã QR",
     "clanDefaultName": "Clan"
+  },
+  "share": {
+    "title": "chia sẻ",
+    "message": "Tham gia Mezon với tôi:",
+    "error": "Lỗi khi chia sẻ: {{error}}"
   }
 }


### PR DESCRIPTION
251008-MOBILE-Feature share invite link to external apps mobile
Issue: https://github.com/mezonai/mezon/issues/9796
Expect: when press share, show share bottom sheet to choose app and content share is created invite link.

https://github.com/user-attachments/assets/e562554d-b651-4c99-bd39-d6e52eb21686

