### PR TITLE
[HOMEPAGE]: add macos Intel download link on homepage

### DIFF
--- a/apps/chat/src/app/pages/homepage/mezonpage/sections/HeroSection.tsx
+++ b/apps/chat/src/app/pages/homepage/mezonpage/sections/HeroSection.tsx
@@ -21,6 +21,7 @@ export const HeroSection = ({ homeRef, isVisible }: HeroSectionProps) => {
 	const downloadLinks = {
 		windows: `${process.env.NX_BASE_IMG_URL}/release/mezon-${version}-win-x64.exe`,
 		macos: `${process.env.NX_BASE_IMG_URL}/release/mezon-${version}-mac-arm64.dmg`,
+		macosIntel: `${process.env.NX_BASE_IMG_URL}/release/mezon-${version}-mac-x64.dmg`,
 		linux: `${process.env.NX_BASE_IMG_URL}/release/mezon-${version}-linux-amd64.deb`
 	};
 
@@ -90,7 +91,14 @@ export const HeroSection = ({ homeRef, isVisible }: HeroSectionProps) => {
 										className="flex items-center gap-3 px-4 py-3 rounded-xl hover:bg-gradient-to-r hover:from-pink-50 hover:to-purple-50 transition-all border border-gray-200 hover:border-purple-300  text-purple-500 hover:text-pink-500 "
 									>
 										<Icons.Apple className="w-6 h-6 " />
-										<span className="font-medium text-gray-800 group-hover:text-purple-600">macOS</span>
+										<span className="font-medium text-gray-800 group-hover:text-purple-600">macOS (Apple)</span>
+									</a>
+									<a
+										href={downloadLinks.macosIntel}
+										className="flex items-center gap-3 px-4 py-3 rounded-xl hover:bg-gradient-to-r hover:from-pink-50 hover:to-purple-50 transition-all border border-gray-200 hover:border-purple-300  text-purple-500 hover:text-pink-500 "
+									>
+										<Icons.Apple className="w-6 h-6 " />
+										<span className="font-medium text-gray-800 group-hover:text-purple-600">macOS (Intel)</span>
 									</a>
 									<a
 										href={downloadLinks.linux}


### PR DESCRIPTION
<img width="432" height="458" alt="image" src="https://github.com/user-attachments/assets/1914fa85-007b-400c-83d6-5265e861cb8d" />
