### PR TITLE
260122 - fix(web): fix input focus, state selectors, and event timestamps

### DIFF
--- a/libs/components/src/lib/components/ChannelList/EventChannelModal/ModalCreate/itemEventManagement.tsx
+++ b/libs/components/src/lib/components/ChannelList/EventChannelModal/ModalCreate/itemEventManagement.tsx
@@ -102,9 +102,9 @@ const ItemEventManagement = (props: ItemEventManagementProps) => {
 	const actualEventStatus = useMemo(() => {
 		if (!event?.start_time_seconds) return { isUpcoming: eventIsUpcomming, isOngoing: eventIsOngoing };
 
-		const startTime = event.start_time_seconds;
+		const startTime = event.start_time_seconds * 1000;
 		const currentTime = Date.now();
-		const endTime = event.end_time_seconds ? event.end_time_seconds : startTime + 2 * 60 * 60 * 1000;
+		const endTime = event.end_time_seconds ? event.end_time_seconds * 1000 : startTime + 2 * 60 * 60 * 1000;
 
 		const isActuallyUpcoming = currentTime < startTime;
 		const isActuallyOngoing = currentTime >= startTime && currentTime <= endTime;
@@ -162,7 +162,7 @@ const ItemEventManagement = (props: ItemEventManagementProps) => {
 	const timeUntilEvent = useMemo(() => {
 		if (!event?.start_time_seconds || !actualEventStatus.isUpcoming) return null;
 
-		const startTime = event.start_time_seconds;
+		const startTime = event.start_time_seconds * 1000;
 		const currentTime = Date.now();
 		const timeDiff = startTime - currentTime;
 		const minutesLeft = Math.ceil(timeDiff / (1000 * 60));

--- a/libs/components/src/lib/components/ChannelList/EventChannelModal/ModalCreate/modalDetailItemEvent.tsx
+++ b/libs/components/src/lib/components/ChannelList/EventChannelModal/ModalCreate/modalDetailItemEvent.tsx
@@ -104,7 +104,7 @@ const EventInfoDetail = (props: EventInfoDetailProps) => {
 	const currentClanName = useSelector(selectCurrentClanName);
 	const avatarClan = currentClanName?.charAt(0).toUpperCase();
 	const userCreate = useAppSelector((state) => selectMemberClanByUserId(state, event?.creator_id || ''));
-	const time = useMemo(() => timeFomat(event?.start_time_seconds || 0), [event?.start_time_seconds]);
+	const time = useMemo(() => timeFomat((event?.start_time_seconds || 0) * 1000), [event?.start_time_seconds]);
 
 	const { toChannelPage, navigate } = useAppNavigation();
 

--- a/libs/components/src/lib/components/ClanSettings/ClanSettingOverview/SystemMessagesManagement/index.tsx
+++ b/libs/components/src/lib/components/ClanSettings/ClanSettingOverview/SystemMessagesManagement/index.tsx
@@ -108,7 +108,7 @@ const SystemMessagesManagement = ({
 	return (
 		<div className={'border-t-theme-primary mt-10 pt-10 flex flex-col '}>
 			<h3 className="text-sm font-bold uppercase mb-2">{t('systemMessages.title')}</h3>
-			<Menu menu={menu} className={'h-fit max-h-[200px] text-xs overflow-y-scroll customSmallScrollLightMode bg-theme-input px-2 z-20'}>
+			<Menu menu={menu} className={'h-fit max-h-[200px] text-xs overflow-y-scroll customSmallScrollLightMode bg-theme-input px-2'}>
 				<div
 					className="w-full cursor-pointer  h-10 rounded-md flex flex-row p-3 justify-between items-center uppercase text-sm border border-theme-primary bg-theme-input "
 					data-e2e={generateE2eId('clan_page.settings.overview.system_messages_channel')}

--- a/libs/components/src/lib/components/ClanSettings/ClanSettingOverview/index.tsx
+++ b/libs/components/src/lib/components/ClanSettings/ClanSettingOverview/index.tsx
@@ -108,7 +108,8 @@ const ClanSettingOverview = () => {
 			const cachedMessageUpdate: ApiSystemMessage = {
 				boost_message:
 					updateSystemMessageRequest?.boost_message === systemMessage?.boost_message ? '' : updateSystemMessageRequest?.boost_message,
-				channel_id: updateSystemMessageRequest?.channel_id === systemMessage?.channel_id ? '' : updateSystemMessageRequest?.channel_id,
+				channel_id:
+					updateSystemMessageRequest?.channel_id === systemMessage?.channel_id ? '0' : updateSystemMessageRequest?.channel_id || '0',
 				clan_id: systemMessage?.clan_id,
 				id: systemMessage?.id,
 				hide_audit_log:

--- a/libs/components/src/lib/components/ClanSettings/Integrations/ClanWebhooks/index.tsx
+++ b/libs/components/src/lib/components/ClanSettings/Integrations/ClanWebhooks/index.tsx
@@ -59,7 +59,7 @@ const ClanWebhooks = ({ allClanWebhooks }: IClanWebhooksProps) => {
 				</>
 			) : (
 				<div className="flex items-center flex-col gap-4">
-					<Image src={`assets/images/empty-webhook.svg`} width={48} height={48} className="clan object-cover w-[272px]" />
+					<Image src={`/assets/images/empty-webhook.svg`} width={48} height={48} className="clan object-cover w-[272px]" />
 					<div className="font-medium ">{t('noWebhooks')}</div>
 					<div
 						onClick={handleAddWebhook}

--- a/libs/components/src/lib/components/ClanSettings/Integrations/Webhooks/WebhookItemModal/index.tsx
+++ b/libs/components/src/lib/components/ClanSettings/Integrations/Webhooks/WebhookItemModal/index.tsx
@@ -362,7 +362,7 @@ const WebhookItemChannelDropdown = ({
 		<Menu
 			trigger="click"
 			menu={menu}
-			className={`bg-option-theme-important  border-none ml-[3px] py-[6px] px-[8px] max-h-[200px] overflow-y-scroll w-[200px] thread-scroll z-20`}
+			className={`bg-option-theme-important  border-none ml-[3px] py-[6px] px-[8px] max-h-[200px] overflow-y-scroll w-[200px] thread-scroll`}
 		>
 			<div className="w-full h-[50px] rounded-md bg-theme-setting-primary flex flex-row px-3 justify-between items-center">
 				<p className="truncate max-w-[90%]">{dropdownValue}</p>

--- a/libs/components/src/lib/components/ClanSettings/Integrations/Webhooks/index.tsx
+++ b/libs/components/src/lib/components/ClanSettings/Integrations/Webhooks/index.tsx
@@ -72,7 +72,7 @@ const Webhooks = ({ allWebhooks, currentChannel, isClanSetting }: IWebhooksProps
 				</>
 			) : (
 				<div className="flex items-center flex-col gap-4">
-					<Image src={`assets/images/empty-webhook.svg`} width={48} height={48} className="clan object-cover w-[272px]" />
+					<Image src={`/assets/images/empty-webhook.svg`} width={48} height={48} className="clan object-cover w-[272px]" />
 					<div className="font-medium ">{t('noWebhooks')}</div>
 					<div
 						onClick={handleAddWebhook}

--- a/libs/components/src/lib/components/ContextMenu/MessageContextMenuContext.tsx
+++ b/libs/components/src/lib/components/ContextMenu/MessageContextMenuContext.tsx
@@ -186,7 +186,7 @@ export const MessageContextMenuProvider = ({ children, channelId }: { children: 
 			})
 		);
 		const attachments = message.attachments?.filter((attach) => isValidUrl(attach.url || '')) || [];
-		const createTime = new Date(message.create_time_seconds || 0).toISOString();
+		const createTime = message.create_time_seconds ? new Date(message.create_time_seconds * 1000).toISOString() : new Date().toISOString();
 		const pinBody: UpdatePinMessage = {
 			clanId: mode !== ChannelStreamMode.STREAM_MODE_CHANNEL && mode !== ChannelStreamMode.STREAM_MODE_THREAD ? '' : (currentClanId ?? ''),
 			channelId:

--- a/libs/components/src/lib/components/MessageBox/ReactionMentionInput/ReactionMentionInput.tsx
+++ b/libs/components/src/lib/components/MessageBox/ReactionMentionInput/ReactionMentionInput.tsx
@@ -41,6 +41,7 @@ import type {
 import {
 	CHANNEL_INPUT_ID,
 	CREATING_TOPIC,
+	GENERAL_INPUT_ID,
 	ID_MENTION_HERE,
 	IS_SAFARI,
 	MIN_THRESHOLD_CHARS,
@@ -135,6 +136,8 @@ export const MentionReactBase = memo((props: MentionReactBaseProps): ReactElemen
 		draftRequest,
 		updateDraft
 	} = props;
+
+	const inputId = props.isTopic ? GENERAL_INPUT_ID : CHANNEL_INPUT_ID;
 
 	const dispatch = useAppDispatch();
 	const openThreadMessageState = useSelector(selectOpenThreadMessageState);
@@ -1006,7 +1009,7 @@ export const MentionReactBase = memo((props: MentionReactBaseProps): ReactElemen
 					{ephemeralTargetUserId ? t('ephemeralMessage', { username: ephemeralTargetUserDisplay }) : t('placeholder')}
 				</span>
 				<MentionsInput
-					id={CHANNEL_INPUT_ID}
+					id={inputId}
 					ref={editorRef}
 					value={draftRequest?.valueTextInput ?? ''}
 					onChange={onChangeMentionInput}

--- a/libs/components/src/lib/components/MessageWithSystem/WaveButton/index.tsx
+++ b/libs/components/src/lib/components/MessageWithSystem/WaveButton/index.tsx
@@ -48,7 +48,6 @@ const WaveButton = ({ message }: IWaveButtonProps) => {
 		try {
 			const content: IMessageSendPayload = { t: '' };
 			const ref = {
-				message_id: '',
 				message_ref_id: message.id,
 				ref_type: 0,
 				message_sender_id: message?.sender_id,
@@ -58,7 +57,7 @@ const WaveButton = ({ message }: IWaveButtonProps) => {
 				message_sender_display_name: WAVE_SENDER_NAME,
 				content: JSON.stringify(message.content),
 				has_attachment: false,
-				channel_id: message.channel_id ?? '',
+				channel_id: message.channel_id ?? '0',
 				mode: message.mode ?? 0,
 				channel_label: message.channel_label
 			};

--- a/libs/core/src/lib/chat/contexts/ChatContext.tsx
+++ b/libs/core/src/lib/chat/contexts/ChatContext.tsx
@@ -1063,7 +1063,7 @@ const ChatContextProvider: React.FC<ChatContextProviderProps> = ({ children, isM
 			}
 
 			if (channel_desc.type === ChannelType.CHANNEL_TYPE_GROUP || channel_desc.type === ChannelType.CHANNEL_TYPE_DM) {
-				const state = getStore();
+				const state = getStore().getState();
 				const existingEntity = selectDmGroupById(state, channel_desc.channel_id || '0');
 				if (existingEntity && existingEntity.id) {
 					dispatch(

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "react-pdf": "^9.2.1",
     "react-qr-code": "^2.0.15",
     "react-redux": "9.1.0",
-    "react-router-dom": "^7.6.1",
+    "react-router-dom": "^7.12.0",
     "react-select": "^5.8.0",
     "react-simple-code-editor": "^0.14.1",
     "react-syntax-highlighter": "^15.5.0",
@@ -184,7 +184,7 @@
     "jest-environment-node": "^29.4.1",
     "jest-react-native": "18.0.0",
     "lint-staged": "^15.2.9",
-    "node-polyfill-webpack-plugin": "^3.0.0",
+    "node-polyfill-webpack-plugin": "^4.1.0",
     "npm": "^10.5.0",
     "nx": "^21.1.2",
     "postcss": "8.4.33",
@@ -219,7 +219,10 @@
     "undici": "^6.21.2",
     "koa": "^2.16.1",
     "esbuild": "^0.25.0",
-    "brace-expansion": "^2.0.2"
+    "brace-expansion": "^2.0.2",
+    "tar": "^7.5.6",
+    "qs": "^6.14.1",
+    "glob": "^10.5.0"
   },
   "optionalDependencies": {
     "@nx/nx-darwin-arm64": "18.2.2",


### PR DESCRIPTION
- Fix topic input auto-focus by using correct input ID (GENERAL_INPUT_ID)
- Fix DM state selector using getStore().getState()
- Fix event timestamps conversion from seconds to milliseconds
- Fix system message channel_id handling
- Remove empty message_id from wave button reference
- Update react-router-dom and webpack dependencies