### PR TITLE
251201 - WEB/DESKTOP - fix download video

### DIFF
--- a/libs/components/src/lib/components/MessageWithUser/MessageVideo.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/MessageVideo.tsx
@@ -63,14 +63,27 @@ function MessageVideo({ attachmentData, isMobile = false, isPreview = false }: M
 		};
 	}, []);
 
-	const handleDownloadVideo = () => {
+	const handleDownloadVideo = async () => {
 		if (attachmentData.url) {
-			const a = document.createElement('a');
-			a.href = attachmentData.url;
-			a.download = attachmentData.filename || 'video';
-			document.body.appendChild(a);
-			a.click();
-			document.body.removeChild(a);
+			try {
+				const response = await fetch(attachmentData.url, {
+					mode: 'cors'
+				});
+
+				if (!response.ok) throw new Error('Network response was not ok');
+				const blob = await response.blob();
+
+				const blobUrl = URL.createObjectURL(blob);
+				const a = document.createElement('a');
+				a.href = blobUrl;
+				a.download = attachmentData.filename || 'video';
+				document.body.appendChild(a);
+				a.click();
+				document.body.removeChild(a);
+				URL.revokeObjectURL(blobUrl);
+			} catch (err) {
+				console.error('Download failed:', err);
+			}
 		}
 	};
 


### PR DESCRIPTION
###  Desciption 
- Some servers don’t serve a static file but instead stream the video in chunks.

- The URL might be like https://server.com/video.m3u8 or a .mp4 served as stream.

- When you try to use <a download> directly on a streaming URL, the browser may open the video in a new tab instead of downloading it.
### Changes 

- Fecth url video then add to blob download
### Ticket

- [Desktop/Website[ Check btn Download video
[#10963](https://github.com/mezonai/mezon/issues/10963)