### PR TITLE
251127-MOBILE-Fix navigation direct message screen after create group mobile

### DIFF
--- a/apps/mobile/src/app/components/MemberStatus/MemberListStatus.tsx
+++ b/apps/mobile/src/app/components/MemberStatus/MemberListStatus.tsx
@@ -93,7 +93,7 @@ export const MemberListStatus = React.memo(() => {
 	const navigateToNewGroupScreen = () => {
 		navigation.navigate(APP_SCREEN.MESSAGES.STACK, {
 			screen: APP_SCREEN.MESSAGES.NEW_GROUP,
-			params: { directMessageId: currentChannel?.id || currentChannel?.channel_id || '' }
+			params: { directMessageId: currentChannel?.id || currentChannel?.channel_id || '', fromUser: true }
 		});
 	};
 

--- a/apps/mobile/src/app/screens/messages/NewGroup/index.tsx
+++ b/apps/mobile/src/app/screens/messages/NewGroup/index.tsx
@@ -35,7 +35,7 @@ export const NewGroupScreen = ({ navigation, route }: { navigation: any; route: 
 	const isTabletLandscape = useTabletLandscape();
 	const { themeValue } = useTheme();
 	const styles = style(themeValue);
-	const directMessageId = route?.params?.directMessageId;
+	const { directMessageId, fromUser = false } = route?.params || {};
 	const [searchText, setSearchText] = useState<string>('');
 	const { t } = useTranslation(['common', 'friends']);
 	const [friendIdSelectedList, setFriendIdSelectedList] = useState<string[]>([]);
@@ -165,10 +165,18 @@ export const NewGroupScreen = ({ navigation, route }: { navigation: any; route: 
 					navigation.navigate(APP_SCREEN.MESSAGES.HOME);
 				} else {
 					directMessageIdRef.current = resPayload?.channel_id || '';
-					navigation.navigate(APP_SCREEN.MESSAGES.MESSAGE_DETAIL, {
-						directMessageId: resPayload.channel_id,
-						from: APP_SCREEN.MESSAGES.NEW_GROUP
-					});
+					if (fromUser) {
+						navigation.popToTop();
+						navigation.navigate(APP_SCREEN.MESSAGES.MESSAGE_DETAIL, {
+							directMessageId: resPayload.channel_id,
+							from: APP_SCREEN.MESSAGES.NEW_GROUP
+						});
+					} else {
+						navigation.replace(APP_SCREEN.MESSAGES.MESSAGE_DETAIL, {
+							directMessageId: resPayload.channel_id,
+							from: APP_SCREEN.MESSAGES.NEW_GROUP
+						});
+					}
 				}
 			});
 		}


### PR DESCRIPTION
251127-MOBILE-Fix navigation direct message screen after create group mobile
Issue: https://github.com/mezonai/mezon/issues/10902
Change change behavior when navigate from create group screen.

https://github.com/user-attachments/assets/3170d9d7-ecf2-46c6-af87-31f0bf19f6b4

