### PR TITLE
251218-WEB/DESKTOP-Fixbug(dm-group): Fix incorrect DM group name when user has no display name

### DIFF
--- a/libs/components/src/lib/components/DmList/CreateMessageGroup/index.tsx
+++ b/libs/components/src/lib/components/DmList/CreateMessageGroup/index.tsx
@@ -106,7 +106,7 @@ const CreateMessageGroup = ({ onClose, classNames, currentDM, rootRef }: CreateM
 			});
 			if (currentDM?.type === ChannelType.CHANNEL_TYPE_DM) {
 				listGroupDM.push(currentDM.user_ids?.at(0) as string);
-				userNameGroup.push(currentDM.display_names?.at(0) as string);
+				userNameGroup.push((currentDM.display_names?.at(0) || currentDM.usernames?.at(0)) as string);
 				avatarGroup.push(currentDM.channel_avatar?.at(0) as string);
 			}
 			const bodyCreateDmGroup: ApiCreateChannelDescRequest = {

--- a/libs/store/src/lib/direct/direct.slice.ts
+++ b/libs/store/src/lib/direct/direct.slice.ts
@@ -457,7 +457,7 @@ export const addGroupUserWS = createAsyncThunk('direct/addGroupUserWS', async (p
 			usernames.push(user.username);
 			avatars.push(user.avatar);
 			onlines.push(user.online);
-			label.push(user.display_name);
+			label.push(user.display_name || user.username);
 		}
 
 		const state = thunkAPI.getState() as RootState;
@@ -581,7 +581,7 @@ export const directSlice = createSlice({
 			directAdapter.updateOne(state, {
 				id: action.payload.channelId,
 				changes: {
-					member_count: (currentDirect.member_count || 0) > 0 ? (currentDirect.member_count || 1) - 1 : 0
+					member_count: (currentDirect?.member_count || 0) > 0 ? (currentDirect?.member_count || 1) - 1 : 0
 				}
 			});
 		},


### PR DESCRIPTION
Task : [Desktop/Website] Show incorrect Dm group name by creating with user has not set display name
[#11267](https://github.com/mezonai/mezon/issues/11267)

Demo : 

https://github.com/user-attachments/assets/189da69e-38c0-49a3-b6db-4d558a94fcb7

