### PR TITLE
251126-WEB/DESKTOP-Fix(status): display correct duration for newly created statuses and disable when fwd

### DIFF
--- a/libs/components/src/lib/components/FooterProfile/index.tsx
+++ b/libs/components/src/lib/components/FooterProfile/index.tsx
@@ -12,12 +12,14 @@ import {
 	selectIsElectronUpdateAvailable,
 	selectIsInCall,
 	selectIsJoin,
+	selectMemberCustomStatusById,
 	selectShowModalCustomStatus,
 	selectShowModalSendToken,
 	selectStatusMenu,
 	selectVoiceJoined,
 	selectWalletDetail,
 	useAppDispatch,
+	useAppSelector,
 	userClanProfileActions
 } from '@mezon/store';
 import { useMezon } from '@mezon/transport';
@@ -66,6 +68,7 @@ function FooterProfile({ name, status, avatar, userId, isDM }: FooterProfileProp
 	const statusMenu = useSelector(selectStatusMenu);
 	const userWallet = useSelector(selectWalletDetail);
 	const myProfile = useAuth();
+	const userMemberStatus = useAppSelector((state) => selectMemberCustomStatusById(state, myProfile.userId as string));
 	const { t } = useTranslation(['setting', 'token']);
 	const { mmnRef } = useMezon();
 
@@ -265,8 +268,15 @@ function FooterProfile({ name, status, avatar, userId, isDM }: FooterProfileProp
 		}
 	};
 	const [openSetCustomStatus, closeSetCustomStatus] = useModal(() => {
-		return <ModalCustomStatus status={userCustomStatus} name={name} onClose={handleCloseModalCustomStatus} />;
-	}, [userCustomStatus]);
+		return (
+			<ModalCustomStatus
+				status={userCustomStatus}
+				name={name}
+				onClose={handleCloseModalCustomStatus}
+				time_reset={userMemberStatus?.time_reset}
+			/>
+		);
+	}, [userCustomStatus, userMemberStatus?.time_reset]);
 
 	const [openModalSendToken, closeModalSendToken] = useModal(() => {
 		return (

--- a/libs/components/src/lib/components/ForwardMessage/index.tsx
+++ b/libs/components/src/lib/components/ForwardMessage/index.tsx
@@ -505,20 +505,33 @@ type FooterButtonsModalProps = {
 
 const FooterButtonsModal = (props: FooterButtonsModalProps) => {
 	const { onClose, sentToMessage, t } = props;
+	const [loading, setLoading] = useState(false);
+
+	const handleSend = async () => {
+		setLoading(true);
+		try {
+			await sentToMessage();
+		} finally {
+			setLoading(false);
+		}
+	};
+
 	return (
 		<div className="flex justify-end p-4 rounded-b gap-4">
 			<button
 				className="py-2 h-10 px-4 rounded-lg border-theme-primary hover:!underline focus:ring-transparent"
 				type="button"
 				onClick={onClose}
+				disabled={loading}
 			>
 				{t('modal.cancel')}
 			</button>
 			<button
-				onClick={sentToMessage}
+				onClick={handleSend}
 				className="py-2 h-10 px-4 rounded text-white bg-bgSelectItem hover:!bg-bgSelectItemHover focus:ring-transparent"
+				disabled={loading}
 			>
-				{t('modal.send')}
+				{loading ? t('modal.sending') : t('modal.send')}
 			</button>
 		</div>
 	);

--- a/libs/components/src/lib/components/ModalUserProfile/StatusProfile/ModalCustomStatus.tsx
+++ b/libs/components/src/lib/components/ModalUserProfile/StatusProfile/ModalCustomStatus.tsx
@@ -10,9 +10,10 @@ type ModalCustomStatusProps = {
 	name: string;
 	onClose: () => void;
 	status?: string;
+	time_reset?: number;
 };
 
-const ModalCustomStatus = ({ name, status, onClose }: ModalCustomStatusProps) => {
+const ModalCustomStatus = ({ name, status, onClose, time_reset = 0 }: ModalCustomStatusProps) => {
 	const { t } = useTranslation(['userProfile'], { keyPrefix: 'statusProfile.customStatusModal' });
 	const dispatch = useAppDispatch();
 
@@ -25,7 +26,23 @@ const ModalCustomStatus = ({ name, status, onClose }: ModalCustomStatusProps) =>
 		setCustomStatus(updatedStatus);
 	};
 
-	const [timeSetReset, setTimeSetReset] = useState<string>(t('timeOptions.today'));
+	function getTimeResetLabel(minutes: number, t: (key: string) => string): string {
+		switch (minutes) {
+			case 0:
+				return t('timeOptions.today');
+			case 240:
+				return t('timeOptions.fourHours');
+			case 60:
+				return t('timeOptions.oneHour');
+			case 30:
+				return t('timeOptions.thirtyMinutes');
+
+			default:
+				return t('timeOptions.today');
+		}
+	}
+
+	const [timeSetReset, setTimeSetReset] = useState<string>(getTimeResetLabel(time_reset, t));
 
 	const setStatusTimer = useCallback(
 		(minutes: number, noClear: boolean, option: string) => {
@@ -46,7 +63,7 @@ const ModalCustomStatus = ({ name, status, onClose }: ModalCustomStatusProps) =>
 	);
 	const currentClanId = useSelector(selectCurrentClanId);
 
-	const [resetTimerStatus, setResetTimerStatus] = useState<number>(0);
+	const [resetTimerStatus, setResetTimerStatus] = useState<number>(time_reset);
 	const [noClearStatus, setNoClearStatus] = useState<boolean>(false);
 	const [customStatus, setCustomStatus] = useState<string>(status ?? '');
 

--- a/libs/core/src/lib/chat/contexts/ChatContext.tsx
+++ b/libs/core/src/lib/chat/contexts/ChatContext.tsx
@@ -1203,7 +1203,8 @@ const ChatContextProvider: React.FC<ChatContextProviderProps> = ({ children }) =
 			dispatch(
 				channelMembersActions.setCustomStatusUser({
 					userId: statusEvent.user_id,
-					status: statusEvent.status
+					status: statusEvent.status,
+					time_reset: statusEvent.time_reset
 				})
 			);
 

--- a/libs/translations/src/languages/en/forwardMessage.json
+++ b/libs/translations/src/languages/en/forwardMessage.json
@@ -7,7 +7,8 @@
 		"searchingChannel": "Searching channel",
 		"sharedContent": "Shared content",
 		"cancel": "Cancel",
-		"send": "Send"
+		"send": "Send",
+		"sending": "Sending..."
 	},
 	"successMessage": "Message forwarded successfully",
 	"errorMessage": "Failed to forward message"

--- a/libs/translations/src/languages/vi/forwardMessage.json
+++ b/libs/translations/src/languages/vi/forwardMessage.json
@@ -7,7 +7,8 @@
 		"searchingChannel": "Tìm kiếm kênh",
 		"sharedContent": "Nội dung được chia sẻ",
 		"cancel": "Hủy",
-		"send": "Gửi"
+		"send": "Gửi",
+		"sending": "Đang gửi..."
 	},
 	"successMessage": "Chuyển tiếp tin nhắn thành công",
 	"errorMessage": "Không thể chuyển tiếp tin nhắn"


### PR DESCRIPTION
Task : [Desktop/Website] Status duration reflect does not incorrectly after creation
[#10836](https://github.com/mezonai/mezon/issues/10836)

Demo : 
<img width="869" height="355" alt="image" src="https://github.com/user-attachments/assets/d26974c4-ea17-4b39-ad06-54b9bdf80561" />
