### PR TITLE
251008-MOBILE-Fix blocked user show hide permission chat and call, buzz mobile

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/components/ChannelList/ChannelListSection/styles.ts
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/ChannelList/ChannelListSection/styles.ts
@@ -24,6 +24,7 @@ export const style = (colors: Attributes) =>
 			fontSize: size.s_13,
 			fontWeight: 'bold',
 			color: colors.text,
+			marginRight: size.s_16,
 			flexShrink: 1
 		}
 	});

--- a/apps/mobile/src/app/screens/home/homedrawer/components/UserProfile/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/UserProfile/index.tsx
@@ -359,7 +359,7 @@ const UserProfile = React.memo(
 				text: t('userAction.voiceCall'),
 				icon: <MezonIconCDN icon={IconCDN.phoneCallIcon} color={themeValue.text} />,
 				action: () => handleCallUser(userId || user?.id),
-				isShow: (!!infoFriend && infoFriend?.state === EFriendState.Friend) || !!userById
+				isShow: ((!!infoFriend && infoFriend?.state === EFriendState.Friend) || !!userById) && !isBlocked
 			},
 			{
 				id: 4,

--- a/apps/mobile/src/app/screens/messages/DirectMessageDetail/HeaderDirectMessage.tsx
+++ b/apps/mobile/src/app/screens/messages/DirectMessageDetail/HeaderDirectMessage.tsx
@@ -11,6 +11,7 @@ import {
 	groupCallActions,
 	messagesActions,
 	selectAllAccount,
+	selectBlockedUsersForMessage,
 	selectDmGroupCurrent,
 	selectLastMessageByChannelId,
 	selectLastSeenMessageStateByChannelId,
@@ -216,6 +217,14 @@ const HeaderDirectMessage: React.FC<HeaderProps> = ({ from, styles, themeValue, 
 		DeviceEventEmitter.emit(ActionEmitEvent.ON_TRIGGER_MODAL, { isDismiss: false, data: dataModal });
 	};
 
+	const isBlocked = useMemo(() => {
+		if (currentDmGroup.type !== ChannelType.CHANNEL_TYPE_DM) return false;
+		const store = getStore();
+		const listBlockedUser = selectBlockedUsersForMessage(store.getState());
+		const blockedUser = listBlockedUser.some((user) => user?.user && user?.user?.id === currentDmGroup?.user_ids?.[0]);
+		return blockedUser;
+	}, [currentDmGroup]);
+
 	const headerOptions: IOption[] = [
 		{
 			title: 'buzz',
@@ -288,21 +297,23 @@ const HeaderDirectMessage: React.FC<HeaderProps> = ({ from, styles, themeValue, 
 				<Text style={styles.titleText} numberOfLines={1}>
 					{dmLabel}
 				</Text>
-				<View style={styles.iconWrapper}>
-					{((!isTypeDMGroup && !!currentDmGroup?.user_ids?.[0]) || (isTypeDMGroup && !!currentDmGroup?.meeting_code)) && (
-						<TouchableOpacity style={styles.iconHeader} onPress={() => goToCall()}>
-							<MezonIconCDN icon={IconCDN.phoneCallIcon} width={size.s_18} height={size.s_18} color={themeValue.text} />
-						</TouchableOpacity>
-					)}
-					{!isTypeDMGroup && (
-						<TouchableOpacity style={styles.iconHeader} onPress={() => goToCall(true)}>
-							<MezonIconCDN icon={IconCDN.videoIcon} width={size.s_18} height={size.s_18} color={themeValue.text} />
-						</TouchableOpacity>
-					)}
-					<View style={styles.iconOption}>
-						<HeaderTooltip onPressOption={onPressOption} options={headerOptions} />
+				{!isBlocked && (
+					<View style={styles.iconWrapper}>
+						{((!isTypeDMGroup && !!currentDmGroup?.user_ids?.[0]) || (isTypeDMGroup && !!currentDmGroup?.meeting_code)) && (
+							<TouchableOpacity style={styles.iconHeader} onPress={() => goToCall()}>
+								<MezonIconCDN icon={IconCDN.phoneCallIcon} width={size.s_18} height={size.s_18} color={themeValue.text} />
+							</TouchableOpacity>
+						)}
+						{!isTypeDMGroup && (
+							<TouchableOpacity style={styles.iconHeader} onPress={() => goToCall(true)}>
+								<MezonIconCDN icon={IconCDN.videoIcon} width={size.s_18} height={size.s_18} color={themeValue.text} />
+							</TouchableOpacity>
+						)}
+						<View style={styles.iconOption}>
+							<HeaderTooltip onPressOption={onPressOption} options={headerOptions} />
+						</View>
 					</View>
-				</View>
+				)}
 			</Pressable>
 		</View>
 	);


### PR DESCRIPTION
251008-MOBILE-Fix blocked user show hide permission chat and call, buzz mobile
Issue: https://github.com/mezonai/mezon/issues/9931
Expect when block user or be blocked:
- Disable chat input and show permission chat view.
- Hide direct message header options: call, video call, buzz.
- Hide option call in user short profile.

<img width="389" height="836" alt="image" src="https://github.com/user-attachments/assets/fb8d78ae-90d0-4124-8fe2-18652b4ce8cc" />
<img width="389" height="431" alt="image" src="https://github.com/user-attachments/assets/5c10e10e-313d-4f8b-b2fd-40fdb4efa547" />

