### PR TITLE
251225-WEB/DESKTOP-Fixbug(inbox) first message not visible in inbox

### DIFF
--- a/libs/store/src/lib/notification/notify.slice.ts
+++ b/libs/store/src/lib/notification/notify.slice.ts
@@ -288,7 +288,7 @@ export const notificationSlice = createSlice({
 			.addCase(
 				markMessageNotify.fulfilled,
 				(state: NotificationState, action: PayloadAction<{ noti: ApiChannelMessageHeader; message: MessagesEntity }>) => {
-					if (state.notifications[NotificationCategory.MESSAGES].data.length) {
+					if (state.notifications[NotificationCategory.MESSAGES].data) {
 						const { noti, message } = action.payload;
 						const notiMark: INotification = {
 							...message,


### PR DESCRIPTION
Issue : The first message added to the inbox doesn't show up 

Demo : 

<img width="388" height="192" alt="image" src="https://github.com/user-attachments/assets/aad188db-ab08-461b-9a0a-de03a9925fd0" />
