### PR TITLE
260102-WEB/MOBILE-Fix group add lost group name

### DIFF
--- a/libs/store/src/lib/direct/direct.slice.ts
+++ b/libs/store/src/lib/direct/direct.slice.ts
@@ -453,7 +453,7 @@ export const addGroupUserWS = createAsyncThunk('direct/addGroupUserWS', async (p
 			avatars,
 			onlines,
 			active: 1,
-			channel_label: existingEntity?.channel_label || label.toString(),
+			channel_label: channel_desc?.channel_label || existingEntity?.channel_label || label.toString(),
 			topic: channel_desc.topic || existingEntity?.topic,
 			member_count: channel_desc.member_count
 		};


### PR DESCRIPTION
Issue: https://github.com/mezonai/mezon/issues/11490
### Change: add target add channel label to new group label.