### PR TITLE
251014-WEB/DESKTOP-fix(profile): show save changes modal after invalid display name submission

### DIFF
--- a/libs/components/src/lib/components/SettingProfile/SettingRightUserProfile/index.tsx
+++ b/libs/components/src/lib/components/SettingProfile/SettingRightUserProfile/index.tsx
@@ -74,7 +74,8 @@ const SettingRightUser = ({
 
 	const handleUpdateUser = async () => {
 		if (name || urlImage || valueDisplayName || editAboutUser || dob) {
-			await updateUser(name, urlImage, valueDisplayName.trim(), editAboutUser, dob, userProfile?.logo || '');
+			const result = await updateUser(name, urlImage, valueDisplayName.trim(), editAboutUser, dob, userProfile?.logo || '');
+			if (result === true) handleSaveClose();
 			if (currentClanId && userProfile?.user?.id) {
 				await dispatch(
 					usersClanActions.updateUserDisplayName({
@@ -99,7 +100,6 @@ const SettingRightUser = ({
 		}
 	};
 
-	// Editor Avatar Profile//
 	const [isLoading, setIsLoading] = useState<boolean>(false);
 	const [imageObject, setImageObject] = useState<ImageSourceObject | null>(null);
 	const [imageCropped, setImageCropped] = useState<File | null>(null);
@@ -475,7 +475,6 @@ const SettingRightUser = ({
 							className=" btn-primary btn-primary-hover rounded-lg px-2 text-nowrap py-1  "
 							onClick={() => {
 								handleUpdateUser();
-								handleSaveClose();
 							}}
 							data-e2e={generateE2eId(`user_setting.profile.user_profile.button.save_changes`)}
 						>

--- a/libs/core/src/lib/chat/hooks/useAccount.ts
+++ b/libs/core/src/lib/chat/hooks/useAccount.ts
@@ -1,4 +1,4 @@
-import { ClansEntity, clansActions, useAppDispatch } from '@mezon/store';
+import { clansActions, useAppDispatch } from '@mezon/store';
 import React, { useMemo } from 'react';
 
 export function useAccount() {
@@ -12,12 +12,12 @@ export function useAccount() {
 					avatar_url: logoUrl,
 					display_name: displayName,
 					about_me: aboutMe,
-					dob: dob,
+					dob,
 					noCache,
-					logo: logo
+					logo
 				})
 			);
-			const payload = action.payload as ClansEntity;
+			const payload = action.payload;
 			return payload;
 		},
 		[dispatch]


### PR DESCRIPTION
Task: [Desktop/Website] Modal save changes is not displayed after saving invalid display name
[#9987](https://github.com/mezonai/mezon/issues/9987)

Demo : 

https://github.com/user-attachments/assets/1a3f97ac-5140-4058-959e-553a5bc86652

