### PR TITLE
251225-MOBILE-Show role icon in suggestion input

### DIFF
--- a/apps/mobile/src/app/components/Suggestions/SuggestItem/SuggestItem.styles.ts
+++ b/apps/mobile/src/app/components/Suggestions/SuggestItem/SuggestItem.styles.ts
@@ -26,6 +26,11 @@ export const style = (colors: Attributes) =>
 			height: size.s_30,
 			borderRadius: 50
 		},
+		roleImage: {
+			width: size.s_20,
+			height: size.s_20,
+			borderRadius: size.s_20
+		},
 		symbol: {
 			fontSize: size.label,
 			fontWeight: '600',

--- a/apps/mobile/src/app/components/Suggestions/SuggestItem/index.tsx
+++ b/apps/mobile/src/app/components/Suggestions/SuggestItem/index.tsx
@@ -55,7 +55,22 @@ const SuggestItem = memo(
 			<View>
 				{isRoleUser && (
 					<View style={{ flexDirection: 'row', alignItems: 'center', gap: size.s_10 }}>
-						<MezonIconCDN icon={IconCDN.shieldUserIcon} color={color ?? themeValue.textRoleLink} width={size.s_20} height={size.s_20} />
+						{avatarUrl ? (
+							<FastImage
+								style={styles.roleImage}
+								source={{
+									uri: createImgproxyUrl(avatarUrl ?? '', { width: 100, height: 100, resizeType: 'fit' })
+								}}
+							/>
+						) : (
+							<MezonIconCDN
+								icon={IconCDN.shieldUserIcon}
+								color={color ?? themeValue.textRoleLink}
+								width={size.s_20}
+								height={size.s_20}
+							/>
+						)}
+
 						<Text style={[styles.roleText, { color: color ?? themeValue.textRoleLink }]}>{`${name}`}</Text>
 					</View>
 				)}
@@ -73,7 +88,7 @@ const SuggestItem = memo(
 		return (
 			<View style={styles.wrapperItem}>
 				<View style={styles.containerItem}>
-					{avatarUrl ? (
+					{avatarUrl && !isRoleUser ? (
 						<FastImage
 							style={styles.image}
 							source={{

--- a/apps/mobile/src/app/hooks/useUserMentionList.ts
+++ b/apps/mobile/src/app/hooks/useUserMentionList.ts
@@ -58,7 +58,7 @@ const transformRoleToMention = (item: ApiRole): MentionDataProps | null => {
 	return {
 		id: item.id,
 		display: item.title,
-		avatarUrl: '',
+		avatarUrl: item?.role_icon || '',
 		clanNick: item.title,
 		isRoleUser: true,
 		color: item.color


### PR DESCRIPTION
Issue: https://github.com/mezonai/mezon/issues/11365
### Change: show image icon if role have role icon.
<img width="893" height="286" alt="image" src="https://github.com/user-attachments/assets/33472713-6004-4384-a37e-89080bf5a76f" />
