### PR TITLE
251231-MOBILE-fix edit message fill duplicate input

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/components/ChatBox/ChatBoxBottomBar/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/ChatBox/ChatBoxBottomBar/index.tsx
@@ -608,7 +608,7 @@ export const ChatBoxBottomBar = memo(
 		}, [channelId]);
 
 		useEffect(() => {
-			if (messageActionNeedToResolve !== null) {
+			if (messageActionNeedToResolve !== null && messageActionNeedToResolve?.targetMessage?.channel_id === channelId) {
 				const { isStillShowKeyboard } = messageActionNeedToResolve;
 				if (!isStillShowKeyboard) {
 					resetInput();
@@ -616,7 +616,7 @@ export const ChatBoxBottomBar = memo(
 				handleMessageAction(messageActionNeedToResolve);
 				openKeyBoard();
 			}
-		}, [messageActionNeedToResolve]);
+		}, [channelId, messageActionNeedToResolve]);
 
 		useEffect(() => {
 			const clearTextInputListener = DeviceEventEmitter.addListener(ActionEmitEvent.CLEAR_TEXT_INPUT, () => {

--- a/apps/mobile/src/app/screens/home/homedrawer/components/ChatBox/ChatBoxBottomBar/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/ChatBox/ChatBoxBottomBar/index.tsx
@@ -608,7 +608,11 @@ export const ChatBoxBottomBar = memo(
 		}, [channelId]);
 
 		useEffect(() => {
-			if (messageActionNeedToResolve !== null && messageActionNeedToResolve?.targetMessage?.channel_id === channelId) {
+			if (
+				messageActionNeedToResolve !== null &&
+				(messageActionNeedToResolve?.targetMessage?.channel_id === channelId ||
+					messageActionNeedToResolve?.targetMessage?.channel_id === topicChannelId)
+			) {
 				const { isStillShowKeyboard } = messageActionNeedToResolve;
 				if (!isStillShowKeyboard) {
 					resetInput();
@@ -616,7 +620,7 @@ export const ChatBoxBottomBar = memo(
 				handleMessageAction(messageActionNeedToResolve);
 				openKeyBoard();
 			}
-		}, [channelId, messageActionNeedToResolve]);
+		}, [channelId, messageActionNeedToResolve, topicChannelId]);
 
 		useEffect(() => {
 			const clearTextInputListener = DeviceEventEmitter.addListener(ActionEmitEvent.CLEAR_TEXT_INPUT, () => {


### PR DESCRIPTION
Issue: https://github.com/mezonai/mezon/issues/11444
### change: check channel id before handle fill input message

https://github.com/user-attachments/assets/29acf8b0-a365-4a88-a0f4-4c7bdeaf2c2f

