### PR TITLE
251126-MOBILE-Fix can press button when nothing change channel setting mobile

### DIFF
--- a/apps/mobile/src/app/components/ChannelSetting/ChannelSetting.tsx
+++ b/apps/mobile/src/app/components/ChannelSetting/ChannelSetting.tsx
@@ -113,7 +113,7 @@ export function ChannelSetting({ navigation, route }: MenuChannelScreenProps<Scr
 			headerStatusBarHeight: Platform.OS === 'android' ? 0 : undefined,
 			headerTitle: isChannel ? t1('menuChannelStack.channelSetting') : t1('menuChannelStack.threadSetting'),
 			headerRight: () => (
-				<Pressable onPress={() => handleSaveChannelSetting()}>
+				<Pressable onPress={() => handleSaveChannelSetting()} disabled={isNotChanged}>
 					<Text style={[styles.saveChangeButton, !isNotChanged ? styles.changed : styles.notChange]}>{t('confirm.save')}</Text>
 				</Pressable>
 			)


### PR DESCRIPTION
251126-MOBILE-Fix can press button when nothing change channel setting mobile
Issue: https://github.com/mezonai/mezon/issues/10891
Change: disable press for save button when nothing change.