### PR TITLE
260128-web/desktop-Bug26a/web/desktop/fix text option role

### DIFF
--- a/libs/translations/src/languages/en/clanRoles.json
+++ b/libs/translations/src/languages/en/clanRoles.json
@@ -93,7 +93,7 @@
 		"back": "BACK",
 		"display": "Display",
 		"permissions": "Permissions",
-		"manageMembers": "Manager Members",
+		"manageMembers": "Manage Members",
 		"searchPermissions": "Search Permissions",
 		"failedToUpdateRoleOrder": "Failed to update role order.",
 		"newRoleDefault": "New Role",


### PR DESCRIPTION
[Desktop/Website] Section Manage members displays in role Everyone
[#11708](https://github.com/mezonai/mezon/issues/11708)