### PR TITLE
250128-Mobile-fix list channel not clear after

### DIFF
--- a/libs/core/src/lib/chat/contexts/ChatContext.tsx
+++ b/libs/core/src/lib/chat/contexts/ChatContext.tsx
@@ -937,6 +937,7 @@ const ChatContextProvider: React.FC<ChatContextProviderProps> = ({ children, isM
 					}
 					dispatch(clansSlice.actions.removeByClanID(user.clan_id));
 					dispatch(listChannelsByUserActions.remove(id));
+					dispatch(listChannelRenderAction.removeListChannelRenderByClanId({ clanId: user?.clan_id }));
 					dispatch(appActions.cleanHistoryClan(user.clan_id));
 					dispatch(channelsActions.removeByClanId(user.clan_id));
 				}


### PR DESCRIPTION
Issue: https://github.com/mezonai/mezon/issues/11559
### change : clear list channel render when leave clan.