### PR TITLE
261021-WEB/DESKTOP fix(components): correct timestamp conversion and sender ID fallback

### DIFF
--- a/libs/components/src/lib/components/ChannelTopbar/TopBarComponents/FilesModal/FileItem.tsx
+++ b/libs/components/src/lib/components/ChannelTopbar/TopBarComponents/FilesModal/FileItem.tsx
@@ -17,7 +17,7 @@ const FileItem = ({ attachmentData, mode }: FileItemProps) => {
 	const { t } = useTranslation('channelTopbar');
 	const userSendAttachment = useAppSelector((state) => selectMemberClanByUserId(state, attachmentData?.uploader ?? ''));
 	const username = userSendAttachment?.user?.username;
-	const attachmentSendTime = attachmentData?.create_time_seconds ? convertTimeString(attachmentData?.create_time_seconds) : '';
+	const attachmentSendTime = attachmentData?.create_time_seconds ? convertTimeString(attachmentData?.create_time_seconds * 1000) : '';
 	const fileType = getFileExtension(attachmentData?.filetype ?? '');
 
 	function getFileExtension(filetype: string) {

--- a/libs/components/src/lib/components/ListMemberInvite/ListMemberInviteItem.tsx
+++ b/libs/components/src/lib/components/ListMemberInvite/ListMemberInviteItem.tsx
@@ -37,7 +37,7 @@ const ListMemberInviteItem = (props: ItemPorp) => {
 		const getDirect = selectDirectById(store.getState(), directParamId);
 		setIsInviteSent(true);
 
-		if (userId && !directParamId) {
+		if (userId && directParamId === '0') {
 			const username = usersInviteExternal?.username || dmGroup?.usernames?.toString() || '';
 			const displayName = usersInviteExternal?.clan_nick || dmGroup?.channel_label || '';
 			const avatar =

--- a/libs/components/src/lib/components/NotificationList/AllNotificationItem.tsx
+++ b/libs/components/src/lib/components/NotificationList/AllNotificationItem.tsx
@@ -77,7 +77,7 @@ function AllNotificationItem({ notify, onCloseTooltip }: NotifyMentionProps) {
 		message,
 		subject: notify.subject,
 		category: notify.category,
-		senderId: notify?.content?.sender_id
+		senderId: notify?.content?.sender_id || notify.sender_id
 	};
 
 	return (


### PR DESCRIPTION
- Fix FileItem timestamp conversion by multiplying seconds by 1000
- Fix ListMemberInvite condition to check directParamId === '0'
- Add fallback for sender_id in AllNotificationItem