### PR TITLE
251023-MOBILE-Fix hide option copy id in category menu mobile

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/components/CategoryMenu/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/CategoryMenu/index.tsx
@@ -14,7 +14,6 @@ import {
 	useAppDispatch
 } from '@mezon/store-mobile';
 import { EPermission, ICategoryChannel, sleep } from '@mezon/utils';
-import Clipboard from '@react-native-clipboard/clipboard';
 import { useNavigation } from '@react-navigation/native';
 import React, { useCallback, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -202,36 +201,16 @@ export default function CategoryMenu({ category }: ICategoryMenuProps) {
 		}
 	];
 
-	const devMenu: IMezonMenuItemProps[] = [
-		{
-			title: t('menu.devMode.copyServerID'),
-			icon: <MezonIconCDN icon={IconCDN.idIcon} color={themeValue.textStrong} />,
-			onPress: () => {
-				Clipboard.setString(category?.category_id);
-				Toast.show({
-					type: 'info',
-					text1: t('notify.serverIDCopied')
-				});
-			}
-		}
-	];
-
 	const menu: IMezonMenuSectionProps[] = [
 		{
 			items: watchMenu
 		},
-		// {
-		// 	items: inviteMenu
-		// },
 		{
 			items: notificationMenu
 		},
 		{
 			items: organizationMenu
 		},
-		{
-			items: devMenu
-		}
 	];
 
 	return (


### PR DESCRIPTION
251023-MOBILE-Fix hide option copy id in category menu mobile
Issue: https://github.com/mezonai/mezon/issues/10230
<img width="382" height="527" alt="image" src="https://github.com/user-attachments/assets/0bce552f-3c3f-4d18-aa3e-c62daf53fd82" />
