### PR TITLE
251210-MOBILE-Fix resize component preview send forward message mobile

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/components/ForwardMessage/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/ForwardMessage/index.tsx
@@ -55,7 +55,6 @@ const MAX_RAW_TEXT_LENGTH = 2000;
 const ForwardMessageScreen = () => {
 	const [searchText, setSearchText] = useState('');
 	const [personalRawMessages, setPersonalRawMessages] = useState<string>('');
-	const [count, setCount] = useState('');
 
 	const navigation = useNavigation();
 	const route = useRoute();
@@ -311,7 +310,6 @@ const ForwardMessageScreen = () => {
 		} else {
 			selectedForwardObjectsRef.current = selectedForwardObjectsRef.current.filter((ob) => ob.channelId !== item.channelId);
 		}
-		setCount(selectedForwardObjectsRef.current?.length ? ` (${selectedForwardObjectsRef.current?.length})` : '');
 	}, []);
 
 	const renderForwardObject = ({ item }: { item: IForwardIObject }) => {
@@ -435,10 +433,7 @@ const ForwardMessageScreen = () => {
 						style={[styles.btn, !selectedForwardObjectsRef.current?.length && { backgroundColor: themeValue.textDisabled }]}
 						onPress={handleForward}
 					>
-						<Text style={styles.btnText} numberOfLines={1}>
-							{t('buzz.confirmText')}
-							{count}
-						</Text>
+						<MezonIconCDN icon={IconCDN.sendMessageIcon} color={baseColor.white} height={size.s_18} width={size.s_18} />
 					</TouchableOpacity>
 				</View>
 			</View>

--- a/apps/mobile/src/app/screens/home/homedrawer/components/ForwardMessage/styles.ts
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/ForwardMessage/styles.ts
@@ -14,12 +14,13 @@ export const style = (colors: Attributes) =>
 		},
 		btn: {
 			height: size.s_40,
+			width: size.s_40,
 			backgroundColor: baseColor.blurple,
 			justifyContent: 'center',
 			alignItems: 'center',
 			borderStartColor: 'red',
 			borderRadius: size.s_50,
-			paddingHorizontal: size.s_12
+			paddingHorizontal: size.s_10
 		},
 		btnText: {
 			color: 'white',
@@ -95,8 +96,9 @@ export const style = (colors: Attributes) =>
 			flex: 1
 		},
 		containerMessage: {
-			paddingTop: size.s_12,
-			paddingHorizontal: size.s_20,
+			paddingTop: size.s_8,
+			paddingLeft: size.s_20,
+			paddingRight: size.s_16,
 			flexDirection: 'row',
 			alignItems: 'center',
 			backgroundColor: colors.secondary,
@@ -110,7 +112,8 @@ export const style = (colors: Attributes) =>
 			backgroundColor: colors.secondary,
 			paddingHorizontal: size.s_6,
 			borderLeftWidth: size.s_2,
-			borderColor: colors.border
+			borderColor: colors.border,
+			paddingVertical: size.s_2
 		},
 		messageContentContainer: {
 			flex: 1,
@@ -122,7 +125,8 @@ export const style = (colors: Attributes) =>
 			minHeight: size.s_20
 		},
 		containerSendMessage: {
-			padding: size.s_16,
+			paddingHorizontal: size.s_16,
+			paddingVertical: size.s_12,
 			flexDirection: 'row',
 			alignItems: 'center',
 			justifyContent: 'space-between',

--- a/apps/mobile/src/app/screens/home/homedrawer/components/RenderForwardMedia/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/RenderForwardMedia/index.tsx
@@ -76,7 +76,7 @@ export const RenderForwardMedia = React.memo(({ attachment, count }: any) => {
 	if (checkIsVideo) {
 		return (
 			<View style={styles.fileViewer}>
-				<ImageNative url={thumbPath || attachment?.thumbnail_url} style={styles.video} />
+				<ImageNative url={thumbPath || attachment?.thumbnail_url} style={styles.image} />
 				<View style={styles.videoOverlay}>
 					<MezonIconCDN icon={IconCDN.playIcon} color={themeValue.bgViolet} />
 				</View>

--- a/apps/mobile/src/app/screens/home/homedrawer/components/RenderForwardMedia/styles.ts
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/RenderForwardMedia/styles.ts
@@ -4,8 +4,8 @@ import { StyleSheet } from 'react-native';
 export const style = (colors: Attributes) =>
 	StyleSheet.create({
 		fileViewer: {
-			width: size.s_60,
-			height: size.s_60,
+			width: size.s_50,
+			height: size.s_50,
 			alignItems: 'center',
 			justifyContent: 'center',
 			borderRadius: size.s_6,
@@ -48,13 +48,8 @@ export const style = (colors: Attributes) =>
 			color: baseColor.white
 		},
 		image: {
-			width: size.s_60,
-			height: size.s_60,
-			borderRadius: size.s_6
-		},
-		video: {
-			width: size.s_60,
-			height: size.s_60,
+			width: size.s_50,
+			height: size.s_50,
 			borderRadius: size.s_6
 		}
 	});


### PR DESCRIPTION
251210-MOBILE-Fix resize component preview send forward message mobile
Issue: https://github.com/mezonai/mezon/issues/11014
change styling for forward preview to reduce size of preview component and chat button.
<img width="431" height="936" alt="image" src="https://github.com/user-attachments/assets/9e28184a-4dfd-4948-898a-b84f3d615c62" />
