### PR TITLE
251222-WEB/DESKTOP-fix(inbox): incorrect timestamp when adding message to inbox

### DIFF
--- a/libs/store/src/lib/notification/notify.slice.ts
+++ b/libs/store/src/lib/notification/notify.slice.ts
@@ -294,7 +294,7 @@ export const notificationSlice = createSlice({
 							...message,
 							id: noti.id || '',
 							...noti,
-							create_time: safeJSONParse(noti.content || '').create_time,
+							create_time: new Date().toISOString(),
 							content: safeJSONParse(noti.content || ''),
 							category: NotificationCategory.MESSAGES
 						};


### PR DESCRIPTION
Task : [Desktop/Website] Timestamp message adding to inbox is not correctly
[#11240](https://github.com/mezonai/mezon/issues/11240)

Demo : 

https://github.com/user-attachments/assets/937cce9f-ec51-426c-ab79-ca3902875126

