### PR TITLE
251023-MOBILE-Fix change position keyboard bottom sheet not dismiss keyboard mobile

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/PanelKeyboard.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/PanelKeyboard.tsx
@@ -68,6 +68,8 @@ const PanelKeyboard = React.memo((props: IProps) => {
 			setHeightKeyboardShow(0);
 			setTypeKeyboardBottomSheet('text');
 			DeviceEventEmitter.emit(ActionEmitEvent.ON_PANEL_KEYBOARD_BOTTOM_SHEET, { isShow: false, mode: '' });
+		} else if (index === 0 && typeKeyboardBottomSheet !== 'text') {
+			Keyboard.dismiss();
 		}
 	};
 


### PR DESCRIPTION
251023-MOBILE-Fix change position keyboard bottom sheet not dismiss keyboard mobile
Issue: https://github.com/mezonai/mezon/issues/10219
Expect: dismiss keyboard when bottom sheet emoji change position

https://github.com/user-attachments/assets/c153589d-c193-4c27-8b16-f2b2e71a2e12

