### PR TITLE
251230 - WEB/DESKTOP - task/voice-channel/fix-hashtag-display

### DIFF
--- a/libs/components/src/lib/components/MarkdownFormatText/HashTag.tsx
+++ b/libs/components/src/lib/components/MarkdownFormatText/HashTag.tsx
@@ -51,9 +51,11 @@ const ChannelHashtag = ({ channelHastagId, isJumMessageEnabled, isTokenClickAble
 	const isStreamingChannel = currentChannelType === ChannelType.CHANNEL_TYPE_STREAMING;
 	const isThreadChannel = currentChannelType === ChannelType.CHANNEL_TYPE_THREAD;
 	const isAppChannel = currentChannelType === ChannelType.CHANNEL_TYPE_APP;
+	const isVoiceChannel = currentChannelType === ChannelType.CHANNEL_TYPE_MEZON_VOICE;
 
 	const existHashtagAndChannelView = channelHastagId && !isClanView;
-	const isValidChannel = (isTextChannel || isStreamingChannel || isThreadChannel || existHashtagAndChannelView || isAppChannel) && channel;
+	const isValidChannel =
+		(isTextChannel || isStreamingChannel || isThreadChannel || isVoiceChannel || existHashtagAndChannelView || isAppChannel) && channel;
 
 	return channel ? (
 		isValidChannel ? (


### PR DESCRIPTION
Fix issue #11245: Enable hashtag channel links to be displayed and sent in voice channel chatbox.

Changes:
- Allow CHANNEL_TYPE_MEZON_VOICE to display channel hashtags t