### PR TITLE
251110-MOBILE-Fix navigate deeplink install bot when background mobile

### DIFF
--- a/apps/mobile/src/app/navigation/Authentication/AuthenticationLoader.tsx
+++ b/apps/mobile/src/app/navigation/Authentication/AuthenticationLoader.tsx
@@ -169,7 +169,7 @@ export const AuthenticationLoader = () => {
 					data: dataParam || undefined
 				});
 			}
-		} else if (path?.includes?.('/bot/install/')) {
+		} else if (path?.includes?.('bot/install/')) {
 			const applicationId = path?.match?.(/bot\/install\/(\d+)/)?.[1];
 			if (applicationId) {
 				navigation.navigate(APP_SCREEN.INSTALL_CLAN, {


### PR DESCRIPTION
251110-MOBILE-Fix navigate deeplink install bot when background mobile
Issue: https://github.com/mezonai/mezon/issues/10003

https://github.com/user-attachments/assets/6e51cc00-960c-4573-8f45-130a0b2a0929

