### PR TITLE
251124-WEB/DESKTOP-fix(dm): display username in profile view after starting new DM

### DIFF
--- a/libs/components/src/lib/components/ModalUserProfile/index.tsx
+++ b/libs/components/src/lib/components/ModalUserProfile/index.tsx
@@ -236,7 +236,9 @@ const ModalUserProfile = ({
 			</div>
 			<AvatarProfile
 				avatar={avatar || avatarByUserId}
-				username={(isFooterProfile && userProfile?.user?.username) || message?.username || userById?.user?.username}
+				username={
+					(isFooterProfile && userProfile?.user?.username) || message?.username || userById?.user?.username || currentUserId?.username
+				}
 				userToDisplay={isFooterProfile ? userProfile : userById}
 				customStatus={status.user_status}
 				isAnonymous={checkAnonymous}

--- a/libs/components/src/lib/components/ModalUserProfile/index.tsx
+++ b/libs/components/src/lib/components/ModalUserProfile/index.tsx
@@ -8,7 +8,8 @@ import {
 	useOnClickOutside,
 	useSendInviteMessage,
 	useSettingFooter,
-	useUserById
+	useUserById,
+	useUserByUserId
 } from '@mezon/core';
 import type { RootState } from '@mezon/store';
 import { EStateFriend, selectAllAccount, selectChannelByChannelId, selectFriendById, selectStatusInVoice, useAppSelector } from '@mezon/store';
@@ -86,12 +87,14 @@ const ModalUserProfile = ({
 	const { t } = useTranslation('userProfile');
 
 	const userProfile = useSelector(selectAllAccount);
+
 	const { userId } = useAuth();
 	const { createDirectMessageWithUser } = useDirect();
 	const { sendInviteMessage } = useSendInviteMessage();
 	const userInvoice = useSelector((state) => selectStatusInVoice(state, userID as string));
 	const status = useMemberStatus(userID || '');
 	const userById = useUserById(userID);
+	const currentUserId = useUserByUserId(userID);
 	const userStatusById = useMemberStatus(userID || '');
 	const userStatus = useMemo(() => {
 		if (userID === userId) {
@@ -101,7 +104,7 @@ const ModalUserProfile = ({
 			};
 		}
 		return userStatusById;
-	}, [userStatusById]);
+	}, [userStatusById, userID, userProfile, userId]);
 
 	const modalRef = useRef<boolean>(false);
 	const onLoading = useRef<boolean>(false);
@@ -179,7 +182,7 @@ const ModalUserProfile = ({
 
 	const usernameShow = useMemo(() => {
 		if (isFooterProfile) {
-			return userProfile?.user?.username;
+			return userProfile?.user?.username || currentUserId?.username;
 		}
 		if (userById) {
 			return userById?.user?.username;
@@ -250,10 +253,14 @@ const ModalUserProfile = ({
 								? t('labels.unknownUser')
 								: checkAnonymous
 									? t('labels.anonymous')
-									: userById?.clan_nick || userById?.user?.display_name || userById?.user?.username || usernameShow}
+									: userById?.clan_nick ||
+										userById?.user?.display_name ||
+										userById?.user?.username ||
+										currentUserId?.display_name ||
+										usernameShow}
 						</p>
 						<p className="text-base font-semibold tracking-wide text-theme-primary my-0 truncate">
-							{isUserRemoved ? t('labels.unknownUser') : usernameShow}
+							{isUserRemoved ? t('labels.unknownUser') : usernameShow || currentUserId?.username}
 						</p>
 					</div>
 

--- a/libs/components/src/lib/components/ModalUserProfile/index.tsx
+++ b/libs/components/src/lib/components/ModalUserProfile/index.tsx
@@ -194,7 +194,7 @@ const ModalUserProfile = ({
 			return message?.username;
 		}
 		return message?.references?.[0].message_sender_username;
-	}, [userById, userID]);
+	}, [userById, userID, currentUserId?.username, userProfile?.user?.username, isFooterProfile, checkAnonymous, message]);
 
 	const handleOnKeyPress = useCallback(
 		(e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -260,7 +260,7 @@ const ModalUserProfile = ({
 										usernameShow}
 						</p>
 						<p className="text-base font-semibold tracking-wide text-theme-primary my-0 truncate">
-							{isUserRemoved ? t('labels.unknownUser') : usernameShow || currentUserId?.username}
+							{isUserRemoved ? t('labels.unknownUser') : usernameShow || currentUserId?.username || ''}
 						</p>
 					</div>
 

--- a/libs/core/src/lib/chat/hooks/useUserById.ts
+++ b/libs/core/src/lib/chat/hooks/useUserById.ts
@@ -39,7 +39,7 @@ export const useUserMetaById = (userID: string | undefined): any | undefined => 
 	});
 };
 
-export const useUserByUserId = (userID: string | undefined): ChannelMembersEntity | any => {
+export const useUserByUserId = (userID: string | undefined): ChannelMembersEntity | undefined => {
 	return useAppSelector((state) => {
 		if (!userID) return undefined;
 		const isClanView = selectClanView(state);

--- a/libs/core/src/lib/chat/hooks/useUserById.ts
+++ b/libs/core/src/lib/chat/hooks/useUserById.ts
@@ -39,7 +39,7 @@ export const useUserMetaById = (userID: string | undefined): any | undefined => 
 	});
 };
 
-export const useUserByUserId = (userID: string | undefined): ChannelMembersEntity | undefined => {
+export const useUserByUserId = (userID: string | undefined): ChannelMembersEntity | any => {
 	return useAppSelector((state) => {
 		if (!userID) return undefined;
 		const isClanView = selectClanView(state);

--- a/libs/utils/src/lib/types/index.ts
+++ b/libs/utils/src/lib/types/index.ts
@@ -792,6 +792,9 @@ export interface ChannelMembersEntity extends IChannelMember {
 	id: string; // Primary ID
 	name?: string;
 	clanNick?: string;
+	display_name?: string;
+	username?: string;
+	avatar_url?: string;
 }
 
 export type SortChannel = {


### PR DESCRIPTION
Task : [Desktop/Website] Username is not displayed in User Profile after opening new DM
[#10811](https://github.com/mezonai/mezon/issues/10811)
Demo : 

https://github.com/user-attachments/assets/e77d6ed3-c0d6-46dc-aee7-5bbe9f0e012b


add case my profile new account 
<img width="1366" height="637" alt="image" src="https://github.com/user-attachments/assets/dc585050-9a09-4b58-9427-c2359a14491f" />
 

