### PR TITLE
251027-MOBILE-Fix add friend using both id and user name mobile

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/WelcomeMessage.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/WelcomeMessage.tsx
@@ -109,7 +109,7 @@ const WelcomeMessage = React.memo(({ channelId }: IWelcomeMessage) => {
 	const handleAcceptFriend = async () => {
 		const store = await getStoreAsync();
 		const body = {
-			usernames: [userName],
+			usernames: [],
 			ids: [targetUserId],
 			isAcceptingRequest: true
 		};

--- a/apps/mobile/src/app/screens/home/homedrawer/components/MessageMenu/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/MessageMenu/index.tsx
@@ -132,10 +132,8 @@ function MessageMenu({ messageInfo }: IServerMenuProps) {
 	];
 
 	const handleAddFriend = () => {
-		addFriend({
-			ids: [messageInfo?.user_ids?.[0]],
-			usernames: [messageInfo?.usernames?.[0]]
-		});
+		const body = messageInfo?.user_ids?.[0] ? { ids: [messageInfo?.user_ids?.[0]] } : { usernames: [messageInfo?.usernames?.[0]] };
+		addFriend(body);
 		dismiss();
 	};
 

--- a/apps/mobile/src/app/screens/home/homedrawer/components/UserProfile/component/PendingContent/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/UserProfile/component/PendingContent/index.tsx
@@ -34,7 +34,7 @@ export const PendingContent = memo((props: IPendingContentProps) => {
 
 	const handleAcceptFriend = () => {
 		const body = {
-			usernames: [targetUser?.user?.username],
+			usernames: [],
 			ids: [targetUser?.user?.id],
 			isAcceptingRequest: true
 		};

--- a/apps/mobile/src/app/screens/home/homedrawer/components/UserProfile/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/UserProfile/index.tsx
@@ -381,11 +381,10 @@ const UserProfile = React.memo(
 		];
 
 		const handleAcceptFriend = () => {
-			const body = {
-				usernames: [infoFriend?.user?.username || ''],
+			const body = infoFriend?.user?.id ?  {
 				ids: [infoFriend?.user?.id || ''],
 				isAcceptingRequest: true
-			};
+			} : {usernames: [infoFriend?.user?.username || ''], isAcceptingRequest: true};
 			dispatch(friendsActions.sendRequestAddFriend(body));
 		};
 


### PR DESCRIPTION
251027-MOBILE-Fix add friend using both id and user name mobile
Issue: https://github.com/mezonai/mezon/issues/10314