### PR TITLE
251014-MOBILE-Fix embed poll message not show checked in other device mobile

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/components/EmbedMessage/EmbedFields/EmbedRadioItem/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/EmbedMessage/EmbedFields/EmbedRadioItem/index.tsx
@@ -1,7 +1,9 @@
 import { useTheme } from '@mezon/mobile-ui';
+import { selectCurrentUserId } from '@mezon/store-mobile';
 import { IMessageRatioOption } from '@mezon/utils';
-import { memo } from 'react';
+import { memo, useEffect } from 'react';
 import { Text, View } from 'react-native';
+import { useSelector } from 'react-redux';
 import MezonRadioButton from '../../../../../../../componentUI/MezonRadioButton';
 import { style } from './styles';
 
@@ -14,6 +16,15 @@ interface EmbedRadioProps {
 export const EmbedRadioButton = memo(({ option, checked, onCheck }: EmbedRadioProps) => {
 	const { themeValue } = useTheme();
 	const styles = style(themeValue);
+	const currentUserId = useSelector(selectCurrentUserId);
+
+	useEffect(() => {
+		if (Array.isArray(option?.extraData) && currentUserId) {
+			if (option?.extraData?.includes(currentUserId)) {
+				onCheck?.();
+			}
+		}
+	}, [option?.extraData, currentUserId]);
 
 	return (
 		<View style={styles.option}>

--- a/libs/utils/src/lib/types/index.ts
+++ b/libs/utils/src/lib/types/index.ts
@@ -311,6 +311,7 @@ export interface IMessageRatioOption {
 	value: string;
 	style?: EButtonMessageStyle;
 	disabled?: boolean;
+	extraData?: string[];
 }
 
 export interface IMessageInput {


### PR DESCRIPTION
251014-MOBILE-Fix embed poll message not show checked in other device mobile
Issue: https://github.com/mezonai/mezon/issues/9687
expect: when user submit options radio, on other device, checked value show or change in mobile.

https://github.com/user-attachments/assets/2fb06d82-6b2f-478e-8dd7-b7c1390a54b5

