### PR TITLE
251222-MOBILE-handle config anonymous overview setting clan

### DIFF
--- a/libs/store/src/lib/clans/clans.slice.ts
+++ b/libs/store/src/lib/clans/clans.slice.ts
@@ -999,6 +999,7 @@ export const selectCurrentClanIsOnboarding = createSelector(selectCurrentClan, (
 export const selectCurrentClanWelcomeChannelId = createSelector(selectCurrentClan, (clan) => clan?.welcome_channel_id);
 export const selectCurrentClanBadgeCount = createSelector(selectCurrentClan, (clan) => clan?.badge_count ?? 0);
 export const selectCurrentClanIsCommunity = createSelector(selectCurrentClan, (clan) => clan?.is_community);
+export const selectCurrentClanPreventAnonymous = createSelector(selectCurrentClan, (clan) => clan?.prevent_anonymous ?? false);
 
 export const selectDefaultClanId = createSelector(selectAllClans, (clans) => (clans.length > 0 ? clans[0].id : null));
 export const selectOrderedClans = createSelector([selectAllClans, (state: RootState) => state.clans.clansOrder], (clans, order) => {

--- a/libs/translations/src/languages/en/clanOverviewSetting.json
+++ b/libs/translations/src/languages/en/clanOverviewSetting.json
@@ -30,7 +30,9 @@
 			"welcomeSticker": "Prompt members to reply to welcome messages with a sticker",
 			"boostMessage": "Send a messages when someone boosts this clan",
 			"setupTips": "Send helpful tips for clan setup",
-			"hideAuditLog": "Send a log when an action is applied to the clan"
+			"hideAuditLog": "Send a log when an action is applied to the clan",
+			"anonymousTitle": "Prevent Anonymous",
+			"anonymousDescription": "Prevent users from using anonymous mode"
 		},
 		"deleteServer": {
 			"title": "Delete Clan",

--- a/libs/translations/src/languages/vi/clanOverviewSetting.json
+++ b/libs/translations/src/languages/vi/clanOverviewSetting.json
@@ -30,7 +30,9 @@
       "welcomeSticker": "Yêu cầu thành viên trả lời tin nhắn chào mừng bằng nhãn dán",
       "boostMessage": "Gửi tin nhắn khi ai đó tăng cấp clan này",
       "setupTips": "Gửi các mẹo hữu ích để thiết lập clan",
-      "hideAuditLog": "Gửi nhật ký khi có hành động được thực hiện với clan"
+      "hideAuditLog": "Gửi nhật ký khi có hành động được thực hiện với clan",
+      "anonymousTitle": "Ngăn chặn chế độ ẩn danh",
+      "anonymousDescription": "Ngăn người dùng sử dụng chế độ ẩn danh"
     },
     "deleteServer": {
       "title": "Xóa clan",


### PR DESCRIPTION
Issue: https://github.com/mezonai/mezon/issues/11242
Expected:
- Show switch to toggle prevent option anonymous in clan setting overview(owner and administrator)
- User in clan prevent action anonymous can not send anonymous message.


https://github.com/user-attachments/assets/e22761a1-b29b-4be0-a7e4-dde470e5945d

