### PR TITLE
251107-WEB/DESKTOP-fix(roles): sync displayed color with selected role on change role

### DIFF
--- a/libs/components/src/lib/components/ClanSettings/SettingRoleManagement/SettingDisplayRole/RoleColor/index.tsx
+++ b/libs/components/src/lib/components/ClanSettings/SettingRoleManagement/SettingDisplayRole/RoleColor/index.tsx
@@ -31,7 +31,9 @@ const RoleColor = () => {
 		} else {
 			setIsCustoms(false);
 		}
-	}, [selectedColor]);
+
+		setSelectedColor(colorRole || '');
+	}, [selectedColor, colorRole]);
 
 	return (
 		<div className="w-full flex flex-col text-[15px] dark:text-textSecondary text-textSecondary800 pr-5">


### PR DESCRIPTION
Task : [Desktop/Website] Role color is not sync when switching roles
[#10543](https://github.com/mezonai/mezon/issues/10543)


Demo : 

https://github.com/user-attachments/assets/fdc649d8-9dec-4b3f-9d85-e539a02805b6

 