### PR TITLE
260324 - WEB/DESKTOP - fix flick when update thread

### DIFF
--- a/libs/store/src/lib/channels/channels.slice.ts
+++ b/libs/store/src/lib/channels/channels.slice.ts
@@ -514,9 +514,6 @@ export const updateChannel = createAsyncThunk('channels/updateChannel', async (b
 						}
 					})
 				);
-				thunkAPI.dispatch(
-					listChannelRenderAction.updateChannelInListRender({ channelId: body.channel_id, clanId: clanId as string, dataUpdate: body })
-				);
 			}
 		}
 	} catch (error) {

--- a/libs/utils/src/lib/utils/index.ts
+++ b/libs/utils/src/lib/utils/index.ts
@@ -898,7 +898,7 @@ export const sortChannelsByLastActivity = (channels: IChannel[]): IChannel[] => 
 	});
 };
 export const checkIsThread = (channel?: IChannel) => {
-	return channel?.parent_id !== '0' && channel?.parent_id !== '';
+	return channel?.type === ChannelType.CHANNEL_TYPE_THREAD || (channel?.parent_id && channel?.parent_id !== '0');
 };
 
 export const isWindowsDesktop = getPlatform() === Platform.WINDOWS && isElectron();


### PR DESCRIPTION
### Changes

- Fix update thread name 

### Ticke

- [Desktop/Website] Thread edit form displays "Channel Name/Channel Topic" labels instead of "Thread Name/Thread Topic"
https://github.com/mezonai/mezon/issues/12641