### PR TITLE
251112-MOBILE-Fix command name in the delete modal quick action incorrectly mobile

### DIFF
--- a/apps/mobile/src/app/screens/channelPermissionSetting/QuickAction/index.tsx
+++ b/apps/mobile/src/app/screens/channelPermissionSetting/QuickAction/index.tsx
@@ -1,5 +1,5 @@
 import { ActionEmitEvent } from '@mezon/mobile-components';
-import { size, useTheme, verticalScale } from '@mezon/mobile-ui';
+import { size, useTheme } from '@mezon/mobile-ui';
 import {
 	deleteQuickMenuAccess,
 	listQuickMenuAccess,
@@ -136,7 +136,7 @@ export function QuickAction({ navigation, route }) {
 						title={t('quickAction.deleteModal')}
 						confirmText={t('confirm.delete.confirmText')}
 						content={t('quickAction.deleteTitle', {
-							key: item.menu_name
+							command: item.menu_name
 						})}
 					/>
 				)

--- a/apps/mobile/src/app/utils/pushNotificationHelpers.ts
+++ b/apps/mobile/src/app/utils/pushNotificationHelpers.ts
@@ -583,7 +583,7 @@ export const navigateToNotification = async (store: any, notification: any, navi
 
 const handleOpenTopicDiscustion = async (store: any, topicId: string, channelId: string, navigation: any) => {
 	const promises = [];
-	await sleep(300);
+	await sleep(500);
 	promises.push(store.dispatch(topicsActions.setCurrentTopicInitMessage(null)));
 	promises.push(store.dispatch(topicsActions.setCurrentTopicId(topicId || '')));
 	promises.push(store.dispatch(topicsActions.setIsShowCreateTopic(true)));


### PR DESCRIPTION
251112-MOBILE-Fix command name in the delete modal quick action incorrectly mobile
Issue: https://github.com/mezonai/mezon/issues/10595
<img width="440" height="970" alt="image" src="https://github.com/user-attachments/assets/f85da555-6376-48aa-a58d-4afcc2b76c64" />
