### PR TITLE
251121-WEB/DESKTOP-Feat(interested): add count number to Interested events section

### DIFF
--- a/libs/components/src/lib/components/ChannelList/EventChannelModal/ModalCreate/modalDetailItemEvent.tsx
+++ b/libs/components/src/lib/components/ChannelList/EventChannelModal/ModalCreate/modalDetailItemEvent.tsx
@@ -83,7 +83,7 @@ const ModalDetailItemEvent = (props?: ModalDetailItemEventProps) => {
 								className={`pb-4 ${currentTab === tabs.interest ? 'text-theme-primary-active border-b border-white' : 'text-zinc-400'}`}
 								onClick={() => setCurrentTab(tabs.interest)}
 							>
-								{t('eventDetail.interested')}
+								{t('eventDetail.interested', { count: event?.user_ids?.length || 0 })}
 							</h4>
 						</div>
 					</div>

--- a/libs/translations/src/languages/en/eventCreator.json
+++ b/libs/translations/src/languages/en/eventCreator.json
@@ -116,7 +116,7 @@
 		"eventIsTaking": "Event is taking place!",
 		"tenMinutesLeft": "{{minutes}} minutes left. Join in!",
 		"eventInfo": "Event Info",
-		"interested": "Interested",
+		"interested": "{{count}} Interested",
 		"personInterested": "{{count}} person is interested",
 		"createdBy": "Created by {{username}}",
 		"inviteFriends": "Invite friends to event?",

--- a/libs/translations/src/languages/vi/eventCreator.json
+++ b/libs/translations/src/languages/vi/eventCreator.json
@@ -116,7 +116,7 @@
 		"eventIsTaking": "Sự kiện đang diễn ra!",
 		"tenMinutesLeft": "Còn {{minutes}} phút. Tham gia ngay!",
 		"eventInfo": "Thông tin sự kiện",
-		"interested": "Quan tâm",
+		"interested": "{{count}} Quan tâm",
 		"personInterested": "{{count}} người quan tâm",
 		"createdBy": "Được tạo bởi {{username}}",
 		"inviteFriends": "Mời bạn bè tham gia sự kiện?",

--- a/libs/translations/src/languages/vi/memberPage.json
+++ b/libs/translations/src/languages/vi/memberPage.json
@@ -3,7 +3,7 @@
 	"membersOf": "Tổng thành viên {{count}}",
 	"addedBy": "Được thêm bởi {{name}}",
 	"you": "bạn",
-	"inVoice": "Đang thoại",
+	"inVoice": "Trong kênh thoại",
 	"onlineCount": "Trực tuyến - {{count}}",
 	"offlineCount": "Ngoại tuyến - {{count}}"
 }


### PR DESCRIPTION
Task : 
[Desktop/Website] Add count number in the Interested event section
[#10637](https://github.com/mezonai/mezon/issues/10637)

Demo : 
<img width="574" height="279" alt="1991548544619646976" src="https://github.com/user-attachments/assets/786a22aa-2a4d-4fec-8448-4aa79d50cd17" />
