### PR TITLE
260311 - WEB/DESKTOP - fix(canvas): save changes modal not showing when editing content in repeat event

### DIFF
--- a/libs/components/src/lib/components/Canvas/useCanvas.ts
+++ b/libs/components/src/lib/components/Canvas/useCanvas.ts
@@ -190,7 +190,9 @@ export function useCanvas(): UseCanvasReturn {
 			if (!canEdit) return;
 			setTitle(newTitle);
 			const titleChanged = newTitle !== originalTitle.current;
-			const contentChanged = !isContentEmpty(content) && content !== originalContent.current && !isContentEmpty(originalContent.current);
+			const isCurrentContentEmpty = isContentEmpty(content);
+			const isOriginalEmpty = isContentEmpty(originalContent.current);
+			const contentChanged = isCurrentContentEmpty && isOriginalEmpty ? false : content !== originalContent.current;
 			setHasChanges(titleChanged || contentChanged);
 		},
 		[canEdit, content]
@@ -201,7 +203,9 @@ export function useCanvas(): UseCanvasReturn {
 			if (!canEdit) return;
 			setContent(newContent);
 			const titleChanged = title !== originalTitle.current;
-			const contentChanged = !isContentEmpty(newContent) && newContent !== originalContent.current && !isContentEmpty(originalContent.current);
+			const isNewContentEmpty = isContentEmpty(newContent);
+			const isOriginalEmpty = isContentEmpty(originalContent.current);
+			const contentChanged = isNewContentEmpty && isOriginalEmpty ? false : newContent !== originalContent.current;
 			setHasChanges(titleChanged || contentChanged);
 		},
 		[canEdit, title]

--- a/libs/components/src/lib/components/ChannelList/EventChannelModal/ModalCreate/index.tsx
+++ b/libs/components/src/lib/components/ChannelList/EventChannelModal/ModalCreate/index.tsx
@@ -181,7 +181,7 @@ const ModalCreate = (props: ModalCreateProps) => {
 			logo: currentEvent.logo ?? '',
 			description: currentEvent.description ?? '',
 			textChannelId: currentEvent.channel_id ?? '',
-			repeatType: currentEvent.repeat_type
+			repeatType: currentEvent.repeat_type || ERepeatType.DOES_NOT_REPEAT
 		};
 
 		const submittedContent = {
@@ -248,7 +248,8 @@ const ModalCreate = (props: ModalCreateProps) => {
 				title: contentSubmit.topic === currentEvent.title ? undefined : contentSubmit.topic,
 				start_time_seconds: timeStart === currentStartMs ? undefined : timeStart,
 				end_time_seconds: timeEnd === currentEndMs ? undefined : timeEnd,
-				repeat_type: contentSubmit.repeatType === currentEvent.repeat_type ? ERepeatType.DOES_NOT_REPEAT : contentSubmit.repeatType
+				repeat_type:
+					contentSubmit.repeatType === (currentEvent.repeat_type || ERepeatType.DOES_NOT_REPEAT) ? undefined : contentSubmit.repeatType
 			};
 
 			const additionalFields: Partial<Record<string, string | number | undefined>> = {


### PR DESCRIPTION
Task : [Desktop/Website] Modal save changes is not showed when entering canvas content
https://github.com/mezonai/mezon/issues/12401