### PR TITLE
251201-WEB/DESKTOP-Fix/threads/close create window on delete

### DIFF
--- a/libs/core/src/lib/chat/contexts/ChatContext.tsx
+++ b/libs/core/src/lib/chat/contexts/ChatContext.tsx
@@ -1652,6 +1652,22 @@ const ChatContextProvider: React.FC<ChatContextProviderProps> = ({ children, isM
 
 			dispatch(voiceActions.removeInVoiceInChannel(channelDeleted?.channel_id));
 			dispatch(appActions.clearHistoryChannel({ channelId: channelDeleted.channel_id }));
+			dispatch(
+				threadsActions.setIsShowCreateThread({
+					channelId: channelDeleted.channel_id as string,
+					isShowCreateThread: false
+				})
+			);
+
+			if (channelDeleted?.parent_id) {
+				dispatch(
+					threadsActions.setIsShowCreateThread({
+						channelId: channelDeleted.parent_id as string,
+						isShowCreateThread: false
+					})
+				);
+			}
+
 			const isVoiceJoined = selectVoiceInfo(store.getState());
 			if (channelDeleted?.channel_id === isVoiceJoined?.channelId) {
 				//Leave Room If It's been deleted

--- a/libs/core/src/lib/chat/hooks/useChannels.ts
+++ b/libs/core/src/lib/chat/hooks/useChannels.ts
@@ -7,6 +7,7 @@ import {
 	selectCurrentChannelId,
 	selectCurrentClanId,
 	selectDefaultChannelIdByClanId,
+	selectIsShowCreateThread,
 	selectWelcomeChannelByClanId,
 	threadsActions,
 	useAppDispatch
@@ -21,6 +22,7 @@ export function useChannels() {
 	const currentClanId = useSelector(selectCurrentClanId);
 	const currentChannelId = useSelector(selectCurrentChannelId);
 	const dispatch = useAppDispatch();
+	const isShowCreateThread = useSelector((state) => selectIsShowCreateThread(state, currentChannelId as string));
 
 	const handleConfirmDeleteChannel = async (channelId: string, clanId: string) => {
 		const store = getStore();
@@ -50,6 +52,15 @@ export function useChannels() {
 		await dispatch(channelsActions.deleteChannel({ channelId, clanId: clanId as string }));
 
 		if (isThread && channelToDelete?.parent_id) {
+			if (isShowCreateThread) {
+				dispatch(
+					threadsActions.setIsShowCreateThread({
+						channelId: currentChannelId as string,
+						isShowCreateThread: false
+					})
+				);
+			}
+
 			await dispatch(threadsActions.remove(channelId));
 			await dispatch(
 				threadsActions.removeThreadFromCache({


### PR DESCRIPTION
Task : [Desktop/Website] Create thread window remains visible after deleting thread
[#10960](https://github.com/mezonai/mezon/issues/10960)

Demo : |

https://github.com/user-attachments/assets/28151d50-dae8-43b1-8b21-8d8504a1f5bb

