### PR TITLE
251223-WEB/DESKTOP-Fix: limit file size modal not show after reselect large file

### DIFF
--- a/libs/components/src/lib/components/ClanSettings/ClanSettingOverview/ClanLogoName/index.tsx
+++ b/libs/components/src/lib/components/ClanSettings/ClanSettingOverview/ClanLogoName/index.tsx
@@ -38,6 +38,7 @@ const ClanLogoName = ({ onUpload, onGetClanName, resetTrigger, onResetComplete, 
 		if (!file) return;
 		if (file.size > MAX_FILE_SIZE_1MB) {
 			setOpenSizeModal(true);
+			e.target.value = null;
 			return;
 		}
 		if (!client || !session) {

--- a/libs/components/src/lib/components/ClanSettings/Integrations/ClanWebhooks/ClanWebhookItemModal/index.tsx
+++ b/libs/components/src/lib/components/ClanSettings/Integrations/ClanWebhooks/ClanWebhookItemModal/index.tsx
@@ -128,10 +128,12 @@ const ExpendedClanWebhookModal = ({ webhookItem }: IExpendedClanWebhookModal) =>
 			if (!file) return;
 			if (file.size > MAX_FILE_SIZE_8MB) {
 				setOpenModal(true);
+				e.target.value = '';
 				return;
 			}
 			if (!fileTypeImage.includes(file.type)) {
 				setOpenTypeModal(true);
+				e.target.value = '';
 				return;
 			}
 			const client = clientRef.current;

--- a/libs/components/src/lib/components/ClanSettings/Integrations/Webhooks/WebhookItemModal/index.tsx
+++ b/libs/components/src/lib/components/ClanSettings/Integrations/Webhooks/WebhookItemModal/index.tsx
@@ -142,10 +142,12 @@ const ExpendedWebhookModal = ({ webhookItem, currentChannel, isClanSetting }: IE
 			if (!file) return;
 			if (file.size > MAX_FILE_SIZE_8MB) {
 				setOpenModal(true);
+				e.target.value = '';
 				return;
 			}
 			if (!fileTypeImage.includes(file.type)) {
 				setOpenTypeModal(true);
+				e.target.value = '';
 				return;
 			}
 			const client = clientRef.current;

--- a/libs/components/src/lib/components/ClanSettings/SettingOnBoarding/Mission/ModalAddRule.tsx
+++ b/libs/components/src/lib/components/ClanSettings/SettingOnBoarding/Mission/ModalAddRule.tsx
@@ -139,11 +139,13 @@ const ModalAddRules = ({ onClose, ruleEdit, tempId }: { onClose: () => void; rul
 			const file = event.target.files[0];
 			if (!fileTypeImage.includes(file.type)) {
 				setOpenTypeModal(true);
+				event.target.value = '';
 				return;
 			}
 
 			if (file.size > MAX_FILE_SIZE_10MB) {
 				setOpenModal(true);
+				event.target.value = '';
 				return;
 			}
 

--- a/libs/components/src/lib/components/ModalEditGroup/index.tsx
+++ b/libs/components/src/lib/components/ModalEditGroup/index.tsx
@@ -83,10 +83,12 @@ const ModalEditGroup: React.FC<ModalEditGroupProps> = ({
 		if (!file) return;
 		if (file.size > MAX_FILE_SIZE_8MB) {
 			setOpenModal(true);
+			event.target.value = '';
 			return;
 		}
 		if (!fileTypeImage.includes(file.type)) {
 			setOpenTypeModal(true);
+			event.target.value = '';
 			return;
 		}
 		if (file && onImageUpload) {

--- a/libs/components/src/lib/components/SettingComunity/index.tsx
+++ b/libs/components/src/lib/components/SettingComunity/index.tsx
@@ -75,10 +75,12 @@ const SettingComunity = ({
 
 		if (file.size > MAX_FILE_SIZE_10MB) {
 			setOpenModal(true);
+			e.target.value = '';
 			return;
 		}
 		if (!fileTypeImage.includes(file.type)) {
 			setOpenTypeModal(true);
+			e.target.value = '';
 			return;
 		}
 

--- a/libs/components/src/lib/components/SettingProfile/SettingRightClanProfile/SettingUserClanProfileEdit.tsx
+++ b/libs/components/src/lib/components/SettingProfile/SettingRightClanProfile/SettingUserClanProfileEdit.tsx
@@ -101,10 +101,12 @@ const SettingUserClanProfileEdit: React.FC<SettingUserClanProfileEditProps> = ({
 		if (!file) return;
 		if (!fileTypeImage.includes(file.type)) {
 			setOpenModalType(true);
+			e.target.value = '';
 			return;
 		}
 		if (file.size > MAX_FILE_SIZE_10MB) {
 			setOpenModal(true);
+			e.target.value = '';
 			return;
 		}
 		if (file.type === fileTypeImage[2]) {

--- a/libs/components/src/lib/components/SettingProfile/SettingRightUserProfile/index.tsx
+++ b/libs/components/src/lib/components/SettingProfile/SettingRightUserProfile/index.tsx
@@ -132,6 +132,7 @@ const SettingRightUser = ({
 		if (!file) return;
 		if (!fileTypeImage.includes(file.type)) {
 			setOpenModalType(true);
+			e.target.value = '';
 			return;
 		}
 		if (file.size > MAX_FILE_SIZE_10MB) {


### PR DESCRIPTION
Task : [Desktop/Website] Limit file size modal doesn't display after rechoosing large file size
[#11309](https://github.com/mezonai/mezon/issues/11309)

Demo : 

https://github.com/user-attachments/assets/72ab2c66-ee5a-49c1-bf75-b67bdf034905

