### PR TITLE
251105-MOBILE-Fix notification jump between two topic tablet

### DIFF
--- a/apps/mobile/src/app/components/StreamBanner/index.tsx
+++ b/apps/mobile/src/app/components/StreamBanner/index.tsx
@@ -10,6 +10,7 @@ import MezonImagePicker from '../../componentUI/MezonImagePicker';
 import { IconCDN } from '../../constants/icon_cdn';
 import type { APP_SCREEN, MenuChannelScreenProps } from '../../navigation/ScreenTypes';
 import { width } from '../ClanSettings/Emoji';
+import StatusBarHeight from '../StatusBarHeight/StatusBarHeight';
 import { style } from './styles';
 
 type ChannelSettingsScreen = typeof APP_SCREEN.MENU_CHANNEL.STREAM_BANNER;
@@ -27,7 +28,7 @@ const StreamBannerScreen = ({ navigation, route }: MenuChannelScreenProps<Channe
 	}, [channel?.channel_avatar]);
 
 	const isBannerChanged = useMemo(() => {
-		return !!channel?.channel_avatar && banner !== channel?.channel_avatar;
+		return !!(banner || channel?.channel_avatar) && banner !== channel?.channel_avatar;
 	}, [banner, channel?.channel_avatar]);
 	const handleLoad = async (url: string) => {
 		if (url) {
@@ -71,6 +72,7 @@ const StreamBannerScreen = ({ navigation, route }: MenuChannelScreenProps<Channe
 
 	return (
 		<View style={styles.container}>
+			<StatusBarHeight />
 			<View style={styles.header}>
 				<Pressable style={styles.backButton} onPress={navigation.goBack}>
 					<MezonIconCDN icon={IconCDN.arrowLargeLeftIcon} height={size.s_20} width={size.s_20} color={themeValue.textStrong} />

--- a/apps/mobile/src/app/utils/pushNotificationHelpers.ts
+++ b/apps/mobile/src/app/utils/pushNotificationHelpers.ts
@@ -583,7 +583,7 @@ export const navigateToNotification = async (store: any, notification: any, navi
 
 const handleOpenTopicDiscustion = async (store: any, topicId: string, channelId: string, navigation: any) => {
 	const promises = [];
-	await sleep(100);
+	await sleep(300);
 	promises.push(store.dispatch(topicsActions.setCurrentTopicInitMessage(null)));
 	promises.push(store.dispatch(topicsActions.setCurrentTopicId(topicId || '')));
 	promises.push(store.dispatch(topicsActions.setIsShowCreateTopic(true)));


### PR DESCRIPTION
251105-MOBILE-Fix notification jump between two topic tablet.
Issue: https://github.com/mezonai/mezon/issues/10378
Expect: list message in topic when jump from other topic and message not send to parent channel or thread.