### PR TITLE
251106-WEB/DESKTOP-fix(reply): preserve reply context when initializing message topic

### DIFF
--- a/libs/components/src/lib/components/MessageWithUser/index.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/index.tsx
@@ -131,8 +131,10 @@ function MessageWithUser({
 		return includesUser || includesRole;
 	})();
 
-	const checkMessageHasReply = !!message?.references?.length && message?.code === TypeMessage.Chat;
+	const checkMessageHasReply = !!message?.references?.length && !!message?.references?.[0]?.message_ref_id;
 	const isEphemeralMessage = message?.code === TypeMessage.Ephemeral;
+
+	const shouldRenderMessageReply = checkMessageHasReply && !isEphemeralMessage;
 
 	const handleOpenShortUser = useCallback(
 		(e: React.MouseEvent<HTMLImageElement, MouseEvent>, userId: string, isClickOnReply = false) => {
@@ -216,7 +218,11 @@ function MessageWithUser({
 						},
 						{
 							'bg-highlight-no-hover':
-								(hasIncludeMention || checkReplied) && !messageReplyHighlight && !checkMessageTargetToMoved && !isEphemeralMessage
+								(hasIncludeMention || checkReplied) &&
+								!messageReplyHighlight &&
+								!checkMessageTargetToMoved &&
+								!isEphemeralMessage &&
+								!isTopic
 						},
 						{ '!bg-bgMessageReplyHighline': messageReplyHighlight },
 						{ 'bg-highlight': isHighlight },
@@ -234,7 +240,7 @@ function MessageWithUser({
 					create_time={message.create_time}
 					showMessageHead={showMessageHead}
 				>
-					{checkMessageHasReply && !isEphemeralMessage && (
+					{shouldRenderMessageReply && (
 						<MessageReply
 							message={message}
 							mode={mode}


### PR DESCRIPTION
Task : [Desktop/Website] Lost replying message on init message topic
[#10465](https://github.com/mezonai/mezon/issues/10465)
Demo : 

https://github.com/user-attachments/assets/274ecb99-8836-4c89-9cf4-96dd7e793d3f

