### PR TITLE
251106-WEB-fix: show correct BOT profile in topbar when chatting with BOT

### DIFF
--- a/apps/chat/src/app/pages/directMessage/DMPage/index.tsx
+++ b/apps/chat/src/app/pages/directMessage/DMPage/index.tsx
@@ -244,10 +244,10 @@ const DirectMessage = () => {
 									channelId={directId || currentDirectId || ''}
 									isPrivate={currentDmGroup?.channel_private}
 									channelLabel={currentDmGroup?.channel_label}
-									username={isDmChannel ? currentDmGroup?.usernames?.toString() : undefined}
+									username={isDmChannel ? currentDmGroup?.usernames?.at(-1) : undefined}
 									type={isDmChannel ? ChannelType.CHANNEL_TYPE_DM : ChannelType.CHANNEL_TYPE_GROUP}
 									mode={isDmChannel ? ChannelStreamMode.STREAM_MODE_DM : ChannelStreamMode.STREAM_MODE_GROUP}
-									avatarDM={isDmChannel ? currentDmGroup?.avatars?.at(0) : 'assets/images/avatar-group.png'}
+									avatarDM={isDmChannel ? currentDmGroup?.avatars?.at(-1) : 'assets/images/avatar-group.png'}
 								/>
 							}
 						</div>
@@ -357,7 +357,7 @@ const DirectMessage = () => {
 								avatar={
 									Number(type) === ChannelType.CHANNEL_TYPE_GROUP
 										? currentDmGroup?.channel_avatar?.[0]
-										: currentDmGroup?.avatars?.[0]
+										: currentDmGroup?.avatars?.at(-1)
 								}
 								isDM={true}
 							/>

--- a/libs/components/src/lib/components/ChannelTopbar/index.tsx
+++ b/libs/components/src/lib/components/ChannelTopbar/index.tsx
@@ -154,7 +154,7 @@ const TopBarChannelText = memo(() => {
 		}
 
 		if (currentDmGroup?.type === ChannelType.CHANNEL_TYPE_DM && currentDmGroup?.user_ids) {
-			return currentDmGroup.avatars?.[0];
+			return currentDmGroup.avatars?.at(-1) || undefined;
 		}
 	}, [currentDmGroup, userProfile?.user?.id]);
 

--- a/libs/components/src/lib/components/DmList/DMListItem/index.tsx
+++ b/libs/components/src/lib/components/DmList/DMListItem/index.tsx
@@ -97,7 +97,7 @@ function DMListItem({ id, currentDmGroupId, joinToChatAndNavigate, navigateToFri
 			data-e2e={generateE2eId(`chat.direct_message.chat_list`)}
 		>
 			<DmItemProfile
-				avatar={isTypeDMGroup ? directMessage?.channel_avatar || 'assets/images/avatar-group.png' : (directMessage?.avatars?.at(0) ?? '')}
+				avatar={isTypeDMGroup ? directMessage?.channel_avatar || 'assets/images/avatar-group.png' : (directMessage?.avatars?.at(-1) ?? '')}
 				name={directMessage?.channel_label || ''}
 				number={directMessage?.member_count || 0}
 				isTypeDMGroup={isTypeDMGroup}


### PR DESCRIPTION
Task : [Website] Display incorrect avatar by chatting with BOT on top.mezon.ai
[#10466](https://github.com/mezonai/mezon/issues/10466)

Demo : 

https://github.com/user-attachments/assets/f7b7faea-c402-4204-8d9d-759690a1e3fb

