### PR TITLE
260203-web/desktop-fix time webhook

### DIFF
--- a/libs/components/src/lib/components/ClanSettings/Integrations/ClanWebhooks/ClanWebhookItemModal/index.tsx
+++ b/libs/components/src/lib/components/ClanSettings/Integrations/ClanWebhooks/ClanWebhookItemModal/index.tsx
@@ -43,7 +43,10 @@ const ClanWebhookItemModal = ({ webhookItem }: IClanWebhookItemModalProps) => {
 							<Icons.ClockIcon className="text-theme-primary" />
 							<div className="text-theme-primary text-[13px]">
 								{t('webhooksItem.createdBy', {
-									webhookCreateTime: timeFormatI18n(webhookItem.create_time_seconds || '', tCommon),
+									webhookCreateTime: timeFormatI18n(
+										webhookItem.create_time_seconds ?? Math.floor(new Date(webhookItem.update_time || '').getTime() / 1000),
+										tCommon
+									),
 									webhookUserOwnerName: webhookOwner?.user?.username
 								})}
 							</div>

--- a/libs/components/src/lib/components/ClanSettings/Integrations/Webhooks/WebhookItemModal/index.tsx
+++ b/libs/components/src/lib/components/ClanSettings/Integrations/Webhooks/WebhookItemModal/index.tsx
@@ -46,7 +46,10 @@ const WebhookItemModal = ({ webhookItem, currentChannel, isClanSetting }: IWebho
 							<Icons.ClockIcon className="text-theme-primary" />
 							<div className="text-theme-primary text-[13px]">
 								{t('webhooksItem.createdBy', {
-									webhookCreateTime: timeFormatI18n(webhookItem.create_time_seconds || 0, tCommon),
+									webhookCreateTime: timeFormatI18n(
+										webhookItem.create_time_seconds ?? Math.floor(new Date(webhookItem.update_time || '').getTime() / 1000),
+										tCommon
+									),
 									webhookUserOwnerName: webhookOwner?.user?.username
 								})}
 							</div>

--- a/libs/utils/src/lib/utils/timeFormatterI18n.ts
+++ b/libs/utils/src/lib/utils/timeFormatterI18n.ts
@@ -1,5 +1,10 @@
-export const timeFormatI18n = (start: string | number, t: (key: string, options?: any) => string) => {
-	const date = new Date(start);
+export const timeFormatI18n = (start: string | number | null | undefined, t: (key: string, options?: any) => string) => {
+	const timestamp = Number(start);
+	if (!timestamp || Number.isNaN(timestamp)) return '';
+
+	const date = new Date(timestamp * 1000);
+
+	if (Number.isNaN(date.getTime())) return '';
 
 	const daysOfWeek = [
 		t('timeFormat.daysOfWeek.sun'),


### PR DESCRIPTION
[Desktop/Website] Incorrect timestamp when creating webhook
[#12029](https://github.com/mezonai/mezon/issues/12029)
<img width="1148" height="599" alt="image" src="https://github.com/user-attachments/assets/fa979c86-ee01-4dc1-a1c1-aa6b747e1c70" />
<img width="976" height="612" alt="image" src="https://github.com/user-attachments/assets/9e8a77e7-2f3e-4f09-a09f-3cdf240e52ab" />
