### PR TITLE
251028-WEB/DESKTOP-Fix(profile/ list member):  Invalid Date displayed for 'Member Since' in My Profile for new user in clan

### DIFF
--- a/libs/core/src/lib/chat/contexts/ChatContext.tsx
+++ b/libs/core/src/lib/chat/contexts/ChatContext.tsx
@@ -1057,8 +1057,10 @@ const ChatContextProvider: React.FC<ChatContextProviderProps> = ({ children }) =
 		const store = await getStoreAsync();
 
 		const clanMemberStore = selectClanMemberByClanId(store.getState() as unknown as RootState, userJoinClan.clan_id);
+
 		if (userJoinClan?.user && clanMemberStore) {
-			const createTime = userJoinClan.user.create_time_second ? new Date(userJoinClan.user.create_time_second * 1000).toISOString() : undefined;
+			const create_time = new Date(userJoinClan.user.create_time_second * 1000).toISOString();
+			const joinTime = new Date().toISOString();
 			dispatch(
 				usersClanActions.add({
 					user: {
@@ -1072,7 +1074,8 @@ const ChatContextProvider: React.FC<ChatContextProviderProps> = ({ children }) =
 							display_name: userJoinClan.user.display_name,
 							metadata: userJoinClan.user.custom_status,
 							username: userJoinClan.user.username,
-							create_time: createTime
+							create_time,
+							join_time: joinTime
 						}
 					},
 					clanId: userJoinClan.clan_id

--- a/libs/core/src/lib/chat/contexts/ChatContext.tsx
+++ b/libs/core/src/lib/chat/contexts/ChatContext.tsx
@@ -1059,7 +1059,7 @@ const ChatContextProvider: React.FC<ChatContextProviderProps> = ({ children }) =
 		const clanMemberStore = selectClanMemberByClanId(store.getState() as unknown as RootState, userJoinClan.clan_id);
 
 		if (userJoinClan?.user && clanMemberStore) {
-			const create_time = new Date(userJoinClan.user.create_time_second * 1000).toISOString();
+			const accountCreateTime = new Date(userJoinClan?.user?.create_time_second * 1000).toISOString();
 			const joinTime = new Date().toISOString();
 			dispatch(
 				usersClanActions.add({
@@ -1074,7 +1074,7 @@ const ChatContextProvider: React.FC<ChatContextProviderProps> = ({ children }) =
 							display_name: userJoinClan.user.display_name,
 							metadata: userJoinClan.user.custom_status,
 							username: userJoinClan.user.username,
-							create_time,
+							create_time: accountCreateTime,
 							join_time: joinTime
 						}
 					},


### PR DESCRIPTION
Task  : [Desktop/Website] Invalid Date displayed for 'Member Since' in My Profile for new user in clan
[#10211](https://github.com/mezonai/mezon/issues/10211)

Demo : 

https://github.com/user-attachments/assets/365a9481-eebe-479f-bf70-320d51c5a720

