### PR TITLE
260304-WEB/DESKTOP-fix: correct incorrect time displayed in search image

### DIFF
--- a/libs/components/src/lib/components/MessageWithUser/MessageAttachment.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/MessageAttachment.tsx
@@ -39,11 +39,23 @@ type MessageAttachmentProps = {
 	defaultMaxWidth?: number;
 };
 
+const getMessageCreateTimeSeconds = (message: IMessageWithUser): number | undefined => {
+	if (message.create_time_seconds) return message.create_time_seconds;
+	const createTime = (message as any).create_time;
+	if (createTime) {
+		const parsed = new Date(createTime).getTime();
+		if (!isNaN(parsed)) return Math.floor(parsed / 1000);
+	}
+	return undefined;
+};
+
 const classifyAttachments = (attachments: ApiMessageAttachment[], message: IMessageWithUser) => {
 	const videos: ApiMessageAttachment[] = [];
 	const images: (ApiMessageAttachment & { create_time?: string })[] = [];
 	const documents: ApiMessageAttachment[] = [];
 	const audio: ApiMessageAttachment[] = [];
+
+	const messageCreateTimeSeconds = getMessageCreateTimeSeconds(message);
 
 	attachments.forEach((attachment) => {
 		if (isMediaTypeNotSupported(attachment.filetype)) {
@@ -69,11 +81,12 @@ const classifyAttachments = (attachments: ApiMessageAttachment[], message: IMess
 			attachment.filetype?.includes(EMimeTypes.heic) ||
 			attachment.url?.endsWith('.gif')
 		) {
+			const createTimeSeconds = attachment.create_time_seconds || messageCreateTimeSeconds;
 			const resultAttach: ApiMessageAttachment & { create_time?: string } = {
 				...attachment,
 				sender_id: message.sender_id,
 				message_id: message.id,
-				create_time: (attachment.create_time_seconds ?? 0) * 1000 || (((message.create_time_seconds ?? 0) * 1000) as any)
+				create_time: createTimeSeconds ? new Date(Number(createTimeSeconds) * 1000).toISOString() : undefined
 			};
 			images.push(resultAttach);
 			return;
@@ -206,11 +219,11 @@ const ImageAlbum = memo(
 
 				if (!attachmentData) return;
 
+				const messageCreateTime = getMessageCreateTimeSeconds(message);
+				const resolvedCreateTimeSeconds = attachmentData?.create_time_seconds || messageCreateTime || Date.now() / 1000;
 				const enhancedAttachmentData = {
 					...attachmentData,
-					create_time_seconds: attachmentData?.create_time_seconds
-						? attachmentData?.create_time_seconds || message.create_time_seconds
-						: Date.now() / 1000
+					create_time_seconds: resolvedCreateTimeSeconds
 				};
 
 				if (isElectron()) {

--- a/libs/components/src/lib/components/MessageWithUser/MessageModalImage/index.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/MessageModalImage/index.tsx
@@ -553,7 +553,11 @@ const SenderUser = () => {
 			<div className="flex flex-col justify-between ">
 				<div className="text-[14px] font-semibold text-textDarkTheme truncate max-sm:w-12">{displayName}</div>
 				<div className="text-[12px] text-bgTextarea truncate max-sm:w-12">
-					{attachment?.create_time ? formatDateI18n(new Date(attachment.create_time || ''), 'en', 'dd/MM/yyyy') : 'N/A'}
+					{attachment?.create_time
+						? formatDateI18n(new Date(attachment.create_time), 'en', 'dd/MM/yyyy')
+						: attachment?.create_time_seconds
+							? formatDateI18n(new Date(Number(attachment.create_time_seconds) * 1000), 'en', 'dd/MM/yyyy')
+							: 'N/A'}
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
Task : Incorrect timestamp in image viewer by clicking on searching attachment message
https://github.com/mezonai/mezon/issues/12037 

Demo : 
<img width="1366" height="655" alt="image" src="https://github.com/user-attachments/assets/b37e1d50-aabe-414e-948c-824dee1f0c5e" />
