### PR TITLE
251230-MOBILE-Fix jump notification clan have leave before

### DIFF
--- a/apps/mobile/src/app/screens/Notifications/index.tsx
+++ b/apps/mobile/src/app/screens/Notifications/index.tsx
@@ -9,6 +9,7 @@ import {
 	getStoreAsync,
 	messagesActions,
 	notificationActions,
+	selectClanById,
 	selectCurrentClanId,
 	selectNotificationClan,
 	selectNotificationForYou,
@@ -24,6 +25,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next';
 import { ActivityIndicator, DeviceEventEmitter, FlatList, Pressable, StyleSheet, Text, View } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
+import Toast from 'react-native-toast-message';
 import { useSelector } from 'react-redux';
 import MezonIconCDN from '../../componentUI/MezonIconCDN';
 import { IconCDN } from '../../constants/icon_cdn';
@@ -139,6 +141,12 @@ const Notifications = ({ navigation, route }) => {
 		async (notify: INotification, currentClanId: string, store: any, navigation: any): Promise<void> => {
 			return new Promise<void>((resolve) => {
 				requestAnimationFrame(async () => {
+					const state = store.getState();
+					const clanById = selectClanById(notify?.content?.clan_id || '')(state);
+					if (!clanById) {
+						Toast.show({ type: 'error', text1: t('unknowClan') });
+						return resolve();
+					}
 					const isTopic =
 						Number(notify?.content?.topic_id) !== 0 ||
 						notify?.content?.code === TypeMessage.Topic ||

--- a/libs/translations/src/languages/en/notification.json
+++ b/libs/translations/src/languages/en/notification.json
@@ -40,5 +40,6 @@
     "ok": "OK"
   },
   "andYou": "and you",
-  "topicAndYou": "Topic and you"
+  "topicAndYou": "Topic and you",
+  "unknowClan": "You are not a member of this clan anymore"
 }

--- a/libs/translations/src/languages/vi/notification.json
+++ b/libs/translations/src/languages/vi/notification.json
@@ -40,5 +40,6 @@
 		"ok": "OK"
 	},
 	"andYou": "và bạn",
-	"topicAndYou": "Thảo luận ngắn và bạn"
+	"topicAndYou": "Thảo luận ngắn và bạn",
+	"unknowClan": "Bạn không còn là thành viên của clan này nữa"
 }


### PR DESCRIPTION
Issue: https://github.com/mezonai/mezon/issues/11378
### change: prevent jump action for notification when clan by clan id not available

https://github.com/user-attachments/assets/201bec9b-c2c7-43aa-8c13-30856d84b94c

