### PR TITLE
251016 - WEB/DESKTOP - fix badge desktop null

### DIFF
--- a/apps/chat/src/app/layouts/MainLayout.tsx
+++ b/apps/chat/src/app/layouts/MainLayout.tsx
@@ -69,7 +69,7 @@ const GlobalEventListener = () => {
 
 		if (isElectron()) {
 			if (hasUnreadChannel && !notificationCount) {
-				electronBridge?.setBadgeCount(null);
+				electronBridge?.setBadgeCount(0);
 				return;
 			}
 			electronBridge?.setBadgeCount(notificationCount);


### PR DESCRIPTION
[Desktop/Website] Check the red dot icon app on taskbar
[#9963](https://github.com/mezonai/mezon/issues/9963)