### PR TITLE
251203-MOBILE-Fix footer overflow embed message mobile

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/components/EmbedMessage/EmbedFooter/styles.ts
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/EmbedMessage/EmbedFooter/styles.ts
@@ -6,6 +6,8 @@ export const style = (colors: Attributes) =>
 		container: {
 			flexDirection: 'row',
 			alignItems: 'center',
+			flexWrap: 'wrap',
+			flexShrink: 1,
 			gap: size.s_6
 		},
 		text: {


### PR DESCRIPTION
251203-MOBILE-Fix footer overflow embed message mobile
Issue: https://github.com/mezonai/mezon/issues/11002
<img width="367" height="436" alt="image" src="https://github.com/user-attachments/assets/28ec2859-5247-4119-bac3-a0d4ff781fc3" />
