### PR TITLE
fix(ci): resolve production build path and jsxDEV error

### DIFF
--- a/.github/workflows/deploy_fe_dev.yml
+++ b/.github/workflows/deploy_fe_dev.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -38,6 +38,8 @@ jobs:
           yarn nx reset
 
       - name: Build
+        env:
+          NODE_ENV: 'production'
         run: |
           echo "Build"
           echo NX_CHAT_APP_API_GW_HOST="${{ secrets.NX_CHAT_APP_API_GW_HOST_DEV }}" >> apps/chat/.env

--- a/apps/chat/vite.config.ts
+++ b/apps/chat/vite.config.ts
@@ -17,7 +17,7 @@ export default defineConfig(({ mode }) => {
 		root: path.join(appRoot, 'src'),
 		publicDir: mode === 'production' ? false : path.join(appRoot, 'src/assets'),
 		cacheDir: path.join(workspaceRoot, 'node_modules/.vite/apps/chat'),
-		base: './',
+		base: mode === 'production' ? '/' : './',
 
 		server: {
 			port: 4200,
@@ -36,6 +36,8 @@ export default defineConfig(({ mode }) => {
 
 		plugins: [
 			react({
+				jsxRuntime: 'automatic',
+				jsxImportSource: 'react',
 				babel: {
 					plugins: [
 						['@babel/plugin-proposal-decorators', { legacy: true }],


### PR DESCRIPTION
- Fix vite base path: use '/' for production, './' for development
- Set NODE_ENV=production for build step to use production React runtime