### PR TITLE
251120-MOBILE-Fix optimize show last send user dm mobile

### DIFF
--- a/apps/mobile/src/app/screens/messages/DmListItem.tsx
+++ b/apps/mobile/src/app/screens/messages/DmListItem.tsx
@@ -50,18 +50,15 @@ export const DmListItem = React.memo((props: { id: string }) => {
 		return Number(directMessage?.type) === ChannelType.CHANNEL_TYPE_GROUP;
 	}, [directMessage?.type]);
 
-	const otherMemberList = useMemo(() => {
-		const DMClone = JSON.parse(JSON.stringify(directMessage));
-		const userIdList = DMClone.user_ids;
-		const usernameList = DMClone?.usernames || [];
-		const displayNameList = DMClone?.display_names || [];
+	const otherMember = useMemo(() => {
+		if (!directMessage?.user_ids) return [];
 
-		return usernameList?.map((username, index) => ({
-			userId: userIdList?.[index],
-			username,
-			displayName: displayNameList?.[index]
-		}));
-	}, [directMessage]);
+		return {
+			userId: directMessage.user_ids?.[0],
+			username: directMessage.usernames?.[0],
+			displayName: directMessage.display_names?.[0]
+		};
+	}, [directMessage?.display_names, directMessage?.user_ids, directMessage?.usernames]);
 
 	const lastMessageTime = useMemo(() => {
 		if (directMessage?.last_sent_message?.timestamp_seconds) {
@@ -149,7 +146,7 @@ export const DmListItem = React.memo((props: { id: string }) => {
 				<MessagePreviewLastest
 					isUnReadChannel={isUnReadChannel}
 					type={directMessage?.type}
-					otherMemberList={otherMemberList}
+					otherMember={otherMember}
 					senderId={directMessage?.last_sent_message?.sender_id}
 					lastSentMessage={directMessage?.last_sent_message}
 				/>

--- a/apps/mobile/src/app/screens/messages/DmListItem.tsx
+++ b/apps/mobile/src/app/screens/messages/DmListItem.tsx
@@ -50,16 +50,6 @@ export const DmListItem = React.memo((props: { id: string }) => {
 		return Number(directMessage?.type) === ChannelType.CHANNEL_TYPE_GROUP;
 	}, [directMessage?.type]);
 
-	const otherMember = useMemo(() => {
-		if (!directMessage?.user_ids) return [];
-
-		return {
-			userId: directMessage.user_ids?.[0],
-			username: directMessage.usernames?.[0],
-			displayName: directMessage.display_names?.[0]
-		};
-	}, [directMessage?.display_names, directMessage?.user_ids, directMessage?.usernames]);
-
 	const lastMessageTime = useMemo(() => {
 		if (directMessage?.last_sent_message?.timestamp_seconds) {
 			const timestamp = Number(directMessage?.last_sent_message?.timestamp_seconds);
@@ -146,7 +136,8 @@ export const DmListItem = React.memo((props: { id: string }) => {
 				<MessagePreviewLastest
 					isUnReadChannel={isUnReadChannel}
 					type={directMessage?.type}
-					otherMember={otherMember}
+					senderName={directMessage?.display_names?.[0] || directMessage.usernames?.[0]}
+					userId={directMessage?.user_ids?.[0] || ''}
 					senderId={directMessage?.last_sent_message?.sender_id}
 					lastSentMessage={directMessage?.last_sent_message}
 				/>

--- a/apps/mobile/src/app/screens/messages/MessagePreviewLastest.tsx
+++ b/apps/mobile/src/app/screens/messages/MessagePreviewLastest.tsx
@@ -11,10 +11,10 @@ import { DmListItemLastMessage } from './DMListItemLastMessage';
 import { style } from './styles';
 
 export const MessagePreviewLastest = React.memo(
-	(props: { type: ChannelType; senderId: string; otherMemberList: any; lastSentMessage: any; isUnReadChannel: boolean }) => {
+	(props: { type: ChannelType; senderId: string; otherMember: any; lastSentMessage: any; isUnReadChannel: boolean }) => {
 		const { themeValue } = useTheme();
 		const styles = style(themeValue);
-		const { lastSentMessage, type, senderId, otherMemberList, isUnReadChannel } = props || {};
+		const { lastSentMessage, type, senderId, otherMember, isUnReadChannel } = props || {};
 
 		const content = useMemo(() => {
 			return typeof lastSentMessage?.content === 'object' ? lastSentMessage?.content : safeJSONParse(lastSentMessage?.content || '{}');
@@ -57,13 +57,12 @@ export const MessagePreviewLastest = React.memo(
 				return `${t('directMessage.you')}: `;
 			}
 
-			const lastMessageSender = otherMemberList?.find?.((it) => it?.userId === senderId);
-			if (lastMessageSender?.username) {
-				return `${lastMessageSender?.displayName || lastMessageSender?.username}: `;
+			if (otherMember && otherMember?.userId === senderId) {
+				return `${otherMember?.displayName || otherMember?.username}: `;
 			}
 
 			return '';
-		}, [isYourAccount, otherMemberList, senderId, t]);
+		}, [senderId, isYourAccount, otherMember, t]);
 
 		const getLastMessageAttachmentContent = async (attachment: ApiMessageAttachment, isLinkMessage: boolean, text: string, embed: any) => {
 			if (embed) {

--- a/apps/mobile/src/app/screens/messages/MessagePreviewLastest.tsx
+++ b/apps/mobile/src/app/screens/messages/MessagePreviewLastest.tsx
@@ -11,10 +11,10 @@ import { DmListItemLastMessage } from './DMListItemLastMessage';
 import { style } from './styles';
 
 export const MessagePreviewLastest = React.memo(
-	(props: { type: ChannelType; senderId: string; otherMember: any; lastSentMessage: any; isUnReadChannel: boolean }) => {
+	(props: { type: ChannelType; senderId: string; senderName: string; userId: string; lastSentMessage: any; isUnReadChannel: boolean }) => {
 		const { themeValue } = useTheme();
 		const styles = style(themeValue);
-		const { lastSentMessage, type, senderId, otherMember, isUnReadChannel } = props || {};
+		const { lastSentMessage, type, senderId, senderName, userId, isUnReadChannel } = props || {};
 
 		const content = useMemo(() => {
 			return typeof lastSentMessage?.content === 'object' ? lastSentMessage?.content : safeJSONParse(lastSentMessage?.content || '{}');
@@ -57,12 +57,12 @@ export const MessagePreviewLastest = React.memo(
 				return `${t('directMessage.you')}: `;
 			}
 
-			if (otherMember && otherMember?.userId === senderId) {
-				return `${otherMember?.displayName || otherMember?.username}: `;
+			if (senderName && senderId === userId) {
+				return `${senderName}: `;
 			}
 
 			return '';
-		}, [senderId, isYourAccount, otherMember, t]);
+		}, [senderId, isYourAccount, senderName, userId, t]);
 
 		const getLastMessageAttachmentContent = async (attachment: ApiMessageAttachment, isLinkMessage: boolean, text: string, embed: any) => {
 			if (embed) {


### PR DESCRIPTION
Issue: https://github.com/mezonai/mezon/issues/10785
# Changes:
- remove logic mapping other users list.
- change to last send user object to check user display name and username.

<img width="406" height="881" alt="image" src="https://github.com/user-attachments/assets/1c0eeef2-dc46-4d2a-bca3-975e8581bd33" />
