### PR TITLE
251111-WEB/DESKTOP-fix user display order DM group

### DIFF
--- a/libs/components/src/lib/components/DmList/CreateMessageGroup/index.tsx
+++ b/libs/components/src/lib/components/DmList/CreateMessageGroup/index.tsx
@@ -97,11 +97,16 @@ const CreateMessageGroup = ({ onClose, classNames, currentDM, rootRef }: CreateM
 		setIsCreating(true);
 		try {
 			const listGroupDM = selectedFriends;
-			const userNameGroup: string[] = [userCurrent?.user?.display_name || userCurrent?.user?.username || ''];
+
+			const userNameGroup: string[] = [];
 			const avatarGroup: string[] = [userCurrent?.user?.avatar_url || ''];
+			dataSelectFriends.current?.map((friend) => {
+				userNameGroup.push(friend.user?.display_name || friend.user?.username || '');
+				avatarGroup.push(friend.user?.avatar_url || '');
+			});
 			if (currentDM?.type === ChannelType.CHANNEL_TYPE_DM) {
 				listGroupDM.push(currentDM.user_ids?.at(0) as string);
-				userNameGroup.push(currentDM.usernames?.at(0) as string);
+				userNameGroup.push(currentDM.display_names?.at(0) as string);
 				avatarGroup.push(currentDM.channel_avatar?.at(0) as string);
 			}
 			const bodyCreateDmGroup: ApiCreateChannelDescRequest = {
@@ -115,10 +120,9 @@ const CreateMessageGroup = ({ onClose, classNames, currentDM, rootRef }: CreateM
 				return;
 			}
 
-			dataSelectFriends.current?.map((friend) => {
-				userNameGroup.push(friend.user?.display_name || friend.user?.username || '');
-				avatarGroup.push(friend.user?.avatar_url || '');
-			});
+			if (currentDM?.user_ids?.[0] !== userCurrent?.user?.id) {
+				userNameGroup.push(userCurrent?.user?.display_name || userCurrent?.user?.username || '');
+			}
 
 			const response = await dispatch(
 				directActions.createNewDirectMessage({ body: bodyCreateDmGroup, username: userNameGroup, avatar: avatarGroup })

--- a/libs/components/src/lib/components/ModalConfirm/index.tsx
+++ b/libs/components/src/lib/components/ModalConfirm/index.tsx
@@ -1,7 +1,7 @@
 import { useEscapeKeyClose } from '@mezon/core';
 import { generateE2eId } from '@mezon/utils';
 import { useEffect, useRef } from 'react';
-import { Trans, useTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 
 interface ModalConfirmProps {
 	handleCancel: () => void;
@@ -58,18 +58,7 @@ const ModalConfirm = ({
 						{customModalName ? customModalName : modalName}
 					</div>
 					<div className=" pb-[20px] text-theme-primary">
-						{customTitle !== '' ? (
-							<span>{customTitle}</span>
-						) : (
-							<span>
-								<Trans
-									i18nKey="common:areYouSureYouWantTo"
-									values={{ action: defaultTitle, name: modalName }}
-									components={[<b className="font-semibold" key="0" />]}
-								/>
-								{defaultMessage && ` ${defaultMessage}`}
-							</span>
-						)}
+						{customTitle !== '' ? <span>{customTitle}</span> : <span>{defaultMessage && ` ${defaultMessage}`}</span>}
 					</div>
 				</div>
 				<div className="bg-theme-setting-nav  flex justify-end items-center gap-4 p-[16px] text-[14px] font-medium rounded-b-md">


### PR DESCRIPTION
Task : [Desktop/Website] Incorrect group name displayed immediately after creation
[#10456](https://github.com/mezonai/mezon/issues/10456)

Demo : 


https://github.com/user-attachments/assets/6eee703d-c16e-48ea-95f5-74cb6cff13b9

