### PR TITLE
251118 - WEB/DESKTOP - fix collapse thread

### DIFF
--- a/libs/store/src/lib/channels/listChannelRender.slice.ts
+++ b/libs/store/src/lib/channels/listChannelRender.slice.ts
@@ -651,8 +651,8 @@ function sortChannels(channels: IChannel[], categoryId: string): IChannel[] {
 			for (; indexThread < numOfChannel; indexThread++) {
 				const thread = channels[indexThread];
 				const parentId = thread.parent_id || '';
-				sortedChannels.push(thread);
 				if (thread.parent_id === channel.id) {
+					sortedChannels.push(thread);
 					if (newChannel.threadIds) {
 						newChannel.threadIds = [...newChannel.threadIds, thread.id];
 					} else {


### PR DESCRIPTION
[Desktop/Website] Display incorrect unread thread when cate is collapsing
[#10701](https://github.com/mezonai/mezon/issues/10701)