### PR TITLE
230326-Mobile-Fix badge direct message and last sent content

### DIFF
--- a/apps/mobile/src/app/navigation/RootListener.tsx
+++ b/apps/mobile/src/app/navigation/RootListener.tsx
@@ -259,7 +259,7 @@ const RootListener = () => {
 			promises.push(dispatch(listUsersByUserActions.fetchListUsersByUser({ noCache: true })));
 			promises.push(dispatch(listChannelsByUserActions.fetchListChannelsByUser({ noCache: true })));
 			promises.push(dispatch(friendsActions.fetchListFriends({ noCache: true })));
-			promises.push(dispatch(clansActions.joinClan({ clanId: '0', isMobile: true })));
+			promises.push(dispatch(clansActions.joinClan({ clanId: '0' })));
 			promises.push(dispatch(directActions.fetchDirectMessage({ noCache: true, isMobile: true })));
 			promises.push(dispatch(emojiSuggestionActions.fetchEmoji({ noCache: true, clanId: currentClanId })));
 			promises.push(dispatch(settingClanStickerActions.fetchStickerByUserId({ noCache: true, clanId: currentClanId })));

--- a/apps/mobile/src/app/screens/home/homedrawer/components/InviteToChannel/FriendList.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/InviteToChannel/FriendList.tsx
@@ -210,7 +210,7 @@ export const FriendList = React.memo(({ isUnknownChannel, isKeyboardVisible, cha
 			linkInvite = `${process.env.NX_CHAT_APP_REDIRECT_URI}/invite/${response.invite_link}`;
 			setCurrentInviteLink(linkInvite);
 			currentInviteLinkRef.current = linkInvite;
-			dispatch(clansActions.joinClan({ clanId: '0', isMobile: true }));
+			dispatch(clansActions.joinClan({ clanId: '0' }));
 		} catch (error) {
 			Toast.show({
 				type: 'error',

--- a/apps/mobile/src/app/screens/home/homedrawer/components/UnreadDMBadgeList/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/UnreadDMBadgeList/index.tsx
@@ -1,10 +1,19 @@
+import { isEmpty } from '@mezon/mobile-components';
 import { size, useTheme } from '@mezon/mobile-ui';
 import type { DirectEntity } from '@mezon/store-mobile';
-import { directActions, selectDirectById, selectDirectsUnreadlist, selectIsLoadDMData, useAppDispatch, useAppSelector } from '@mezon/store-mobile';
+import {
+	directActions,
+	selectDirectById,
+	selectDirectMessageEntities,
+	selectDirectsUnreadlist,
+	selectIsLoadDMData,
+	useAppDispatch,
+	useAppSelector
+} from '@mezon/store-mobile';
 import { createImgproxyUrl, sleep } from '@mezon/utils';
 import { useNavigation } from '@react-navigation/native';
 import { ChannelType } from 'mezon-js';
-import React, { memo, useEffect, useRef, useState } from 'react';
+import React, { memo, useEffect, useMemo, useRef, useState } from 'react';
 import { Animated, Text, TouchableOpacity, View } from 'react-native';
 import { Flow } from 'react-native-animated-spinkit';
 import FastImage from 'react-native-fast-image';
@@ -23,6 +32,10 @@ const UnreadDMBadgeItem = memo(({ dmId, numUnread }: { dmId: string; numUnread: 
 	const styles = style(themeValue);
 	const isTabletLandscape = useTabletLandscape();
 	const dispatch = useAppDispatch();
+
+	if (isEmpty(dm)) {
+		return null;
+	}
 
 	const getBadge = (dm: DirectEntity) => {
 		switch (dm.type) {
@@ -94,12 +107,19 @@ const UnreadDMLoading = memo(() => {
 	const { themeValue } = useTheme();
 	const styles = style(themeValue);
 	const unReadDM = useSelector(selectDirectsUnreadlist);
+	const directEntities = useSelector(selectDirectMessageEntities);
 	const isLoading = useSelector(selectIsLoadDMData);
 	const opacity = useRef(new Animated.Value(!isLoading ? 1 : 0)).current;
 	const containerHeight = useRef(new Animated.Value(!isLoading ? size.s_50 : 0)).current;
 	const listOpacity = useRef(new Animated.Value(0)).current;
 	const listTranslateY = useRef(new Animated.Value(20)).current;
 	const [showData, setShowData] = useState(false);
+
+	const validUnreadDM = useMemo(() => {
+		return unReadDM.filter((dm) => {
+			return dm?.id && directEntities[dm.id];
+		});
+	}, [unReadDM, directEntities]);
 
 	useEffect(() => {
 		Animated.timing(opacity, {
@@ -144,18 +164,18 @@ const UnreadDMLoading = memo(() => {
 	}, [showData, listOpacity, listTranslateY]);
 
 	return (
-		<View style={[styles.container, !!unReadDM?.length && styles.containerBottom]}>
+		<View style={[styles.container, !!validUnreadDM?.length && styles.containerBottom]}>
 			<Animated.View style={[styles.animatedContainer, { height: containerHeight }]}>
 				<Animated.View style={[styles.animatedInner, { opacity }]}>
 					<Flow color={themeValue.textDisabled} size={size.s_30} />
 				</Animated.View>
 			</Animated.View>
 			{showData &&
-				!!unReadDM?.length &&
-				unReadDM?.map((dm: DirectEntity, index) => {
+				!!validUnreadDM?.length &&
+				validUnreadDM?.map((dm: DirectEntity, index) => {
 					return <UnreadDMBadgeItem key={`${dm?.id}_${index}`} dmId={dm?.id} numUnread={dm?.count_mess_unread || 0} />;
 				})}
-			{showData && !!unReadDM?.length && <View style={styles.lineBottom} />}
+			{showData && !!validUnreadDM?.length && <View style={styles.lineBottom} />}
 		</View>
 	);
 });

--- a/apps/mobile/src/app/screens/home/homedrawer/components/UnreadDMBadgeList/index.tsx
+++ b/apps/mobile/src/app/screens/home/homedrawer/components/UnreadDMBadgeList/index.tsx
@@ -33,10 +33,6 @@ const UnreadDMBadgeItem = memo(({ dmId, numUnread }: { dmId: string; numUnread: 
 	const isTabletLandscape = useTabletLandscape();
 	const dispatch = useAppDispatch();
 
-	if (isEmpty(dm)) {
-		return null;
-	}
-
 	const getBadge = (dm: DirectEntity) => {
 		switch (dm.type) {
 			case ChannelType.CHANNEL_TYPE_DM:
@@ -95,6 +91,10 @@ const UnreadDMBadgeItem = memo(({ dmId, numUnread }: { dmId: string; numUnread: 
 			navigation.navigate(APP_SCREEN.MESSAGES.MESSAGE_DETAIL, { directMessageId: dm?.channel_id, from: APP_SCREEN.HOME });
 		}
 	};
+
+	if (isEmpty(dm)) {
+		return null;
+	}
 
 	return (
 		<TouchableOpacity onPress={navigateToDirectMessageMDetail} style={[styles.mt10]}>

--- a/apps/mobile/src/app/screens/profile/SendToken/index.tsx
+++ b/apps/mobile/src/app/screens/profile/SendToken/index.tsx
@@ -165,7 +165,7 @@ export const SendTokenScreen = ({ route }: any) => {
 		async (walletAddress) => {
 			if (!walletAddress) {
 				try {
-					dispatch(clansActions.joinClan({ clanId: '0', isMobile: true }));
+					dispatch(clansActions.joinClan({ clanId: '0' }));
 					if (directMessageId) {
 						await sendInviteMessage(
 							`${t('tokensSent')} ${formatMoney(Number(plainTokenCount || 1))}₫ | ${note?.replace?.(/\s+/g, ' ')?.trim() || ''}`,

--- a/libs/store/src/lib/badge/badgeService.ts
+++ b/libs/store/src/lib/badge/badgeService.ts
@@ -461,6 +461,8 @@ class BadgeService extends EventEmitter {
 		const dispatch = this.dispatch;
 		if (!dispatch) return;
 		dispatch(directMetaActions.setCountMessUnread({ channelId: event.channelId, count: event.count, isMention: event.isMention }));
+		dispatch(channelMetaActions.updateChannelBadgeCount({ clanId: '0', channelId: event.channelId, count: event.count }));
+		dispatch(channelMetaActions.setDirectLastSentTimestamp({ channelId: event.channelId, timestamp: Date.now() / 1000 }));
 	}
 
 	private executeMarkAsRead(event: MarkAsReadClanEvent | MarkAsReadCategoryEvent | MarkAsReadChannelEvent) {

--- a/libs/store/src/lib/channels/channelmeta.slice.ts
+++ b/libs/store/src/lib/channels/channelmeta.slice.ts
@@ -105,11 +105,20 @@ export const channelMetaSlice = createSlice({
 		},
 		updateChannelBadgeCount: (state, action: PayloadAction<{ clanId: string; channelId: string; count: number; isReset?: boolean }>) => {
 			const { clanId, channelId, count, isReset = false } = action.payload;
-			const entity = state.entities[channelId];
+			const entity = clanId === '0' ? state.dmEntities.entities?.[channelId] : state.entities?.[channelId];
 			if (!entity) return;
 			const newCountMessUnread = isReset ? 0 : (entity.count_mess_unread ?? 0) + count;
 			const finalCount = Math.max(0, newCountMessUnread);
 			if ((entity.count_mess_unread || 0) === finalCount) return;
+			if (clanId === '0') {
+				dmMetaAdapter.updateOne(state.dmEntities, {
+					id: channelId,
+					changes: {
+						count_mess_unread: finalCount
+					}
+				});
+				return;
+			}
 			channelMetaAdapter.updateOne(state, {
 				id: channelId,
 				changes: {
@@ -153,6 +162,16 @@ export const channelMetaSlice = createSlice({
 					lastSeenTimestamp: lastSeenMessage,
 					count_mess_unread: 0,
 					lastSeenMessageId: messageId
+				}
+			});
+		},
+		setDirectLastSentTimestamp: (state, action: PayloadAction<{ channelId: string; timestamp: number }>) => {
+			const { channelId, timestamp } = action.payload;
+			const lastSentMessage = Math.floor(timestamp);
+			dmMetaAdapter.updateOne(state.dmEntities, {
+				id: channelId,
+				changes: {
+					lastSentTimestamp: lastSentMessage
 				}
 			});
 		}
@@ -279,7 +298,7 @@ export const selectDmSort = createSelector([getChannelMetaState], (state) => sel
 export const selectAllDmSort = createSelector([getChannelMetaState], (state) => selectAllDmMetadata(state.dmEntities) || []);
 export const selectDirectsUnreadlist = createSelector(selectAllDmSort, (state) => {
 	return state.filter((item) => {
-		return item?.count_mess_unread && item?.isMute !== true;
+		return !!item?.count_mess_unread && item?.isMute !== true;
 	});
 });
 

--- a/libs/store/src/lib/clans/clans.slice.ts
+++ b/libs/store/src/lib/clans/clans.slice.ts
@@ -14,6 +14,7 @@ import { createApiKey, createCacheMetadata, markApiFirstCalled, shouldForceApiCa
 import { channelMetaActions } from '../channels/channelmeta.slice';
 import { channelsActions } from '../channels/channels.slice';
 import { listOnlineUserClan, usersClanActions } from '../clanMembers/clan.members';
+import { directActions } from '../direct/direct.slice';
 import { emojiSuggestionSlice } from '../emojiSuggestion/emojiSuggestion.slice';
 import { eventManagementActions } from '../eventManagement/eventManagement.slice';
 import type { MezonValueContext } from '../helpers';
@@ -167,6 +168,7 @@ export const listChannelBadgeCount = createAsyncThunk('clans/listChannelBadgeCou
 		const state = thunkAPI.getState() as RootState;
 		if ((response as any)?.channeldesc && clanId && !state.clans.checkJoinList[clanId]) {
 			thunkAPI.dispatch(channelMetaActions.updateBulkChannelMetadata({ data: (response as any)?.channeldesc, clanId }));
+			thunkAPI.dispatch(directActions.setDirectMetaEntities((response as any)?.channeldesc));
 		}
 		return clanId;
 	} catch (error) {

--- a/libs/store/src/lib/direct/direct.slice.ts
+++ b/libs/store/src/lib/direct/direct.slice.ts
@@ -58,6 +58,14 @@ export const mapDmGroupToEntity = (channelRes: ApiChannelDescription, existingEn
 		mapped.channel_avatar = '/assets/images/avatar-group.png';
 	}
 
+	if (existingEntity?.last_sent_message && !mapped?.last_sent_message) {
+		mapped.last_sent_message = existingEntity?.last_sent_message;
+	}
+
+	if (existingEntity?.last_seen_message && !mapped?.last_seen_message) {
+		mapped.last_seen_message = existingEntity?.last_seen_message;
+	}
+
 	return mapped;
 };
 


### PR DESCRIPTION
Issues: https://github.com/mezonai/mezon/issues/12576
### Change:
- Update last sent timestamp channel meta
- Update direct meta when get badge clan to show last send messages content
- Write badge count to direct adapter.