### PR TITLE
251121-MOBILE-Fix change category name not validate input and save button mobile

### DIFF
--- a/apps/mobile/src/app/components/CategorySetting/CategorySetting.tsx
+++ b/apps/mobile/src/app/components/CategorySetting/CategorySetting.tsx
@@ -11,6 +11,7 @@ import MezonIconCDN from '../../componentUI/MezonIconCDN';
 import MezonInput from '../../componentUI/MezonInput';
 import { IconCDN } from '../../constants/icon_cdn';
 import { APP_SCREEN, MenuClanScreenProps } from '../../navigation/ScreenTypes';
+import { validInput } from '../../utils/validate';
 import { style } from './styles';
 
 type ScreenCategorySetting = typeof APP_SCREEN.MENU_CLAN.CATEGORY_SETTING;
@@ -26,6 +27,7 @@ export function CategorySetting({ navigation, route }: MenuClanScreenProps<Scree
 
 	const isNotChanged = useMemo(() => {
 		if (!currentSettingValue) return true;
+		if (!validInput(currentSettingValue)) return true;
 		return isEqual(categorySettingValue, currentSettingValue);
 	}, [categorySettingValue, currentSettingValue]);
 
@@ -76,7 +78,12 @@ export function CategorySetting({ navigation, route }: MenuClanScreenProps<Scree
 
 	return (
 		<ScrollView style={styles.container}>
-			<MezonInput label={t('fields.categoryName.title')} value={currentSettingValue} onTextChange={handleUpdateValue} />
+			<MezonInput
+				label={t('fields.categoryName.title')}
+				value={currentSettingValue}
+				errorMessage={t('fields.categoryName.errorMessage')}
+				onTextChange={handleUpdateValue}
+			/>
 		</ScrollView>
 	);
 }

--- a/libs/translations/src/languages/en/categoryCreator.json
+++ b/libs/translations/src/languages/en/categoryCreator.json
@@ -7,7 +7,7 @@
         "cateName": {
             "title": "Category Name",
             "placeholder": "New Category",
-            "errorMessage": "Please enter a valid channel name (max 64 characters, only words, numbers, _ or -)."
+            "errorMessage": "Please enter a valid category name (max 64 characters, only words, numbers, _ or -)."
         },
         "catePrivate": {
             "title": "Private Category",

--- a/libs/translations/src/languages/en/categorySetting.json
+++ b/libs/translations/src/languages/en/categorySetting.json
@@ -2,7 +2,8 @@
 	"fields": {
 		"categoryName": {
 			"title": "Category Name",
-			"placeholder": "Text Channels"
+			"placeholder": "Text Channels",
+			"errorMessage": "Please enter a valid category name (max 64 characters, only words, numbers, _ or -)."
 		},
 		"categoryPermission": {
 			"title": "",

--- a/libs/translations/src/languages/vi/categorySetting.json
+++ b/libs/translations/src/languages/vi/categorySetting.json
@@ -2,7 +2,8 @@
     "fields": {
         "categoryName": {
             "title": "Tên danh mục",
-            "placeholder": "Nhập vào tên danh mục"
+            "placeholder": "Nhập vào tên danh mục",
+            "errorMessage": "Vui lòng nhập tên danh mục hợp lệ (tối đa 64 ký tự, chỉ từ, số, _ hoặc -)."
         },
         "categoryPermission": {
             "title": "",


### PR DESCRIPTION
Issue: https://github.com/mezonai/mezon/issues/10782
Change: add prop to show error message and validate save button.

https://github.com/user-attachments/assets/e7a6e78e-38fc-4fc3-8b03-b443629a2f83

