### PR TITLE
251219-MOBILE-Fix leave clan still show channel hashtag

### DIFF
--- a/libs/core/src/lib/chat/contexts/ChatContext.tsx
+++ b/libs/core/src/lib/chat/contexts/ChatContext.tsx
@@ -929,6 +929,7 @@ const ChatContextProvider: React.FC<ChatContextProviderProps> = ({ children, isM
 					dispatch(clansSlice.actions.removeByClanID(user.clan_id));
 					dispatch(listChannelsByUserActions.remove(id));
 					dispatch(appActions.cleanHistoryClan(user.clan_id));
+					dispatch(channelsActions.removeByClanId(user.clan_id));
 				}
 				dispatch(
 					channelMembersActions.removeUserByUserIdAndClan({
@@ -1631,6 +1632,7 @@ const ChatContextProvider: React.FC<ChatContextProviderProps> = ({ children, isM
 			dispatch(stickerSettingActions.removeStickersByClanId(clanDelete.clan_id));
 			dispatch(emojiSuggestionActions.invalidateCache());
 			dispatch(stickerSettingActions.invalidateCache());
+			dispatch(channelsActions.removeByClanId(clanDelete.clan_id));
 			if (clanDelete.deletor !== userId && currentClanId === clanDelete.clan_id) {
 				if (isMobile) {
 					const isVoiceJoined = selectVoiceInfo(store.getState());
@@ -2938,3 +2940,4 @@ const ChatContextConsumer = ChatContext.Consumer;
 ChatContextProvider.displayName = 'ChatContextProvider';
 
 export { ChatContext, ChatContextConsumer, ChatContextProvider, MobileEventEmitter };
+

--- a/libs/store/src/lib/channels/channels.slice.ts
+++ b/libs/store/src/lib/channels/channels.slice.ts
@@ -1514,6 +1514,11 @@ export const channelsSlice = createSlice({
 			if (state.byClans[clanId]?.entities) {
 				channelsAdapter.removeMany(state.byClans[clanId].entities, channelIds);
 			}
+		},
+
+		removeByClanId: (state, action: PayloadAction<string>) => {
+			const clanId = action.payload;
+			delete state.byClans[clanId];
 		}
 	},
 	extraReducers: (builder) => {


### PR DESCRIPTION
Issue: https://github.com/mezonai/mezon/issues/11126
### change: update logic remove channel entities when leave clan.

https://github.com/user-attachments/assets/228d8053-b61d-48ea-ba15-8821d9b2a9b1

