### PR TITLE
251020-WEB/DESKTOP-Fix(context-menu): auto-close menu after mute channel/thread action

### DIFF
--- a/libs/components/src/lib/components/PanelCategory/index.tsx
+++ b/libs/components/src/lib/components/PanelCategory/index.tsx
@@ -270,7 +270,19 @@ const PanelCategory: React.FC<IPanelCategoryProps> = ({
 					className=" bg-theme-contexify text-theme-primary border-theme-primary ml-[3px] py-[6px] px-[8px] w-[200px]"
 				>
 					<div>
-						<ItemPanel dropdown="change here">{t('notificationSettings')}</ItemPanel>
+						<ItemPanel
+							dropdown="change here"
+							subText={
+								defaultCategoryNotificationSetting?.notification_setting_type === ENotificationTypes.DEFAULT ||
+								defaultCategoryNotificationSetting?.notification_setting_type === undefined
+									? t('useClanDefault')
+									: notificationTypesList.find(
+											(type) => type.value === defaultCategoryNotificationSetting?.notification_setting_type
+										)?.label || ''
+							}
+						>
+							{t('notificationSettings')}
+						</ItemPanel>
 					</div>
 				</Menu>
 			</GroupPanels>

--- a/libs/components/src/lib/components/PanelChannel/ItemPanel.tsx
+++ b/libs/components/src/lib/components/PanelChannel/ItemPanel.tsx
@@ -50,7 +50,7 @@ const ItemPanel = ({
 				{type === 'checkbox' && <input type="checkbox" id="accept" checked={checked} defaultChecked={defaultChecked} readOnly />}
 				{type === 'radio' && <input type="radio" className="" name={name} value="change here" checked={checked} readOnly />}
 			</div>
-			{subText && <div className="text-[12px] ml-[8px] -mt-2 mb-1 text-theme-primary">{subText}</div>}
+			{subText && <div className="text-[12px] self-start ml-2 -mt-2 mb-1 text-theme-primary">{subText}</div>}
 		</button>
 	);
 };

--- a/libs/components/src/lib/components/PanelChannel/index.tsx
+++ b/libs/components/src/lib/components/PanelChannel/index.tsx
@@ -423,6 +423,11 @@ const PanelChannel = ({ coords, channel, openSetting, setIsShowPanelChannel, onD
 		menuOpenNoti.current = visible;
 	}, []);
 
+	const onToggleMenuMute = useCallback(() => {
+		muteOrUnMuteChannel(getNotificationChannelSelected?.active === 1 ? 0 : 1);
+		menuOpenMute.current = false;
+	}, []);
+
 	return (
 		<div
 			ref={panelRef}
@@ -461,7 +466,7 @@ const PanelChannel = ({ coords, channel, openSetting, setIsShowPanelChannel, onD
 								onVisibleChange={handleOpenMenuMute}
 							>
 								<div>
-									<ItemPanel children={nameChildren} dropdown="change here" />
+									<ItemPanel children={nameChildren} dropdown="change here" onClick={onToggleMenuMute} />
 								</div>
 							</Menu>
 						) : (
@@ -479,7 +484,16 @@ const PanelChannel = ({ coords, channel, openSetting, setIsShowPanelChannel, onD
 								className="bg-theme-contexify text-theme-primary border-theme-primary ml-[3px] py-[6px] px-[8px] w-[200px]"
 							>
 								<div>
-									<ItemPanel children={t('menu.notification.notification')} dropdown="change here" />
+									<ItemPanel
+										children={t('menu.notification.notification')}
+										dropdown="change here"
+										subText={
+											getNotificationChannelSelected?.notification_setting_type === ENotificationTypes.DEFAULT ||
+											getNotificationChannelSelected?.notification_setting_type === undefined
+												? defaultNotifiName
+												: notiLabelsTranslated[getNotificationChannelSelected?.notification_setting_type || 0]
+										}
+									/>
 								</div>
 							</Menu>
 						)}
@@ -537,7 +551,16 @@ const PanelChannel = ({ coords, channel, openSetting, setIsShowPanelChannel, onD
 								className="bg-theme-contexify text-theme-primary border-theme-primary ml-[3px] py-[6px] px-[8px] w-[200px]"
 							>
 								<div>
-									<ItemPanel children={t('menu.notification.notification')} dropdown="change here" />
+									<ItemPanel
+										children={t('menu.notification.notification')}
+										dropdown="change here"
+										subText={
+											getNotificationChannelSelected?.notification_setting_type === ENotificationTypes.DEFAULT ||
+											getNotificationChannelSelected?.notification_setting_type === undefined
+												? defaultNotifiName
+												: notiLabelsTranslated[getNotificationChannelSelected?.notification_setting_type || 0]
+										}
+									/>
 								</div>
 							</Menu>
 						)}


### PR DESCRIPTION
Task :  [[Desktop/Website] Cannot close context menu after muting channel/thread](https://github.com/mezonai/mezon/issues/9820)

Demo: 

https://github.com/user-attachments/assets/3a852bb3-6a0d-4b46-a9c9-0711ed616cfb

