### PR TITLE
251117-Feat: support facebook video embed for message content

### DIFF
--- a/libs/components/src/lib/components/MarkdownFormatText/MarkdownContent.tsx
+++ b/libs/components/src/lib/components/MarkdownFormatText/MarkdownContent.tsx
@@ -2,10 +2,13 @@ import { channelsActions, getStore, inviteActions, selectAppChannelById, selectT
 import { Icons } from '@mezon/ui';
 import {
 	EBacktickType,
+	getFacebookEmbedSize,
+	getFacebookEmbedUrl,
 	getTikTokEmbedSize,
 	getTikTokEmbedUrl,
 	getYouTubeEmbedSize,
 	getYouTubeEmbedUrl,
+	isFacebookLink,
 	isTikTokLink,
 	isYouTubeLink
 } from '@mezon/utils';
@@ -274,6 +277,9 @@ export const MarkdownContent: React.FC<MarkdownContentOpt> = ({
 			{!isReply && isLink && content && isYouTubeLink(content) && (
 				<SocialEmbed url={content} platform="youtube" isSearchMessage={isSearchMessage} isInPinMsg={isInPinMsg} />
 			)}
+			{!isReply && isLink && content && isFacebookLink(content) && (
+				<SocialEmbed url={content} platform="facebook" isSearchMessage={isSearchMessage} isInPinMsg={isInPinMsg} />
+			)}
 			{!isReply && isLink && content && isTikTokLink(content) && <SocialEmbed url={content} platform="tiktok" isInPinMsg={isInPinMsg} />}
 			{!isLink && isBacktick && (typeOfBacktick === EBacktickType.SINGLE || typeOfBacktick === EBacktickType.CODE) ? (
 				<SingleBacktick contentBacktick={content} isInPinMsg={isInPinMsg} isLightMode={isLightMode} posInNotification={posInNotification} />
@@ -359,7 +365,7 @@ const TripleBackticks: React.FC<BacktickOpt> = ({ contentBacktick, isLightMode: 
 	);
 };
 
-type SocialPlatform = 'youtube' | 'tiktok';
+type SocialPlatform = 'youtube' | 'tiktok' | 'facebook';
 
 const SocialEmbed: React.FC<{ url: string; platform: SocialPlatform; isSearchMessage?: boolean; isInPinMsg?: boolean }> = ({
 	url,
@@ -382,6 +388,13 @@ const SocialEmbed: React.FC<{ url: string; platform: SocialPlatform; isSearchMes
 					size: getTikTokEmbedSize(),
 					borderColor: '#ff0050',
 					allowAttributes: 'fullscreen; autoplay; clipboard-write; encrypted-media; picture-in-picture'
+				};
+			case 'facebook':
+				return {
+					embedUrl: getFacebookEmbedUrl(url),
+					size: getFacebookEmbedSize(),
+					borderColor: '#1877f2',
+					allowAttributes: 'autoplay; clipboard-write; encrypted-media; picture-in-picture; web-share'
 				};
 			default:
 				return null;

--- a/libs/utils/src/lib/utils/embed-social.ts
+++ b/libs/utils/src/lib/utils/embed-social.ts
@@ -1,0 +1,53 @@
+export function isYouTubeLink(url: string): boolean {
+	return /(?:youtube\.com\/(?:watch\?v=|embed\/|v\/|e\/|shorts\/)|youtu\.be\/)/.test(url);
+}
+
+export function getYouTubeEmbedUrl(url: string): string {
+	// check xss
+	const match = url.match(/(?:youtube\.com\/(?:watch\?v=|v\/|e\/|embed\/|shorts\/)|youtu\.be\/)([a-zA-Z0-9_-]{11})/);
+	return match ? `https://www.youtube.com/embed/${match[1]}` : '';
+}
+
+export function getFacebookEmbedUrl(url: string): string {
+	const match = url.match(/(?:facebook\.com\/(?:reel\/|watch\?v=|[\w.]+\/videos\/(?:[\w.]+\/)?))([\w-]+)/);
+	const reelUrl = `https://www.facebook.com/reel/${match?.[1]}`;
+	return match ? `https://www.facebook.com/plugins/video.php?href=${encodeURIComponent(reelUrl)}` : '';
+}
+
+export function getFacebookEmbedSize(isSearchMessage?: boolean) {
+	if (isSearchMessage) {
+		return { width: `${267 * 0.65}px`, height: `${476 * 0.65}px` };
+	}
+	return { width: '267px', height: '476px' };
+}
+
+export function isFacebookLink(url: string): boolean {
+	return /(?:facebook\.com\/(?:reel\/|watch\?v=|[\w.]+\/videos\/(?:[\w.]+\/)?))([\w-]+)/.test(url);
+}
+
+export function isYouTubeShorts(url: string) {
+	return /youtube\.com\/shorts\//.test(url);
+}
+
+export function getYouTubeEmbedSize(url: string, isSearchMessage?: boolean) {
+	if (isYouTubeShorts(url)) {
+		return { width: '169px', height: '300px' };
+	}
+	if (isSearchMessage) {
+		return { width: `${400 * 0.65}px`, height: `${225 * 0.65}px` };
+	}
+	return { width: '400px', height: '225px' };
+}
+
+export function isTikTokLink(url: string): boolean {
+	return /(?:tiktok\.com\/@[^/]+\/video\/\d+|vm\.tiktok\.com\/[a-zA-Z0-9]+|tiktok\.com\/t\/[a-zA-Z0-9]+)/.test(url);
+}
+
+export function getTikTokEmbedUrl(url: string): string {
+	const match = url.match(/tiktok\.com\/@[^/]+\/video\/(\d+)/);
+	return match ? `https://www.tiktok.com/player/v1/${match[1]}` : '';
+}
+
+export function getTikTokEmbedSize() {
+	return { width: '253px', height: '450px' };
+}

--- a/libs/utils/src/lib/utils/index.ts
+++ b/libs/utils/src/lib/utils/index.ts
@@ -60,6 +60,7 @@ export * from './canvasLink';
 export * from './convertMessageToHtml';
 export * from './dateI18n';
 export * from './detectTokenMessage';
+export * from './embed-social';
 export * from './file';
 export * from './forceReflow';
 export * from './heavyAnimation';
@@ -1194,43 +1195,6 @@ export const isElementInViewport = (element: HTMLElement) => {
 		rect.right <= (window.innerWidth || document.documentElement.clientWidth)
 	);
 };
-
-export function isYouTubeLink(url: string): boolean {
-	return /(?:youtube\.com\/(?:watch\?v=|embed\/|v\/|e\/|shorts\/)|youtu\.be\/)/.test(url);
-}
-
-export function getYouTubeEmbedUrl(url: string): string {
-	// check xss
-	const match = url.match(/(?:youtube\.com\/(?:watch\?v=|v\/|e\/|embed\/|shorts\/)|youtu\.be\/)([a-zA-Z0-9_-]{11})/);
-	return match ? `https://www.youtube.com/embed/${match[1]}` : '';
-}
-
-export function isYouTubeShorts(url: string) {
-	return /youtube\.com\/shorts\//.test(url);
-}
-
-export function getYouTubeEmbedSize(url: string, isSearchMessage?: boolean) {
-	if (isYouTubeShorts(url)) {
-		return { width: '169px', height: '300px' };
-	}
-	if (isSearchMessage) {
-		return { width: `${400 * 0.65}px`, height: `${225 * 0.65}px` };
-	}
-	return { width: '400px', height: '225px' };
-}
-
-export function isTikTokLink(url: string): boolean {
-	return /(?:tiktok\.com\/@[^/]+\/video\/\d+|vm\.tiktok\.com\/[a-zA-Z0-9]+|tiktok\.com\/t\/[a-zA-Z0-9]+)/.test(url);
-}
-
-export function getTikTokEmbedUrl(url: string): string {
-	const match = url.match(/tiktok\.com\/@[^/]+\/video\/(\d+)/);
-	return match ? `https://www.tiktok.com/player/v1/${match[1]}` : '';
-}
-
-export function getTikTokEmbedSize() {
-	return { width: '253px', height: '450px' };
-}
 
 export const formatMoney = (number: number) => {
 	if (number === 0) {


### PR DESCRIPTION
## Descriptions 
- Supported facebook embed for reel, watch and user upload videos

## Changes
- Added some utils function for process facebook links 
- Split social media embed logic to special file

## Screenshots
<img width="1062" height="991" alt="image" src="https://github.com/user-attachments/assets/b094277e-3e01-4019-a06f-6641680d8222" />

## Testing
- Tested on macOS 15.x (Desktop)
- Tested on Chrome for macOS version 142.0.7444.135

## Additional information
- Some videos cannot play on embed mode because that be disabled by facebook user