### PR TITLE
251209-MOBILE-Fix get emotions list when join new clan mobile

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/Discover/DiscoverDetailScreen.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/Discover/DiscoverDetailScreen.tsx
@@ -1,8 +1,7 @@
 import { ActionEmitEvent, remove, save, STORAGE_CHANNEL_CURRENT_CACHE, STORAGE_CLAN_ID } from '@mezon/mobile-components';
 import type { Attributes } from '@mezon/mobile-ui';
 import { baseColor, size, useTheme } from '@mezon/mobile-ui';
-import { clansActions, inviteActions } from '@mezon/store';
-import { getStoreAsync, useAppDispatch } from '@mezon/store-mobile';
+import { clansActions, emojiSuggestionActions, getStoreAsync, inviteActions, settingClanStickerActions, useAppDispatch } from '@mezon/store-mobile';
 import type { ApiClanDiscover, ApiInviteUserRes } from 'mezon-js/api.gen';
 import moment from 'moment/moment';
 import React, { memo, useState } from 'react';
@@ -255,6 +254,8 @@ const DiscoverDetailScreen: React.FC<DiscoverDetailScreenProps> = ({ clanDetail 
 				await store.dispatch(clansActions.fetchClans({ noCache: true, isMobile: true }));
 				store.dispatch(clansActions.joinClan({ clanId: payload?.clan_id }));
 				store.dispatch(clansActions.changeCurrentClan({ clanId: payload?.clan_id }));
+				store.dispatch(emojiSuggestionActions.fetchEmoji({ clanId: payload?.clan_id, noCache: true }));
+				store.dispatch(settingClanStickerActions.fetchStickerByUserId({ noCache: true, clanId: payload?.clan_id }));
 				DeviceEventEmitter.emit(ActionEmitEvent.ON_TRIGGER_MODAL, { isDismiss: true });
 			}
 			setLoadingJoinClan(false);

--- a/apps/mobile/src/app/screens/home/homedrawer/components/JoinClanModal/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/JoinClanModal/index.tsx
@@ -8,7 +8,7 @@ import {
 	validLinkInviteRegex
 } from '@mezon/mobile-components';
 import { size, useTheme } from '@mezon/mobile-ui';
-import { clansActions, getStoreAsync, inviteActions } from '@mezon/store-mobile';
+import { clansActions, emojiSuggestionActions, getStoreAsync, inviteActions, settingClanStickerActions } from '@mezon/store-mobile';
 import type { ApiInviteUserRes } from 'mezon-js/api.gen';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -44,6 +44,8 @@ const JoinClanModal = () => {
 				save(STORAGE_CLAN_ID, payload.clan_id);
 				store.dispatch(clansActions.joinClan({ clanId: payload.clan_id }));
 				store.dispatch(clansActions.changeCurrentClan({ clanId: payload.clan_id }));
+				store.dispatch(emojiSuggestionActions.fetchEmoji({ clanId: payload?.clan_id, noCache: true }));
+				store.dispatch(settingClanStickerActions.fetchStickerByUserId({ noCache: true, clanId: payload?.clan_id }));
 				await store.dispatch(clansActions.fetchClans({ noCache: true, isMobile: true }));
 				DeviceEventEmitter.emit(ActionEmitEvent.ON_TRIGGER_MODAL, { isDismiss: true });
 			} else {

--- a/apps/mobile/src/app/screens/home/homedrawer/components/RenderMessageInvite/LinkInvite/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/RenderMessageInvite/LinkInvite/index.tsx
@@ -4,10 +4,12 @@ import { useTheme } from '@mezon/mobile-ui';
 import {
 	appActions,
 	clansActions,
+	emojiSuggestionActions,
 	getStoreAsync,
 	inviteActions,
 	selectInviteById,
 	selectInviteLoadingById,
+	settingClanStickerActions,
 	useAppDispatch,
 	useAppSelector
 } from '@mezon/store-mobile';
@@ -63,6 +65,8 @@ function LinkInvite({ inviteID }: { inviteID: string }) {
 					await store.dispatch(clansActions.fetchClans({ noCache: true, isMobile: true }));
 					store.dispatch(clansActions.joinClan({ clanId: res?.clan_id }));
 					store.dispatch(clansActions.changeCurrentClan({ clanId: res?.clan_id }));
+					store.dispatch(emojiSuggestionActions.fetchEmoji({ clanId: res?.clan_id, noCache: true }));
+					store.dispatch(settingClanStickerActions.fetchStickerByUserId({ noCache: true, clanId: res?.clan_id }));
 					save(STORAGE_CLAN_ID, res?.clan_id);
 					store.dispatch(appActions.setLoadingMainMobile(false));
 				});

--- a/apps/mobile/src/app/screens/inviteClan/InviteClanScreen.tsx
+++ b/apps/mobile/src/app/screens/inviteClan/InviteClanScreen.tsx
@@ -1,7 +1,17 @@
 import { useInvite } from '@mezon/core';
 import { STORAGE_CHANNEL_CURRENT_CACHE, STORAGE_CLAN_ID, remove, save } from '@mezon/mobile-components';
 import { size, useTheme } from '@mezon/mobile-ui';
-import { appActions, clansActions, getStoreAsync, inviteActions, selectInviteById, useAppDispatch, useAppSelector } from '@mezon/store-mobile';
+import {
+	appActions,
+	clansActions,
+	emojiSuggestionActions,
+	getStoreAsync,
+	inviteActions,
+	selectInviteById,
+	settingClanStickerActions,
+	useAppDispatch,
+	useAppSelector
+} from '@mezon/store-mobile';
 import { useNavigation } from '@react-navigation/native';
 import React, { useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -53,6 +63,8 @@ const InviteClanScreen = ({ route }: { route: any }) => {
 					await store.dispatch(clansActions.fetchClans({ noCache: true, isMobile: true }));
 					store.dispatch(clansActions.joinClan({ clanId: res?.clan_id }));
 					store.dispatch(clansActions.changeCurrentClan({ clanId: res?.clan_id }));
+					store.dispatch(emojiSuggestionActions.fetchEmoji({ clanId: res?.clan_id, noCache: true }));
+					store.dispatch(settingClanStickerActions.fetchStickerByUserId({ noCache: true, clanId: res?.clan_id }));
 					save(STORAGE_CLAN_ID, res?.clan_id);
 					store.dispatch(appActions.setLoadingMainMobile(false));
 					navigation.navigate(APP_SCREEN.BOTTOM_BAR);


### PR DESCRIPTION
251209-MOBILE-Fix get emotions list when join new clan mobile
Issue: https://github.com/mezonai/mezon/issues/11080
Change: handle fetch emoji and sticker list when join new clan.