### PR TITLE
251119-MOBILE-Fix show avatar dm group share event mobile

### DIFF
--- a/apps/mobile/src/app/components/Event/EventShare/index.tsx
+++ b/apps/mobile/src/app/components/Event/EventShare/index.tsx
@@ -49,7 +49,7 @@ export const ShareEventModal = memo(({ event, onConfirm }: IShareEventModalProps
 		return {
 			channelId: dm?.id,
 			type: dm?.type,
-			avatar: dm?.type === ChannelType.CHANNEL_TYPE_DM ? dm?.channel_avatar?.[0] : dm?.topic,
+			avatar: dm?.type === ChannelType.CHANNEL_TYPE_DM ? dm?.avatars?.[0] : dm?.channel_avatar,
 			name: dm?.channel_label,
 			clanId: '',
 			clanName: ''


### PR DESCRIPTION
251119-MOBILE-Fix show avatar dm group share event mobile
Issue: https://github.com/mezonai/mezon/issues/10700
Expect: Show correct group avatar and dm user avatar.
<img width="412" height="915" alt="image" src="https://github.com/user-attachments/assets/4011a352-69b9-4844-8992-e7877487fa31" />
<img width="419" height="402" alt="image" src="https://github.com/user-attachments/assets/397494b4-d07e-405a-ae60-fcd3c8557e17" />
