### PR TITLE
251120-MOBILE-Fix jump notification from topic mobile

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/components/TopicDiscussion/TopicDiscussion.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/TopicDiscussion/TopicDiscussion.tsx
@@ -87,8 +87,9 @@ export default function TopicDiscussion() {
 			mode: ''
 		});
 		return () => {
-			dispatch(topicsActions.setCurrentTopicId(''));
-			dispatch(topicsActions.setIsShowCreateTopic(false));
+			if (topicIdRef.current) {
+				dispatch(topicsActions.attemptClearTopicId(topicIdRef.current));
+			}
 			DeviceEventEmitter.emit(ActionEmitEvent.SHOW_KEYBOARD, null);
 			DeviceEventEmitter.emit(ActionEmitEvent.ON_PANEL_KEYBOARD_BOTTOM_SHEET, {
 				isShow: false,

--- a/apps/mobile/src/app/screens/messages/DirectMessageDetailTablet/styles.ts
+++ b/apps/mobile/src/app/screens/messages/DirectMessageDetailTablet/styles.ts
@@ -4,7 +4,7 @@ import { StyleSheet } from 'react-native';
 export const style = (colors: Attributes) =>
 	StyleSheet.create({
 		dmMessageContainer: {
-			backgroundColor: colors.secondary,
+			backgroundColor: colors.primary,
 			flex: 1
 		},
 		headerWrapper: {

--- a/apps/mobile/src/app/utils/pushNotificationHelpers.ts
+++ b/apps/mobile/src/app/utils/pushNotificationHelpers.ts
@@ -12,7 +12,6 @@ import {
 } from '@mezon/mobile-components';
 import { appActions, channelsActions, clansActions, directActions, getFirstMessageOfTopic, getStoreAsync, topicsActions } from '@mezon/store-mobile';
 import i18n from '@mezon/translations';
-import { sleep } from '@mezon/utils';
 import notifee, { AndroidLaunchActivityFlag, AuthorizationStatus as NotifeeAuthorizationStatus } from '@notifee/react-native';
 import type { NotificationAndroid } from '@notifee/react-native/src/types/NotificationAndroid';
 import {
@@ -584,7 +583,6 @@ export const navigateToNotification = async (store: any, notification: any, navi
 
 const handleOpenTopicDiscustion = async (store: any, topicId: string, channelId: string, navigation: any) => {
 	const promises = [];
-	await sleep(500);
 	promises.push(store.dispatch(topicsActions.setCurrentTopicInitMessage(null)));
 	promises.push(store.dispatch(topicsActions.setCurrentTopicId(topicId || '')));
 	promises.push(store.dispatch(topicsActions.setIsShowCreateTopic(true)));

--- a/libs/store/src/lib/topicDiscussion/topicDiscussions.slice.ts
+++ b/libs/store/src/lib/topicDiscussion/topicDiscussions.slice.ts
@@ -126,6 +126,16 @@ export const handleTopicNotification = createAsyncThunk('topics/handleTopicNotif
 	}
 });
 
+export const attemptClearTopicId = createAsyncThunk('topics/attemptClearTopicId', async (topicIdToClear: string, thunkAPI) => {
+	const state = thunkAPI.getState() as RootState;
+	const currentTopicId = state.topicdiscussions.currentTopicId;
+
+	if (currentTopicId === topicIdToClear) {
+		thunkAPI.dispatch(topicsActions.setCurrentTopicId(''));
+		thunkAPI.dispatch(topicsActions.setIsShowCreateTopic(false));
+	}
+});
+
 type SendTopicPayload = {
 	clanId: string;
 	channelId: string;
@@ -294,7 +304,7 @@ export const topicsReducer = topicsSlice.reducer;
  *
  * See: https://react-redux.js.org/next/api/hooks#usedispatch
  */
-export const topicsActions = { ...topicsSlice.actions, createTopic, fetchTopics, handleSendTopic };
+export const topicsActions = { ...topicsSlice.actions, createTopic, fetchTopics, handleSendTopic, attemptClearTopicId };
 
 /*
  * Export selectors to query state. For use with the `useSelector` hook.


### PR DESCRIPTION
Issue: https://github.com/mezonai/mezon/issues/10378
Clean up was call after notification function open topic.
Change: Only set empty topic discussion when clean up current topic the same with state

https://github.com/user-attachments/assets/8cbd16e7-b078-447b-8518-5c8114059487

