### PR TITLE
251126-MOBILE-Fix category validate and UI menu mobile

### DIFF
--- a/apps/mobile/src/app/components/Category/Category.tsx
+++ b/apps/mobile/src/app/components/Category/Category.tsx
@@ -10,6 +10,7 @@ import MezonInput from '../../componentUI/MezonInput';
 import { IconCDN } from '../../constants/icon_cdn';
 import { APP_SCREEN, MenuClanScreenProps } from '../../navigation/ScreenTypes';
 import { validInput } from '../../utils/validate';
+import { MAX_NAME_LENGTH } from '../ClanSettings/Emoji/EmojiPreview';
 import { style } from './styles';
 
 type CreateCategoryScreen = typeof APP_SCREEN.MENU_CLAN.CREATE_CATEGORY;
@@ -68,6 +69,7 @@ export function CategoryCreator({ navigation }: MenuClanScreenProps<CreateCatego
 				placeHolder={t('fields.cateName.placeholder')}
 				errorMessage={t('fields.cateName.errorMessage')}
 				label={t('fields.cateName.title')}
+				maxCharacter={MAX_NAME_LENGTH}
 			/>
 		</View>
 	);

--- a/apps/mobile/src/app/components/CategorySetting/CategorySetting.tsx
+++ b/apps/mobile/src/app/components/CategorySetting/CategorySetting.tsx
@@ -12,6 +12,7 @@ import MezonInput from '../../componentUI/MezonInput';
 import { IconCDN } from '../../constants/icon_cdn';
 import { APP_SCREEN, MenuClanScreenProps } from '../../navigation/ScreenTypes';
 import { validInput } from '../../utils/validate';
+import { MAX_NAME_LENGTH } from '../ClanSettings/Emoji/EmojiPreview';
 import { style } from './styles';
 
 type ScreenCategorySetting = typeof APP_SCREEN.MENU_CLAN.CATEGORY_SETTING;
@@ -58,7 +59,7 @@ export function CategorySetting({ navigation, route }: MenuClanScreenProps<Scree
 		navigation.setOptions({
 			headerStatusBarHeight: Platform.OS === 'android' ? 0 : undefined,
 			headerRight: () => (
-				<Pressable onPress={() => handleSaveCategorySetting()}>
+				<Pressable onPress={() => handleSaveCategorySetting()} disabled={isNotChanged}>
 					<Text style={[styles.saveChangeButton, !isNotChanged ? styles.changed : styles.notChange]}>{t('confirm.save')}</Text>
 				</Pressable>
 			)
@@ -83,6 +84,7 @@ export function CategorySetting({ navigation, route }: MenuClanScreenProps<Scree
 				value={currentSettingValue}
 				errorMessage={t('fields.categoryName.errorMessage')}
 				onTextChange={handleUpdateValue}
+				maxCharacter={MAX_NAME_LENGTH}
 			/>
 		</ScrollView>
 	);

--- a/apps/mobile/src/app/screens/home/homedrawer/components/CategoryMenu/styles.ts
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/CategoryMenu/styles.ts
@@ -14,7 +14,8 @@ export const style = ({ textStrong }: Attributes) =>
 		serverName: {
 			color: textStrong,
 			fontSize: Fonts.size.h7,
-			fontWeight: '700'
+			fontWeight: '700',
+			flexShrink: 1
 		},
 
 		header: {


### PR DESCRIPTION
251126-MOBILE-Fix category validate and UI menu mobile
Issue: https://github.com/mezonai/mezon/issues/10782
Change:
- Change max length of category name to 64
- Disable save button when validate error.

https://github.com/user-attachments/assets/54060c10-bb18-4fe4-8213-d98ac92d779a

