### PR TITLE
260130-mobile-fix notification inbox wrong items

### DIFF
--- a/apps/mobile/src/app/screens/Notifications/MessageNotification/index.tsx
+++ b/apps/mobile/src/app/screens/Notifications/MessageNotification/index.tsx
@@ -12,8 +12,15 @@ import { style } from './MessageNotification.styles';
 interface IMessageNotificationProps {
 	message: IMessageWithUser;
 	mentions: IMentionOnMessage[];
+	attacmentItem: attacmentNotifyItem;
 }
-const MessageNotification = React.memo(({ message, mentions }: IMessageNotificationProps) => {
+
+export type attacmentNotifyItem = {
+	url: string;
+	hasMore: boolean;
+};
+
+const MessageNotification = React.memo(({ message, mentions, attacmentItem }: IMessageNotificationProps) => {
 	const { themeValue } = useTheme();
 	const styles = style(themeValue);
 	const { t } = useTranslation('message');
@@ -27,10 +34,13 @@ const MessageNotification = React.memo(({ message, mentions }: IMessageNotificat
 
 	return (
 		<View>
-			{message?.attachments?.length ? (
-				<View style={styles.attachmentBox}>
-					<Text style={styles.tapToSeeAttachmentText}>{t('tapToSeeAttachment')}</Text>
-					<MezonIconCDN icon={IconCDN.imageIcon} width={size.s_13} height={size.s_13} color={themeValue.textDisabled} />
+			{message?.attachments?.length || attacmentItem ? (
+				<View>
+					<View style={styles.attachmentBox}>
+						<Text style={styles.tapToSeeAttachmentText}>{t('tapToSeeAttachment')}</Text>
+						<MezonIconCDN icon={IconCDN.imageIcon} width={size.s_13} height={size.s_13} color={themeValue.textDisabled} />
+					</View>
+					{message?.attachments?.length > 1 || (attacmentItem?.hasMore && <Text style={styles.tapToSeeAttachmentText}>More files</Text>)}
 				</View>
 			) : null}
 			<RenderTextMarkdownContent

--- a/apps/mobile/src/app/screens/Notifications/MessageNotification/index.tsx
+++ b/apps/mobile/src/app/screens/Notifications/MessageNotification/index.tsx
@@ -12,7 +12,7 @@ import { style } from './MessageNotification.styles';
 interface IMessageNotificationProps {
 	message: IMessageWithUser;
 	mentions: IMentionOnMessage[];
-	attacmentItem: attacmentNotifyItem;
+	attachmentItem: attacmentNotifyItem;
 }
 
 export type attacmentNotifyItem = {
@@ -20,7 +20,7 @@ export type attacmentNotifyItem = {
 	hasMore: boolean;
 };
 
-const MessageNotification = React.memo(({ message, mentions, attacmentItem }: IMessageNotificationProps) => {
+const MessageNotification = React.memo(({ message, mentions, attachmentItem }: IMessageNotificationProps) => {
 	const { themeValue } = useTheme();
 	const styles = style(themeValue);
 	const { t } = useTranslation('message');
@@ -34,13 +34,14 @@ const MessageNotification = React.memo(({ message, mentions, attacmentItem }: IM
 
 	return (
 		<View>
-			{message?.attachments?.length || attacmentItem ? (
+			{message?.attachments?.length || attachmentItem ? (
 				<View>
 					<View style={styles.attachmentBox}>
 						<Text style={styles.tapToSeeAttachmentText}>{t('tapToSeeAttachment')}</Text>
 						<MezonIconCDN icon={IconCDN.imageIcon} width={size.s_13} height={size.s_13} color={themeValue.textDisabled} />
 					</View>
-					{message?.attachments?.length > 1 || (attacmentItem?.hasMore && <Text style={styles.tapToSeeAttachmentText}>More files</Text>)}
+					{message?.attachments?.length > 1 ||
+						(attachmentItem?.hasMore && <Text style={styles.tapToSeeAttachmentText}>{t('moreFiles')}</Text>)}
 				</View>
 			) : null}
 			<RenderTextMarkdownContent

--- a/apps/mobile/src/app/screens/Notifications/NotificationIndividualItem/NotificationIndividualItem.styles.ts
+++ b/apps/mobile/src/app/screens/Notifications/NotificationIndividualItem/NotificationIndividualItem.styles.ts
@@ -1,10 +1,14 @@
-import { Attributes, size } from '@mezon/mobile-ui';
+import type { Attributes } from '@mezon/mobile-ui';
+import { size } from '@mezon/mobile-ui';
 import { StyleSheet } from 'react-native';
 export const style = (colors: Attributes) =>
 	StyleSheet.create({
 		notifyContainer: {
 			paddingHorizontal: size.s_10,
-			marginBottom: size.s_10
+			marginBottom: size.s_6,
+			borderBottomWidth: size.s_2,
+			borderBottomColor: colors.secondaryLight,
+			paddingVertical: size.s_6
 		},
 		notifyHeader: {
 			flexDirection: 'row',

--- a/apps/mobile/src/app/screens/Notifications/NotificationItem/index.tsx
+++ b/apps/mobile/src/app/screens/Notifications/NotificationItem/index.tsx
@@ -1,4 +1,4 @@
-import { size, useTheme } from '@mezon/mobile-ui';
+import { useTheme } from '@mezon/mobile-ui';
 import { NotificationCategory } from '@mezon/utils';
 import { memo } from 'react';
 import { View } from 'react-native';
@@ -12,7 +12,7 @@ const NotificationItem = memo(({ notify, onLongPressNotify, onPressNotify }: Not
 	const { themeValue } = useTheme();
 
 	return (
-		<View style={{ borderBottomWidth: size.s_2, borderBottomColor: themeValue.secondaryLight, paddingTop: size.s_6 }}>
+		<View>
 			{notify?.category === NotificationCategory.FOR_YOU && (
 				<NotificationIndividualItem notify={notify} onLongPressNotify={onLongPressNotify} />
 			)}

--- a/apps/mobile/src/app/screens/Notifications/NotificationMentionItem/NotificationMentionItem.styles.ts
+++ b/apps/mobile/src/app/screens/Notifications/NotificationMentionItem/NotificationMentionItem.styles.ts
@@ -5,7 +5,10 @@ export const style = (colors: Attributes) =>
 	StyleSheet.create({
 		notifyContainer: {
 			paddingHorizontal: size.s_10,
-			marginBottom: size.s_10
+			marginBottom: size.s_6,
+			borderBottomWidth: size.s_2,
+			borderBottomColor: colors.secondaryLight,
+			paddingVertical: size.s_6
 		},
 
 		notifyHeader: {

--- a/apps/mobile/src/app/screens/Notifications/NotificationMentionItem/index.tsx
+++ b/apps/mobile/src/app/screens/Notifications/NotificationMentionItem/index.tsx
@@ -124,7 +124,7 @@ const NotificationMentionItem = memo(({ notify, onLongPressNotify, onPressNotify
 							{subjectText}
 						</Text>
 						<View style={styles.contentMessage}>
-							<MessageNotification message={data} mentions={mentions} attacmentItem={attachmentItem} />
+							<MessageNotification message={data} mentions={mentions} attachmentItem={attachmentItem} />
 						</View>
 					</View>
 					<Text style={styles.notifyDuration}>{messageTimeDifference}</Text>

--- a/apps/mobile/src/app/screens/Notifications/NotificationMentionItem/index.tsx
+++ b/apps/mobile/src/app/screens/Notifications/NotificationMentionItem/index.tsx
@@ -7,6 +7,7 @@ import { safeJSONParse } from 'mezon-js';
 import { memo, useMemo } from 'react';
 import { Text, TouchableOpacity, View } from 'react-native';
 import MezonAvatar from '../../../componentUI/MezonAvatar';
+import type { attacmentNotifyItem } from '../MessageNotification';
 import MessageNotification from '../MessageNotification';
 import type { NotifyProps } from '../types';
 import { ENotifyBsToShow } from '../types';
@@ -77,6 +78,15 @@ const NotificationMentionItem = memo(({ notify, onLongPressNotify, onPressNotify
 		return priorityAvatar || notify?.content?.avatar;
 	}, [notify?.content?.avatar, priorityAvatar]);
 
+	const attachmentItem: attacmentNotifyItem = useMemo(() => {
+		return notify?.content?.attachment_link
+			? {
+					url: notify?.content?.attachment_link,
+					hasMore: notify?.content?.has_more_attachment
+				}
+			: null;
+	}, [notify?.content?.attachment_link, notify?.content?.has_more_attachment]);
+
 	const mentions = useMemo<IMentionOnMessage[]>(() => {
 		const message = notify?.content;
 		const mention = message.mention_ids?.map((item, index) => {
@@ -89,6 +99,10 @@ const NotificationMentionItem = memo(({ notify, onLongPressNotify, onPressNotify
 		});
 		return mention || [];
 	}, [notify?.content]);
+
+	if (!data?.content && !subjectText && !data?.attachments?.length && !attachmentItem) {
+		return null;
+	}
 
 	return (
 		<TouchableOpacity
@@ -110,7 +124,7 @@ const NotificationMentionItem = memo(({ notify, onLongPressNotify, onPressNotify
 							{subjectText}
 						</Text>
 						<View style={styles.contentMessage}>
-							<MessageNotification message={data} mentions={mentions} />
+							<MessageNotification message={data} mentions={mentions} attacmentItem={attachmentItem} />
 						</View>
 					</View>
 					<Text style={styles.notifyDuration}>{messageTimeDifference}</Text>

--- a/apps/mobile/src/app/screens/Notifications/NotificationTopicItem/styles.ts
+++ b/apps/mobile/src/app/screens/Notifications/NotificationTopicItem/styles.ts
@@ -5,7 +5,10 @@ export const style = (colors: Attributes) =>
 	StyleSheet.create({
 		notifyContainer: {
 			paddingHorizontal: size.s_10,
-			marginBottom: size.s_10
+			marginBottom: size.s_10,
+			borderBottomWidth: size.s_2,
+			borderBottomColor: colors.secondaryLight,
+			paddingVertical: size.s_6
 		},
 
 		notifyHeader: {

--- a/apps/mobile/src/app/screens/Notifications/NotificationWebhookClan/MessageWebhookClan.tsx
+++ b/apps/mobile/src/app/screens/Notifications/NotificationWebhookClan/MessageWebhookClan.tsx
@@ -50,7 +50,7 @@ const MessageWebhookClan = memo(({ message }: IMessageNotificationProps) => {
 			<View>
 				<RenderTextMarkdownContent
 					content={{
-						...(typeof message.content === 'object' ? message.content : {}),
+						...(typeof message.content === 'object' ? message.content : { t: message?.content?.toString() || '' }),
 						mentions: message?.mentions
 					}}
 					isEdited={isEdited}

--- a/apps/mobile/src/app/screens/Notifications/NotificationWebhookClan/NotificationWebhookClan.tsx
+++ b/apps/mobile/src/app/screens/Notifications/NotificationWebhookClan/NotificationWebhookClan.tsx
@@ -17,6 +17,10 @@ const NotificationWebhookClan = ({ notify, onLongPressNotify }: NotifyProps) => 
 	const messageTimeDifference = convertTimestampToTimeAgo(notify?.content?.create_time_seconds);
 	const data = parseObject(notify?.content);
 
+	if (!data?.content && !data?.attachments) {
+		return null;
+	}
+
 	return (
 		<TouchableOpacity onLongPress={() => onLongPressNotify(ENotifyBsToShow.removeNotification, notify)}>
 			<View style={styles.notifyContainer}>

--- a/apps/mobile/src/app/screens/Notifications/NotificationWebhookClan/styles.ts
+++ b/apps/mobile/src/app/screens/Notifications/NotificationWebhookClan/styles.ts
@@ -5,7 +5,9 @@ export const style = (colors: Attributes) =>
 	StyleSheet.create({
 		notifyContainer: {
 			paddingHorizontal: size.s_10,
-			marginBottom: size.s_10
+			borderBottomWidth: size.s_2,
+			borderBottomColor: colors.secondaryLight,
+			paddingVertical: size.s_6
 		},
 
 		notifyHeader: {

--- a/libs/translations/src/languages/en/message.json
+++ b/libs/translations/src/languages/en/message.json
@@ -97,6 +97,7 @@
 		"private": "Exposing private identifying information"
 	},
 	"tapToSeeAttachment": "Tap to see attachment",
+	"moreFiles": "More files",
 	"clickToSeeAttachment": "Click to see attachment",
 	"findThePerfectReaction": "Find the perfect reaction",
 	"findThePerfectGif": "Find the perfect GIF",

--- a/libs/translations/src/languages/vi/message.json
+++ b/libs/translations/src/languages/vi/message.json
@@ -97,6 +97,7 @@
 		"private": "Tiết lộ thông tin cá nhân riêng tư"
 	},
 	"tapToSeeAttachment": "Nhấn để xem tệp đính kèm",
+	"moreFiles": "Nhiều tệp",
 	"clickToSeeAttachment": "Nhấn để xem tệp đính kèm",
 	"findThePerfectReaction": "Tìm biểu cảm hoàn hảo",
 	"findThePerfectGif": "Tìm ảnh động hoàn hảo",


### PR DESCRIPTION
Issue: https://github.com/mezonai/mezon/issues/11502
### change:
- Show attachment item missing in mention tab.
- Hide all empty content notification.
- Change content type show in message tab webhook and mark message item.