### PR TITLE
251110-WEB/DESKTOP-Fix: Prevent removed users from seeing private channels in search

### DIFF
--- a/libs/components/src/lib/components/ChannelSetting/Component/Modal/addMemRoleModal.tsx
+++ b/libs/components/src/lib/components/ChannelSetting/Component/Modal/addMemRoleModal.tsx
@@ -54,19 +54,25 @@ export const AddMemRole: React.FC<AddMemRoleProps> = ({
 		[rolesChannel]
 	);
 	const listRolesNotAddChannel = useMemo(
-		() => rolesClan.filter((role) => !rolesAddChannel.map((roleAddChannel) => roleAddChannel.id).includes(role.id) && role.creator_id !== '0'),
-		[rolesClan, rolesAddChannel]
+		() =>
+			rolesClan.filter(
+				(role) =>
+					!rolesAddChannel.map((roleAddChannel) => roleAddChannel.id).includes(role.id) &&
+					role.creator_id !== '0' &&
+					!selectedRoleIds.includes(role.id)
+			),
+		[rolesClan, rolesAddChannel, selectedRoleIds]
 	);
 
 	const usersClan = useSelector(selectAllUserClans);
 	const rawMembers = useSelector(selectAllUserChannel(channel.channel_id || ''));
 	const listUserInvite = useMemo(() => {
 		if (channel.channel_private !== 1) {
-			return usersClan.filter((user) => user.id !== userProfile?.user?.id);
+			return usersClan.filter((user) => user.id !== userProfile?.user?.id && !selectedUserIds.includes(user.id));
 		}
 		const memberIds = rawMembers.map((member) => member.user?.id || '');
-		return usersClan.filter((user) => !memberIds.some((userId) => userId === user.id));
-	}, [usersClan, rawMembers, channel.channel_private, userProfile?.user?.id]);
+		return usersClan.filter((user) => !memberIds.some((userId) => userId === user.id) && !selectedUserIds.includes(user.id));
+	}, [usersClan, rawMembers, channel.channel_private, userProfile?.user?.id, selectedUserIds]);
 
 	const listMembersNotInChannel = useMemo(
 		() =>
@@ -148,7 +154,10 @@ export const AddMemRole: React.FC<AddMemRoleProps> = ({
 					const clanName = member?.clanNick?.toLowerCase();
 					const displayName = member?.display_name?.toLowerCase();
 					const username = member?.username?.toLowerCase();
-					return clanName?.includes(searchValue) || displayName?.includes(searchValue) || username?.includes(searchValue);
+					return (
+						(clanName?.includes(searchValue) || displayName?.includes(searchValue) || username?.includes(searchValue)) &&
+						!selectedUserIds.includes(member?.id || '')
+					);
 				});
 				setFilterItem({
 					listMembersNotInChannel: filteredMembers,
@@ -160,17 +169,23 @@ export const AddMemRole: React.FC<AddMemRoleProps> = ({
 				const clanName = member?.clanNick?.toLowerCase();
 				const displayName = member?.display_name?.toLowerCase();
 				const username = member?.username?.toLowerCase();
-				return clanName?.includes(inputData) || displayName?.includes(inputData) || username?.includes(inputData);
+				return (
+					(clanName?.includes(inputData) || displayName?.includes(inputData) || username?.includes(inputData)) &&
+					!selectedUserIds.includes(member?.id || '')
+				);
 			});
 			const filteredRoles = listRolesNotAddChannel.filter(
-				(item) => item?.title?.toLowerCase().trim().includes(inputData.toLowerCase().trim()) && item?.creator_id !== '0'
+				(item) =>
+					item?.title?.toLowerCase().trim().includes(inputData.toLowerCase().trim()) &&
+					item?.creator_id !== '0' &&
+					!selectedRoleIds.includes(item.id)
 			);
 			setFilterItem({
 				listMembersNotInChannel: filteredMembers,
 				listRolesNotAddChannel: filteredRoles
 			});
 		},
-		[listRolesNotAddChannel, listMembersNotInChannel]
+		[listRolesNotAddChannel, listMembersNotInChannel, selectedUserIds, selectedRoleIds]
 	);
 
 	const debouncedSetValueSearch = useDebouncedCallback((value) => {
@@ -179,7 +194,7 @@ export const AddMemRole: React.FC<AddMemRoleProps> = ({
 
 	useEffect(() => {
 		debouncedSetValueSearch(valueSearch);
-	}, [valueSearch]);
+	}, [valueSearch, debouncedSetValueSearch]);
 
 	const modalRef = useRef<HTMLDivElement>(null);
 	useEscapeKeyClose(modalRef, onClose);

--- a/libs/components/src/lib/components/ChannelSetting/Component/PermissionsChannel/index.tsx
+++ b/libs/components/src/lib/components/ChannelSetting/Component/PermissionsChannel/index.tsx
@@ -87,8 +87,6 @@ const PermissionsChannel = (props: PermissionsChannelProps) => {
 
 	const closeAddMemRoleModal = useCallback(() => {
 		setShowAddMemRole(false);
-		setSelectedRoleIds([]);
-		setSelectedUserIds([]);
 		setTimeout(() => {
 			openModalAdd.current = false;
 			parentRef?.current?.focus();
@@ -149,14 +147,22 @@ const PermissionsChannel = (props: PermissionsChannelProps) => {
 								<div className="py-4">
 									<p className="uppercase font-bold text-xs pb-4 text-theme-primary">{t('channelPermission.roles')}</p>
 									<div data-e2e={generateE2eId('channel_setting_page.permissions.section.member_role_management.role_list')}>
-										<ListRolePermission channel={channel} selectedRoleIds={selectedRoleIds} />
+										<ListRolePermission
+											channel={channel}
+											selectedRoleIds={selectedRoleIds}
+											setSelectedRoleIds={setSelectedRoleIds}
+										/>
 									</div>
 								</div>
 								<hr className="border-t border-solid dark:border-borderDefault border-bgModifierHoverLight" />
 								<div className="py-4">
 									<p className="uppercase font-bold text-xs pb-4 text-theme-primary">{t('channelPermission.members')}</p>
 									<div data-e2e={generateE2eId('channel_setting_page.permissions.section.member_role_management.member_list')}>
-										<ListMemberPermission channel={channel} selectedUserIds={selectedUserIds} />
+										<ListMemberPermission
+											channel={channel}
+											selectedUserIds={selectedUserIds}
+											setSelectedUserIds={setSelectedUserIds}
+										/>
 									</div>
 								</div>
 							</div>

--- a/libs/components/src/lib/components/ChannelSetting/Component/PermissionsChannel/listRolePermission.tsx
+++ b/libs/components/src/lib/components/ChannelSetting/Component/PermissionsChannel/listRolePermission.tsx
@@ -8,10 +8,11 @@ import { useSelector } from 'react-redux';
 type ListRolePermissionProps = {
 	channel: IChannel;
 	selectedRoleIds: string[];
+	setSelectedRoleIds?: (roleIds: string[]) => void;
 };
 
 const ListRolePermission = (props: ListRolePermissionProps) => {
-	const { channel } = props;
+	const { channel, selectedRoleIds, setSelectedRoleIds } = props;
 	const { t } = useTranslation('common');
 	const dispatch = useAppDispatch();
 	const RolesChannel = useSelector(selectRolesByChannelId(channel.id));
@@ -29,6 +30,10 @@ const ListRolePermission = (props: ListRolePermissionProps) => {
 	}, [RolesChannel, props.selectedRoleIds]);
 
 	const deleteRole = async (roleId: string) => {
+		if (setSelectedRoleIds && selectedRoleIds) {
+			const newSelectedRoleIds = selectedRoleIds.filter((id) => id !== roleId);
+			setSelectedRoleIds(newSelectedRoleIds);
+		}
 		const body = {
 			channelId: channel.id,
 			clanId: currentClanId || '',

--- a/libs/core/src/lib/chat/contexts/ChatContext.tsx
+++ b/libs/core/src/lib/chat/contexts/ChatContext.tsx
@@ -825,6 +825,14 @@ const ChatContextProvider: React.FC<ChatContextProviderProps> = ({ children }) =
 							channelId: user.channel_id
 						})
 					);
+					dispatch(
+						channelsActions.removePreviousChannel({
+							clanId: user.clan_id,
+							channelId: user.channel_id
+						})
+					);
+
+					dispatch(listChannelsByUserActions.remove(user.channel_id));
 				} else {
 					if (user.channel_type === ChannelType.CHANNEL_TYPE_GROUP) {
 						dispatch(directActions.removeGroupMember({ userId: userID, currentUserId: userId as string, channelId: user.channel_id }));

--- a/libs/store/src/lib/channels/channels.slice.ts
+++ b/libs/store/src/lib/channels/channels.slice.ts
@@ -1253,6 +1253,15 @@ export const channelsSlice = createSlice({
 			state.byClans[clanId].previousChannels = [{ clanId, channelId }, ...(state.byClans[clanId].previousChannels || []).slice(0, 4)];
 		},
 
+		removePreviousChannel: (state: ChannelsState, action: PayloadAction<{ clanId: string; channelId: string }>) => {
+			const { clanId, channelId } = action.payload;
+			if (!state.byClans[clanId]?.previousChannels) return;
+
+			state.byClans[clanId].previousChannels = state.byClans[clanId].previousChannels.filter(
+				(prevChannel) => prevChannel.channelId !== channelId
+			);
+		},
+
 		updateChannelBadgeCount: (
 			state: ChannelsState,
 			action: PayloadAction<{ clanId: string; channelId: string; count: number; isReset?: boolean }>

--- a/libs/translations/src/languages/en/setting.json
+++ b/libs/translations/src/languages/en/setting.json
@@ -35,7 +35,7 @@
 	},
 	"activity": {
 		"title": "Show my activity",
-		"description": "Show your current coding, music, or gaming activities to friends. This lets them see what you're up to and makes it easier to connect."
+		"description": "Show your current activities to friends. This lets them see what you're up to and makes it easier to connect."
 	},
 	"supportSettings": {
 		"title": "Support",

--- a/libs/translations/src/languages/vi/setting.json
+++ b/libs/translations/src/languages/vi/setting.json
@@ -35,7 +35,7 @@
 	},
 	"activity": {
 		"title": "Hiển thị hoạt động của tôi",
-		"description": "Chia sẻ những hoạt động lập trình, âm nhạc, hoặc trò chơi hiện tại của bạn với bạn bè. Điều này giúp họ biết bạn đang làm gì và dễ dàng kết nối hơn!"
+		"description": "Chia sẻ những hoạt động hiện tại của bạn với bạn bè. Điều này giúp họ biết bạn đang làm gì và dễ dàng kết nối hơn!"
 	},
 	"supportSettings": {
 		"title": "Hỗ trợ",


### PR DESCRIPTION
Task : [Desktop/Website] Still search the private channel even though user has been removed from channel
[#10496](https://github.com/mezonai/mezon/issues/10496)

Demo : 

https://github.com/user-attachments/assets/5eeb3d0d-f975-4ee8-bcf4-e1815656362c


add task : #10575 

demo : 

https://github.com/user-attachments/assets/1792c958-9811-4760-87f1-1a66ba8e8581



