### PR TITLE
260126-MOBILE-fix can not reply with sticker

### DIFF
--- a/apps/mobile/src/app/screens/home/homedrawer/components/EmojiPicker/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/EmojiPicker/index.tsx
@@ -119,7 +119,7 @@ function EmojiPicker({ onDone, bottomSheetRef, directMessageId = '', messageActi
 		if (messageActionNeedToResolve?.type === EMessageActionType.Reply) {
 			const targetMessage = messageActionNeedToResolve?.targetMessage;
 			messageRef = {
-				message_id: '',
+				message_id: '0',
 				message_ref_id: targetMessage?.id,
 				ref_type: 0,
 				message_sender_id: targetMessage?.sender_id,


### PR DESCRIPTION
Issue: https://github.com/mezonai/mezon/issues/11861
### Change: check empty string for ref message_id before send.


https://github.com/user-attachments/assets/4e8e9d4d-0aff-4d02-8b77-bf90d6a332fb

