### PR TITLE
251218-MOBILE-Fix hide category emoji pannel

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/components/EmojiPicker/EmojiSelectorContainer/components/CategoryList/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/EmojiPicker/EmojiSelectorContainer/components/CategoryList/index.tsx
@@ -1,6 +1,7 @@
 import { useTheme } from '@mezon/mobile-ui';
-import { IEmoji } from '@mezon/utils';
-import { FC, memo, ReactNode, useState } from 'react';
+import type { IEmoji } from '@mezon/utils';
+import type { FC, ReactNode } from 'react';
+import { memo, useState } from 'react';
 import { Pressable, ScrollView } from 'react-native-gesture-handler';
 import { style } from '../../styles';
 
@@ -32,6 +33,9 @@ const CategoryList: FC<CategoryListProps> = ({ categoriesWithIcons, setSelectedC
 		>
 			{categoriesWithIcons?.length > 0 &&
 				categoriesWithIcons.map((item, index) => {
+					if (!item?.emojis?.length) {
+						return null;
+					}
 					return (
 						<Pressable
 							key={`${item.name}_cate_emoji${index}`}

--- a/apps/mobile/src/app/screens/home/homedrawer/components/EmojiPicker/EmojiSelectorContainer/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/EmojiPicker/EmojiSelectorContainer/index.tsx
@@ -1,6 +1,6 @@
 import { BottomSheetFlatList } from '@gorhom/bottom-sheet';
 import { useEmojiSuggestionContext } from '@mezon/core';
-import { ActionEmitEvent, debounce } from '@mezon/mobile-components';
+import { ActionEmitEvent, debounce, isEmpty } from '@mezon/mobile-components';
 import { size, useTheme } from '@mezon/mobile-ui';
 import { emojiSuggestionActions, getStore, selectCurrentTopicId, selectDmGroupCurrentId } from '@mezon/store-mobile';
 import type { IEmoji } from '@mezon/utils';
@@ -80,7 +80,6 @@ export default function EmojiSelectorContainer({
 			if (!emoji?.id || emoji?.is_for_sale) continue;
 			if (emoji?.category) {
 				categoriesEmoji.forEach((cat) => {
-					if (cat === FOR_SALE_CATE) return;
 					if (emoji?.category?.includes(cat)) {
 						const list = map.get(cat);
 						if (list) list.push(emoji);
@@ -228,6 +227,7 @@ export default function EmojiSelectorContainer({
 		};
 
 		categoriesEmoji.forEach((category) => {
+			if (isEmpty(emojisByCategory?.get(category))) return;
 			processCategory(category);
 		});
 


### PR DESCRIPTION
Issue: https://github.com/mezonai/mezon/issues/11232
### Change: hide category when category has no emoji. 
<img width="426" height="938" alt="image" src="https://github.com/user-attachments/assets/49b55af7-2a0e-4afb-a808-ecf77a361dbb" />
