### PR TITLE
251128-MOBILE-Fix notification setting not sync after update and miss channel name when add mobile

### DIFF
--- a/apps/mobile/src/app/components/ClanNotificationSetting/CategoryChannel/CategoryChannel.tsx
+++ b/apps/mobile/src/app/components/ClanNotificationSetting/CategoryChannel/CategoryChannel.tsx
@@ -1,3 +1,4 @@
+import { EOptionOverridesType } from '@mezon/mobile-components';
 import { selectAllchannelCategorySetting } from '@mezon/store-mobile';
 import { ChannelType } from 'mezon-js';
 import React from 'react';
@@ -31,7 +32,9 @@ export const CategoryChannel = React.memo(() => {
 						<CategoryChannelItem
 							categoryLabel={item?.channel_category_label}
 							categorySubtext={item?.channel_category_title}
-							typePreviousIcon={ChannelType.CHANNEL_TYPE_CHANNEL}
+							typePreviousIcon={
+								item?.channel_category_title === 'category' ? EOptionOverridesType.Category : ChannelType.CHANNEL_TYPE_CHANNEL
+							}
 							expandable={true}
 							notificationStatus={item.notification_setting_type}
 							data={item}

--- a/apps/mobile/src/app/components/ClanNotificationSetting/CategoryChannelItem/CategoryChannelItem.tsx
+++ b/apps/mobile/src/app/components/ClanNotificationSetting/CategoryChannelItem/CategoryChannelItem.tsx
@@ -49,7 +49,7 @@ export const CategoryChannelItem = React.memo(
 					notifyChannelCategorySetting: dataNotificationsSetting || data
 				}
 			});
-		}, []);
+		}, [dataNotificationsSetting, data]);
 
 		return (
 			<TouchableOpacity onPress={navigateToNotificationDetail} style={[styles.categoryItem, stylesItem]}>

--- a/apps/mobile/src/app/components/ClanNotificationSetting/NotificationSettingDetail/NotificationSettingDetail.tsx
+++ b/apps/mobile/src/app/components/ClanNotificationSetting/NotificationSettingDetail/NotificationSettingDetail.tsx
@@ -1,5 +1,7 @@
+import type { ICategoryChannelOption } from '@mezon/mobile-components';
 import { ENotificationActive, ENotificationChannelId, EOptionOverridesType, optionNotification } from '@mezon/mobile-components';
-import { size, useTheme } from '@mezon/mobile-ui';
+import { useTheme } from '@mezon/mobile-ui';
+import type { NotiChannelCategorySettingEntity } from '@mezon/store-mobile';
 import {
 	defaultNotificationCategoryActions,
 	notificationSettingActions,
@@ -21,12 +23,21 @@ const NotificationSettingDetail = memo(({ route }: { route: any }) => {
 	const currentChannelId = notifyChannelCategorySetting?.id;
 	const currentClanId = useSelector(selectCurrentClanId);
 	const { t } = useTranslation(['clanNotificationsSetting']);
-	const [selectedOption, setSelectedOption] = useState(notifyChannelCategorySetting?.notification_setting_type);
+	const [selectedOption, setSelectedOption] = useState(
+		notifyChannelCategorySetting?.type || notifyChannelCategorySetting?.notification_setting_type
+	);
 	const { themeValue } = useTheme();
 	const dispatch = useAppDispatch();
 	const styles = style(themeValue);
 	const title = useMemo(() => {
 		return notifyChannelCategorySetting?.channel_category_title || notifyChannelCategorySetting?.title;
+	}, [notifyChannelCategorySetting]);
+
+	const label = useMemo(() => {
+		return (
+			(notifyChannelCategorySetting as ICategoryChannelOption)?.label ||
+			(notifyChannelCategorySetting as NotiChannelCategorySettingEntity)?.channel_category_label
+		);
 	}, [notifyChannelCategorySetting]);
 
 	useEffect(() => {
@@ -51,7 +62,9 @@ const NotificationSettingDetail = memo(({ route }: { route: any }) => {
 					defaultNotificationCategoryActions.setDefaultNotificationCategory({
 						category_id: currentChannelId,
 						notification_type: value,
-						clan_id: currentClanId || ''
+						clan_id: currentClanId || '',
+						title,
+						label
 					})
 				);
 			}
@@ -60,12 +73,14 @@ const NotificationSettingDetail = memo(({ route }: { route: any }) => {
 					notificationSettingActions.setNotificationSetting({
 						channel_id: currentChannelId,
 						notification_type: value,
-						clan_id: currentClanId || ''
+						clan_id: currentClanId || '',
+						title,
+						label
 					})
 				);
 			}
 		},
-		[title, currentChannelId, currentClanId, dispatch]
+		[title, currentChannelId, currentClanId, label, dispatch]
 	);
 
 	const handleRemoveOverride = useCallback(() => {

--- a/apps/mobile/src/app/screens/home/homedrawer/components/ClanMenu/ClanMenu/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/ClanMenu/ClanMenu/index.tsx
@@ -4,6 +4,7 @@ import { baseColor, useTheme } from '@mezon/mobile-ui';
 import {
 	appActions,
 	categoriesActions,
+	defaultNotificationCategoryActions,
 	selectCurrentClanId,
 	selectCurrentClanLogo,
 	selectCurrentClanName,
@@ -74,9 +75,10 @@ export default function ClanMenu() {
 	}, [navigation]);
 
 	const handelOpenNotifications = useCallback(() => {
+		dispatch(defaultNotificationCategoryActions.fetchChannelCategorySetting({ clanId: currentClanId || '' }));
 		DeviceEventEmitter.emit(ActionEmitEvent.ON_TRIGGER_BOTTOM_SHEET, { isDismiss: true });
 		navigation.navigate(APP_SCREEN.MENU_CLAN.STACK, { screen: APP_SCREEN.MENU_CLAN.NOTIFICATION_SETTING });
-	}, [navigation]);
+	}, [navigation, currentClanId]);
 
 	const organizationMenu: IMezonMenuItemProps[] = [
 		{


### PR DESCRIPTION
251128-MOBILE-Fix notification setting not sync after update and miss channel name when add mobile
Issue: https://github.com/mezonai/mezon/issues/10918
Change: update dependencies for press item after change, add title and label when add new channel or category to list override notification.

https://github.com/user-attachments/assets/78014bf3-f99d-46b7-bd5a-f6e8b391b935

