### PR TITLE
251126-MOBILE-Fix emoji max length validate mobile

### DIFF
--- a/apps/mobile/src/app/components/ClanSettings/Emoji/EmojiDetail/EmojiDetail.tsx
+++ b/apps/mobile/src/app/components/ClanSettings/Emoji/EmojiDetail/EmojiDetail.tsx
@@ -85,11 +85,11 @@ export const EmojiDetail = forwardRef(({ item, onSwipeOpen }: ServerDetailProps,
 
 	const handleBlur = () => {
 		setIsFocused(false);
-		if (!CLAN_MEDIA_NAME_REGEX.test(emojiName) || emojiName?.length < MIN_NAME_LENGTH || emojiName?.length > MAX_NAME_LENGTH) {
+		if (!CLAN_MEDIA_NAME_REGEX.test(emojiName) || emojiName?.length < MIN_NAME_LENGTH || emojiName?.length > MAX_NAME_LENGTH - 2) {
 			setEmojiName(item?.shortname?.split(':')?.join(''));
 			Toast.show({
 				type: 'error',
-				text1: t('toast.validateName', { min: MIN_NAME_LENGTH, max: MAX_NAME_LENGTH })
+				text1: t('toast.validateName', { min: MIN_NAME_LENGTH, max: MAX_NAME_LENGTH - 2 })
 			});
 			return;
 		}

--- a/apps/mobile/src/app/components/ClanSettings/Emoji/EmojiPreview/index.tsx
+++ b/apps/mobile/src/app/components/ClanSettings/Emoji/EmojiPreview/index.tsx
@@ -32,7 +32,7 @@ export const EmojiPreview = memo(({ isSticker = false, image, onConfirm }: IShar
 	}
 
 	function handleUploadConfirm() {
-		if (emojiName?.trim()?.length >= MIN_NAME_LENGTH && emojiName?.length <= MAX_NAME_LENGTH && CLAN_MEDIA_NAME_REGEX.test(emojiName)) {
+		if (emojiName?.trim()?.length >= MIN_NAME_LENGTH && emojiName?.length <= MAX_NAME_LENGTH - 2 && CLAN_MEDIA_NAME_REGEX.test(emojiName)) {
 			setError('');
 			if (onConfirm) {
 				onConfirm(image, emojiName, isForSale);
@@ -41,7 +41,7 @@ export const EmojiPreview = memo(({ isSticker = false, image, onConfirm }: IShar
 		} else {
 			setError(
 				t('itemClanPreview.lenghtError', {
-					max: MAX_NAME_LENGTH,
+					max: MAX_NAME_LENGTH - 2,
 					min: MIN_NAME_LENGTH,
 					type: isSticker ? t('itemClanPreview.sticker') : t('itemClanPreview.emoji')
 				})


### PR DESCRIPTION
251126-MOBILE-Fix emoji max length validate mobile
Issue: https://github.com/mezonai/mezon/issues/10704
Change: set max length raw name of emoji to 62( not include ":")

https://github.com/user-attachments/assets/7fdf1181-087c-4fbd-925c-e6abd4ad8283

