### PR TITLE
251126-MOBILE-Fix delete clan not navigation user to home mobile

### DIFF
--- a/apps/mobile/src/app/components/DeleteClanModal/index.tsx
+++ b/apps/mobile/src/app/components/DeleteClanModal/index.tsx
@@ -49,6 +49,7 @@ const DeleteClanModal = ({ isLeaveClan = false }: { isLeaveClan?: boolean }) => 
 		await remove(STORAGE_CHANNEL_CURRENT_CACHE);
 		const indexClanJoin = currentClanId === clans[0]?.clan_id ? 1 : 0;
 		if (clans?.length === 1) {
+			navigation.navigate(APP_SCREEN.HOME);
 			return;
 		}
 		if (clans?.[indexClanJoin]) {


### PR DESCRIPTION
251126-MOBILE-Fix delete clan not navigation user to home mobile
Issue: https://github.com/mezonai/mezon/issues/10894
Change: add navigate logic when not change clan after delete.