### PR TITLE
260120-web/desktop/fix cannot click outside to close image

### DIFF
--- a/libs/components/src/lib/components/ImagePreview/index.tsx
+++ b/libs/components/src/lib/components/ImagePreview/index.tsx
@@ -8,18 +8,26 @@ type ImagePreviewProps = {
 
 export const ImagePreview: React.FC<ImagePreviewProps> = ({ imageUrl, onClose }) => {
 	const containerRef = useRef<HTMLDivElement>(null);
+	const imageRef = useRef<HTMLImageElement>(null);
 
-	useOnClickOutside(containerRef, onClose);
+	useOnClickOutside(imageRef, onClose);
 
 	useEscapeKeyClose(containerRef, onClose);
+
+	const handleOverlayClick = (e: React.MouseEvent<HTMLDivElement>) => {
+		if (e.target === e.currentTarget) {
+			onClose();
+		}
+	};
 
 	return (
 		<div
 			ref={containerRef}
 			tabIndex={-1}
+			onClick={handleOverlayClick}
 			className="outline-none w-[100vw] h-[100vh] overflow-hidden fixed top-0 left-0 z-50 bg-black bg-opacity-80 flex flex-row justify-center items-center p-20"
 		>
-			<img src={imageUrl} alt="" className={'max-h-full w-auto max-w-full'} />
+			<img ref={imageRef} src={imageUrl} alt="" className={'max-h-full w-auto max-w-full'} />
 		</div>
 	);
 };


### PR DESCRIPTION
Desktop/Website] Cannot click outside to close image in embedding
[#11766](https://github.com/mezonai/mezon/issues/11766)