### PR TITLE
250519 - WEB/DESKTOP - fix badge data channel meta

### DIFF
--- a/libs/core/src/lib/chat/contexts/ChatContext.tsx
+++ b/libs/core/src/lib/chat/contexts/ChatContext.tsx
@@ -1756,11 +1756,11 @@ const ChatContextProvider: React.FC<ChatContextProviderProps> = ({ children, isM
 						navigate(`/chat/clans/${clanId}/member-safety`);
 					}
 				}
-				dispatch(channelMetaActions.deleteChannelMeta({ channelId: channelDeleted.channel_id }));
 				dispatch(channelsActions.deleteChannelSocket(channelDeleted));
 				dispatch(listChannelsByUserActions.remove(channelDeleted.channel_id));
 				dispatch(updateClanBadgeRender({ channelId: channelDeleted.channel_id, clanId: channelDeleted.clan_id }));
 				dispatch(channelsActions.removeChannelApp({ channelId: channelDeleted.channel_id, clanId: channelDeleted.clan_id }));
+				dispatch(channelMetaActions.deleteChannelMeta({ channelId: channelDeleted.channel_id }));
 
 				dispatch(
 					threadsActions.removeThreadFromCache({

--- a/libs/store/src/lib/channels/channelmeta.slice.ts
+++ b/libs/store/src/lib/channels/channelmeta.slice.ts
@@ -20,9 +20,9 @@ export interface ChannelMetaEntity {
 	last_sent_message?: ApiChannelMessageHeader;
 }
 
-function extractChannelMeta(channel: ApiChannelDescription, clanId: string): ChannelMetaEntity {
+function extractChannelMeta(channel: ApiChannelDescription & { id?: string }, clanId: string): ChannelMetaEntity {
 	return {
-		id: channel.channel_id || '0',
+		id: channel.id || channel.channel_id || '0',
 		lastSeenTimestamp:
 			Number.isNaN(channel.last_seen_message?.timestamp_seconds) || !channel.last_seen_message?.timestamp_seconds
 				? 0


### PR DESCRIPTION
### Changes 

- updateClanBadgeCount before delete channelMetaData 
- fix map data to channel meta

### Description 

- Channel meta is summary from channelBadgeCount (type ApiChannelDesc || any) and from socket (type ChannelDescription). On socket case dont have key channel_id so have to map from key "id"

- When delete or remove user from channel has badge count. Delete channelMetaData first so when updateClanBadgeCount run cannot minus count_mess_unread of channel meta 

### Test Case 

- Add from socket then deleted 
- Add from socket then refresh
- Refresh and delete from channel 
- Create thread then add then delete 
- Create thread then add then remove