### PR TITLE
260224-WEB/DESKTOP-bug26a/incorect timestamp and cutting text

### DIFF
--- a/libs/components/src/lib/components/EmbedMessage/EmbedMessage.tsx
+++ b/libs/components/src/lib/components/EmbedMessage/EmbedMessage.tsx
@@ -23,7 +23,7 @@ export function EmbedMessage({ embed, message_id, senderId, onClick, channelId, 
 			<div className="flex flex-col px-5 pt-2 pb-4">
 				<div className={`absolute left-0 top-0 h-full w-1 `} style={{ backgroundColor: color }} />
 				<div className={'flex flex-row justify-between'}>
-					<div className={`flex flex-col break-words break-all ${thumbnail && 'pr-2'}`}>
+					<div className={`flex flex-col break-words ${thumbnail && 'pr-2'}`}>
 						{author && <EmbedAuthor {...author} />}
 						{title && <EmbedTitle title={title} url={url} onClick={onClick} />}
 						{description && <EmbedDescription description={description} />}

--- a/libs/components/src/lib/components/EmbedMessage/components/EmbedFields.tsx
+++ b/libs/components/src/lib/components/EmbedMessage/components/EmbedFields.tsx
@@ -51,7 +51,7 @@ export function EmbedFields({ fields, message_id, senderId, channelId, observeIn
 							key={index}
 							className={`${field.inline ? `col-span-${3 / row.length}` : 'col-span-3'} ${field.button ? 'flex justify-between' : 'flex-col'}`}
 						>
-							<div className="flex flex-col gap-1 break-all">
+							<div className="flex flex-col gap-1 break-words">
 								<div className="font-semibold text-sm">{field.name}</div>
 								<div className=" text-sm">{field.value}</div>
 							</div>

--- a/libs/components/src/lib/components/MessageWithUser/MessageModalImage/index.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/MessageModalImage/index.tsx
@@ -553,9 +553,7 @@ const SenderUser = () => {
 			<div className="flex flex-col justify-between ">
 				<div className="text-[14px] font-semibold text-textDarkTheme truncate max-sm:w-12">{displayName}</div>
 				<div className="text-[12px] text-bgTextarea truncate max-sm:w-12">
-					{attachment?.create_time_seconds
-						? formatDateI18n(new Date(attachment.create_time_seconds * 1000 || ''), 'en', 'dd/MM/yyyy')
-						: 'N/A'}
+					{attachment?.create_time ? formatDateI18n(new Date(attachment.create_time || ''), 'en', 'dd/MM/yyyy') : 'N/A'}
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
Task :
- [Desktop/Website] Adjust cutting text in text block
https://github.com/mezonai/mezon/issues/12259
-[Desktop/Website] Incorrect timestamp in image viewer by clicking on searching attachment message
https://github.com/mezonai/mezon/issues/12037