### PR TITLE
251028-MOBILE-Fix copy image save to media storage android

### DIFF
--- a/apps/mobile/android/app/src/main/res/xml/file_paths.xml
+++ b/apps/mobile/android/app/src/main/res/xml/file_paths.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths xmlns:android="http://schemas.android.com/apk/res/android">
-    <cache-path name="image_cache" path="." />
+    <cache-path name="clipboard_images" path="clipboard_images/" />
 </paths>


### PR DESCRIPTION
251028-MOBILE-Fix copy image save to media storage android
Issue: https://github.com/mezonai/mezon/issues/10319
Expect: not save cache image clipboard to media storage android.