### PR TITLE
260513 - ADMIN - handle 404 as empty state for room summary

### DIFF
--- a/libs/store/src/lib/dashboard/dashboard.slice.ts
+++ b/libs/store/src/lib/dashboard/dashboard.slice.ts
@@ -496,6 +496,9 @@ export const fetchRoomSummaryByRoomId = createAsyncThunk('dashboard/fetchRoomSum
 		const url = `${base}/dashboard/room/${encodeURIComponent(roomId)}/summary`;
 		const res = await fetch(url, { headers: authHeadersForDashboard(thunkAPI.getState as () => RootState) });
 		if (!res.ok) {
+			if (res.status === 404) {
+				return { roomId, summary: null };
+			}
 			const text = await res.text().catch(() => '');
 			return thunkAPI.rejectWithValue({ roomId, message: text || res.statusText });
 		}


### PR DESCRIPTION
- Modify fetchRoomSummaryByRoomId to treat 404 responses as successful empty states instead of load errors, ensuring UI displays "Empty" messages instead of error alerts.