### PR TITLE
251022-MOBILE-Fix show DM group last send user mobile

### DIFF
--- a/apps/mobile/src/app/screens/messages/DmListItem.tsx
+++ b/apps/mobile/src/app/screens/messages/DmListItem.tsx
@@ -81,7 +81,17 @@ export const DmListItem = React.memo((props: { id: string }) => {
 	}, [isYourAccount, otherMemberList, senderId, t]);
 
 	const getLastMessageContent = (content: string | IExtendedMessage) => {
-		if (!content || (typeof content === 'object' && Object.keys(content).length === 0) || content === '{}') return null;
+		if (!content || (typeof content === 'object' && Object.keys(content).length === 0) || content === '{}') {
+			if (isTypeDMGroup) {
+				return  (
+				<Text style={[styles.defaultText, styles.lastMessage, { color: isUnReadChannel ? themeValue.textStrong : themeValue.textDisabled }]}>
+					{t('directMessage.groupCreated')}
+				</Text>
+			);
+			} else {
+				return null;
+			}
+		};
 		const text = typeof content === 'string' ? safeJSONParse(content)?.t : safeJSONParse(JSON.stringify(content) || '{}')?.t;
 
 		if (!text) {
@@ -210,19 +220,7 @@ export const DmListItem = React.memo((props: { id: string }) => {
 						</Text>
 					) : null}
 				</View>
-
-				{directMessage?.member_count ? (
-					<View style={styles.contentMessage}>
-						<Text
-							style={[styles.defaultText, styles.lastMessage, { color: themeValue.textDisabled, textTransform: 'capitalize' }]}
-							numberOfLines={1}
-						>
-							{`${directMessage?.member_count} ${t(directMessage?.member_count > 1 ? 'members' : 'member', { ns: 'common' })}`}
-						</Text>
-					</View>
-				) : (
-					getLastMessageContent(directMessage?.last_sent_message?.content)
-				)}
+				{getLastMessageContent(directMessage?.last_sent_message?.content)}
 			</View>
 		</TouchableOpacity>
 	);

--- a/libs/store/src/lib/direct/direct.slice.ts
+++ b/libs/store/src/lib/direct/direct.slice.ts
@@ -392,6 +392,7 @@ const mapMessageToConversation = (message: ChannelMessage): DirectEntity => {
 		onlines: [true],
 		active: ActiveDm.OPEN_DM,
 		usernames: [message.username as string],
+		display_names: [message.display_name as string],
 		creator_name: message.username as string,
 		create_time_seconds: message.create_time_seconds,
 		update_time_seconds: message.create_time_seconds
@@ -742,7 +743,10 @@ export const directSlice = createSlice({
 					changes = {
 						...currentData,
 						last_sent_message: data?.last_sent_message,
-						update_time_seconds: data?.update_time_seconds
+						update_time_seconds: data?.update_time_seconds,
+						display_names: data?.display_names,
+						usernames: data?.usernames,
+						user_ids: data?.user_ids,
 					};
 				} else {
 					changes = {

--- a/libs/translations/src/languages/en/message.json
+++ b/libs/translations/src/languages/en/message.json
@@ -57,7 +57,8 @@
 		"shareImageSuccess": "Image shared successfully"
 	},
 	"directMessage": {
-		"you": "You"
+		"you": "You",
+		"groupCreated": "Group is created"
 	},
 	"edited": "(edited)",
 	"newMessage": {

--- a/libs/translations/src/languages/vi/message.json
+++ b/libs/translations/src/languages/vi/message.json
@@ -56,7 +56,8 @@
 		"shareImageSuccess": "Chia sẻ ảnh thành công"
 	},
 	"directMessage": {
-		"you": "Bạn"
+		"you": "Bạn",
+		"groupCreated": "Nhóm đã được tạo"
 	},
 	"edited": "(đã chỉnh sửa)",
 	"newMessage": {


### PR DESCRIPTION
251022-MOBILE-Fix show DM group last send user mobile
Issue: https://github.com/mezonai/mezon/issues/10179
Expect: show user display name for last send user DM group

https://github.com/user-attachments/assets/1ff6dc97-3169-4779-a0f0-c2f0208708ad

