### PR TITLE
260520 - WEB/DESKTOP - Fix26b/web/fix ogp data

### DIFF
--- a/libs/components/src/lib/components/ChannelTopbar/TopBarComponents/Threads/ThreadModal/ThreadList.tsx
+++ b/libs/components/src/lib/components/ChannelTopbar/TopBarComponents/Threads/ThreadModal/ThreadList.tsx
@@ -4,7 +4,7 @@ import { selectTheme, useAppSelector } from '@mezon/store';
 import { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import GroupThreads from './GroupThreads';
-import { getActiveThreads, getJoinedThreadsWithinLast30Days, getThreadsOlderThan30Days } from './hepler';
+import { getActiveThreads, getJoinedThreads, getThreadsOlderThan30Days } from './hepler';
 
 type ThreadListProps = {
 	isLoading: boolean;
@@ -18,7 +18,7 @@ export default function ThreadList({ isLoading, threads, loadMore, preventCloseP
 	const ulRef = useRef<HTMLUListElement | null>(null);
 
 	const activeThreads = getActiveThreads(threads);
-	const joinedThreads = getJoinedThreadsWithinLast30Days(threads);
+	const joinedThreads = getJoinedThreads(threads);
 	const oldThreads = getThreadsOlderThan30Days(threads);
 
 	const { measureRef, isIntersecting, observer } = useOnScreen({ root: ulRef.current });
@@ -49,7 +49,7 @@ export default function ThreadList({ isLoading, threads, loadMore, preventCloseP
 			/>
 			<GroupThreads
 				preventClosePannel={preventClosePannel}
-				title={t('joinedThreadsLast30Days')}
+				title={t('joinedThreads')}
 				threads={joinedThreads}
 				measureRef={isLastInJoined ? measureRef : undefined}
 			/>

--- a/libs/components/src/lib/components/ChannelTopbar/TopBarComponents/Threads/ThreadModal/hepler.ts
+++ b/libs/components/src/lib/components/ChannelTopbar/TopBarComponents/Threads/ThreadModal/hepler.ts
@@ -2,19 +2,19 @@ import type { ThreadsEntity } from '@mezon/store';
 import { ThreadStatus } from '@mezon/utils';
 
 // is thread public and last message within 30days
-export const getActiveThreads = (threads: ThreadsEntity[]): ThreadsEntity[] => {
+export const getJoinedThreads = (threads: ThreadsEntity[]): ThreadsEntity[] => {
 	const thirtyDaysInSeconds = 30 * 24 * 60 * 60;
 	const currentTime = Math.floor(Date.now() / 1000);
 
 	const result = threads.filter((thread) => {
 		const lastMessageTimestamp = thread?.last_sent_message?.timestamp_seconds;
 		const isWithin30Days = lastMessageTimestamp && currentTime - Number(lastMessageTimestamp) < thirtyDaysInSeconds;
-		return thread.active === ThreadStatus.activePublic && isWithin30Days;
+		return thread.active === ThreadStatus.joined && isWithin30Days;
 	});
 
 	return result;
 };
-export const getJoinedThreadsWithinLast30Days = (threads: ThreadsEntity[]): ThreadsEntity[] => {
+export const getActiveThreads = (threads: ThreadsEntity[]): ThreadsEntity[] => {
 	const thirtyDaysInSeconds = 30 * 24 * 60 * 60;
 	const currentTime = Math.floor(Date.now() / 1000);
 
@@ -39,8 +39,8 @@ export const getThreadsOlderThan30Days = (threads: ThreadsEntity[]): ThreadsEnti
 	const olderThreads: ThreadsEntity[] = [];
 
 	for (const thread of threads) {
-		const timestamp = Number(thread.last_sent_message?.timestamp_seconds);
-		if (!timestamp) {
+		const timestamp = thread.active || Number(thread.last_sent_message?.timestamp_seconds);
+		if (!thread.active) {
 			olderThreads.push(thread);
 			continue;
 		}

--- a/libs/components/src/lib/components/MessageBox/PreviewOgp.tsx
+++ b/libs/components/src/lib/components/MessageBox/PreviewOgp.tsx
@@ -84,7 +84,9 @@ function PreviewOgp({ contextId }: PreviewOgpProps) {
 						image: invite?.clan_logo || '',
 						banner: resolvedBanner,
 						is_community: Boolean((invite as InviteBannerData)?.is_community),
-						type: 'invite'
+						type: 'invite',
+						clan_id: invite?.clan_id,
+						member_count: invite?.member_count
 					};
 				} else {
 					const res = await fetch(`${process.env.NX_OGP_URL}`, {
@@ -112,7 +114,11 @@ function PreviewOgp({ contextId }: PreviewOgpProps) {
 						image: previewData?.image || '',
 						title: previewData?.title || '',
 						description: previewData?.description || '',
-						type: previewData?.type || ''
+						type: previewData?.type || '',
+						member_count: previewData.member_count,
+						clan_id: previewData.clan_id,
+						banner: previewData.banner,
+						is_community: previewData.is_community
 					})
 				);
 			} catch (error: unknown) {

--- a/libs/components/src/lib/components/MessageBox/PreviewOgp.tsx
+++ b/libs/components/src/lib/components/MessageBox/PreviewOgp.tsx
@@ -115,10 +115,10 @@ function PreviewOgp({ contextId }: PreviewOgpProps) {
 						title: previewData?.title || '',
 						description: previewData?.description || '',
 						type: previewData?.type || '',
-						member_count: previewData.member_count,
-						clan_id: previewData.clan_id,
-						banner: previewData.banner,
-						is_community: previewData.is_community
+						member_count: previewData?.member_count,
+						clan_id: previewData?.clan_id,
+						banner: previewData?.banner,
+						is_community: previewData?.is_community
 					})
 				);
 			} catch (error: unknown) {

--- a/libs/components/src/lib/components/MessageBox/ReactionMentionInput/ReactionMentionInput.tsx
+++ b/libs/components/src/lib/components/MessageBox/ReactionMentionInput/ReactionMentionInput.tsx
@@ -262,7 +262,7 @@ export const MentionReactBase = memo((props: MentionReactBaseProps): ReactElemen
 			const lastMessageTimestamp = threadMeta?.lastSentTimestamp;
 			const isArchived = lastMessageTimestamp && currentTime - Number(lastMessageTimestamp) > THREAD_ARCHIVE_DURATION_SECONDS;
 			try {
-				if (isArchived || channel.active !== ThreadStatus.joined) {
+				if (isArchived || !channel.active) {
 					await dispatch(
 						threadsActions.writeActiveArchivedThread({
 							clanId: channel.clan_id ?? '',

--- a/libs/components/src/lib/components/MessageBox/types.ts
+++ b/libs/components/src/lib/components/MessageBox/types.ts
@@ -5,6 +5,8 @@ export type PreviewData = {
 	banner?: string;
 	is_community?: boolean;
 	type?: string;
+	clan_id?: string;
+	member_count?: number;
 };
 
 export type InviteBannerData = {

--- a/libs/components/src/lib/components/MessageWithUser/MessageLine.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/MessageLine.tsx
@@ -544,16 +544,7 @@ export const MessageLine = ({
 					);
 				} else if (element.type === EBacktickType.OGP_PREVIEW) {
 					if (!isSending) {
-						const url =
-							element.index !== undefined && t
-								? t.substring(
-										element.index,
-										Math.min(
-											t.indexOf(' ', element.index) === -1 ? t.length : t.indexOf(' ', element.index),
-											t.indexOf('\n', element.index) === -1 ? t.length : t.indexOf('\n', element.index)
-										)
-									)
-								: '';
+						const url = element.url || '';
 
 						if (INVITE_URL_REGEX.test(url || '')) {
 							formattedContent.push(<InvitePreviewCard key={`invite-${s}-${messageId}`} element={element} url={url} />);

--- a/libs/components/src/lib/components/MessageWithUser/MessageLine.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/MessageLine.tsx
@@ -1,5 +1,5 @@
 // eslint-disable-next-line @nx/enforce-module-boundaries
-import { clansActions, getStore, inviteActions, selectCanvasIdsByChannelId, selectClanById, selectInviteById, useAppDispatch } from '@mezon/store';
+import { clansActions, getStore, inviteActions, selectCanvasIdsByChannelId, selectClanById, useAppDispatch } from '@mezon/store';
 import { Icons } from '@mezon/ui';
 import type { IExtendedMessage } from '@mezon/utils';
 import { EBacktickType, ETokenMessage, INVITE_URL_REGEX, TypeMessage, convertMarkdown } from '@mezon/utils';
@@ -50,8 +50,12 @@ export interface ElementToken {
 	title?: string;
 	image?: string;
 	description?: string;
+	clan_id?: string;
+	banner?: string;
 	index?: number;
 	language?: string;
+	member_count?: number;
+	url?: string;
 }
 
 export function extractIdsFromUrl(url: string) {
@@ -172,25 +176,20 @@ const InvitePreviewCard = ({ element, url }: InvitePreviewCardProps) => {
 	const navigate = useNavigate();
 	const [joining, setJoining] = useState(false);
 	const [error, setError] = useState('');
-	const [banner, setBanner] = useState('');
 	const inviteId = url.match(INVITE_URL_REGEX)?.[1] || '';
-	const inviteInfo = useSelector(selectInviteById(inviteId || ''));
-	const joinedClan = useSelector(selectClanById(inviteInfo?.clan_id || ''));
+	const joinedClan = useSelector(selectClanById(element?.clanId || ''));
 
-	const clanTitle = inviteInfo?.clan_name || element.title || t('unknownClan');
-	const memberCount = Number(inviteInfo?.member_count || 0);
-	const memberLabel = t('memberCount', { count: memberCount });
-	const isJoined = Boolean(inviteInfo?.user_joined || joinedClan);
+	const clanTitle = element.title || t('unknownClan');
+	const isJoined = Boolean(joinedClan);
 	const isInvalidInvite = element.title === 'Invite Error';
-	const clanImage = inviteInfo?.clan_logo || element.image || '';
+	const clanImage = element.image || '';
 	const clanInitial = (clanTitle || 'M').trim().charAt(0).toUpperCase();
-	const isCommunityEnabled = Boolean((inviteInfo as { is_community?: boolean })?.is_community);
+	const isCommunityEnabled = false;
 
 	const handleJoinOrGoTo = async (event: React.MouseEvent<HTMLButtonElement>) => {
 		event.stopPropagation();
-		if (!inviteId) return;
-		if (isJoined && inviteInfo?.clan_id) {
-			navigate(`/chat/clans/${inviteInfo.clan_id}/channels/${inviteInfo.channel_id || '0'}`);
+		if (isJoined && element?.clanId) {
+			navigate(`/chat/clans/${element?.clanId}/members-safe`);
 			return;
 		}
 		try {
@@ -229,7 +228,7 @@ const InvitePreviewCard = ({ element, url }: InvitePreviewCardProps) => {
 		<div className="flex flex-col gap-0.5 max-w-[350px]">
 			<div className="relative rounded-2xl overflow-hidden border border-theme-primary bg-item-theme">
 				<div className="h-[76px] relative overflow-hidden bg-theme-setting-nav bg-theme-chat">
-					{banner ? <img src={banner} className="absolute inset-0 w-full h-full object-cover" alt="" /> : null}
+					{element.banner ? <img src={element.banner} className="absolute inset-0 w-full h-full object-cover" alt="" /> : null}
 				</div>
 				<div className="absolute top-[40px] left-4 w-[72px] h-[72px] rounded-[22px] overflow-hidden border-4 border-theme-primary bg-theme-setting-primary shadow-lg">
 					<div className="w-full h-full">
@@ -256,7 +255,7 @@ const InvitePreviewCard = ({ element, url }: InvitePreviewCardProps) => {
 					<div className="mt-2 flex items-center gap-2 text-theme-primary text-sm">
 						<span className="inline-flex items-center gap-1">
 							<span className="w-2 h-2 rounded-full text-theme-primary-active bg-[#22c55e]" />
-							{memberLabel}
+							{t('memberCount', { count: element.member_count || 0 })}
 						</span>
 					</div>
 					{error ? <p className="mt-2 text-xs text-red-300">{error}</p> : null}

--- a/libs/store/src/lib/channels/channels.slice.ts
+++ b/libs/store/src/lib/channels/channels.slice.ts
@@ -8,7 +8,7 @@ import type {
 	IChannel,
 	LoadingStatus
 } from '@mezon/utils';
-import { ModeResponsive, TypeCheck, checkIsThread, mapChannelToAppEntity } from '@mezon/utils';
+import { ModeResponsive, ThreadStatus, TypeCheck, checkIsThread, mapChannelToAppEntity } from '@mezon/utils';
 import type { EntityState, GetThunkAPI, PayloadAction, Update } from '@reduxjs/toolkit';
 import { createAsyncThunk, createEntityAdapter, createSelector, createSlice } from '@reduxjs/toolkit';
 import isEqual from 'lodash.isequal';
@@ -715,7 +715,10 @@ export const addThreadToChannels = createAsyncThunk(
 				thunkAPI.dispatch(
 					channelsActions.upsertOne({
 						clanId,
-						channel: { ...matchedThread, active: 1 } as ChannelsEntity
+						channel: {
+							...matchedThread,
+							active: matchedThread.active ? ThreadStatus.joined : ThreadStatus.activePublic
+						} as ChannelsEntity
 					})
 				);
 			}
@@ -1214,7 +1217,9 @@ export const channelsSlice = createSlice({
 					if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
 						rememberChannel = parsed as Record<string, string>;
 					}
-				} catch {}
+				} catch (e) {
+					console.error(e);
+				}
 				rememberChannel[clanId] = channelId;
 				localStorage.setItem('remember_channel', JSON.stringify(rememberChannel));
 			}

--- a/libs/store/src/lib/messages/messages.slice.ts
+++ b/libs/store/src/lib/messages/messages.slice.ts
@@ -1218,7 +1218,12 @@ export const sendMessage = createAsyncThunk('messages/sendMessage', async (paylo
 				s: content.t?.length || 0,
 				e: (content.t?.length || 0) + 1,
 				type: EBacktickType.OGP_PREVIEW,
-				index: ogpData.index
+				index: ogpData.index,
+				clan_id: ogpData.clan_id,
+				url: ogpData.url,
+				member_count: ogpData.member_count,
+				banner: ogpData.banner,
+				is_community: ogpData.is_community
 			});
 			content = {
 				...content,

--- a/libs/store/src/lib/messages/references.slice.ts
+++ b/libs/store/src/lib/messages/references.slice.ts
@@ -46,6 +46,10 @@ export interface OgpEntity {
 	description?: string;
 	channel_id: string;
 	type?: string;
+	clan_id?: string;
+	member_count?: number;
+	banner?: string;
+	is_community?: boolean;
 }
 
 export const referencesAdapter = createEntityAdapter<ReferencesEntity>();
@@ -266,6 +270,10 @@ export const referencesSlice = createSlice({
 				description?: string;
 				channel_id: string;
 				type?: string;
+				clan_id?: string;
+				member_count?: number;
+				banner?: string;
+				is_community?: boolean;
 			} | null>
 		) {
 			state.ogpData = action.payload;

--- a/libs/translations/src/languages/de/channelTopbar.json
+++ b/libs/translations/src/languages/de/channelTopbar.json
@@ -28,7 +28,7 @@
 	},
 	"directMessage": "Direktnachrichten",
 	"activeThreads": "Aktive Threads",
-	"joinedThreadsLast30Days": "Beigetretene Threads (letzte 30 Tage)",
+	"joinedThreads": "Beigetretene Threads",
 	"olderThreads": "Ältere Threads",
 	"loading": "Wird geladen...",
 	"topic": "Thema",

--- a/libs/translations/src/languages/en/channelTopbar.json
+++ b/libs/translations/src/languages/en/channelTopbar.json
@@ -28,7 +28,7 @@
 	},
 	"directMessage": "Direct message",
 	"activeThreads": "Active Threads",
-	"joinedThreadsLast30Days": "Joined Threads (Last 30 Days)",
+	"joinedThreads": "Joined Threads",
 	"olderThreads": "Older Threads",
 	"loading": "Loading...",
 	"topic": "Topic",

--- a/libs/translations/src/languages/es/channelTopbar.json
+++ b/libs/translations/src/languages/es/channelTopbar.json
@@ -27,7 +27,7 @@
 	},
 	"directMessage": "Mensaje directo",
 	"activeThreads": "Hilos activos",
-	"joinedThreadsLast30Days": "Hilos unidos (últimos 30 días)",
+	"joinedThreads": "Hilos unidos",
 	"olderThreads": "Hilos anteriores",
 	"loading": "Cargando...",
 	"topic": "Tema",

--- a/libs/translations/src/languages/it/channelTopbar.json
+++ b/libs/translations/src/languages/it/channelTopbar.json
@@ -28,7 +28,7 @@
 	},
 	"directMessage": "Messaggio diretto",
 	"activeThreads": "Thread attivi",
-	"joinedThreadsLast30Days": "Thread a cui hai partecipato (ultimi 30 giorni)",
+	"joinedThreads": "Thread a cui hai partecipato",
 	"olderThreads": "Thread più vecchi",
 	"loading": "Caricamento...",
 	"topic": "Argomento",

--- a/libs/translations/src/languages/jpn/channelTopbar.json
+++ b/libs/translations/src/languages/jpn/channelTopbar.json
@@ -28,7 +28,7 @@
 	},
 	"directMessage": "ダイレクトメッセージ",
 	"activeThreads": "アクティブスレッド",
-	"joinedThreadsLast30Days": "参加したスレッド（過去30日）",
+	"joinedThreads": "参加したスレッド",
 	"olderThreads": "古いスレッド",
 	"loading": "読み込み中...",
 	"topic": "トピック",

--- a/libs/translations/src/languages/kr/channelTopbar.json
+++ b/libs/translations/src/languages/kr/channelTopbar.json
@@ -28,7 +28,7 @@
 	},
 	"directMessage": "다이렉트 메시지",
 	"activeThreads": "활성 스레드",
-	"joinedThreadsLast30Days": "참가한 스레드 (지난 30 일)",
+	"joinedThreads": "참가한 스레드",
 	"olderThreads": "이전 스레드",
 	"loading": "로딩 중...",
 	"topic": "주제",

--- a/libs/translations/src/languages/pt/channelTopbar.json
+++ b/libs/translations/src/languages/pt/channelTopbar.json
@@ -28,7 +28,7 @@
 	},
 	"directMessage": "Mensagem direta",
 	"activeThreads": "Tópicos ativos",
-	"joinedThreadsLast30Days": "Tópicos participados (últimos 30 dias)",
+	"joinedThreads": "Tópicos participados",
 	"olderThreads": "Tópicos mais antigos",
 	"loading": "Carregando...",
 	"topic": "Tópico",

--- a/libs/translations/src/languages/ru/channelTopbar.json
+++ b/libs/translations/src/languages/ru/channelTopbar.json
@@ -27,7 +27,7 @@
 	},
 	"directMessage": "Личное сообщение",
 	"activeThreads": "Активные ветки",
-	"joinedThreadsLast30Days": "Мои ветки (последние 30 дней)",
+	"joinedThreads": "Мои ветки",
 	"olderThreads": "Старые ветки",
 	"loading": "Загрузка...",
 	"topic": "Тема",
@@ -165,4 +165,3 @@
 	"moreFile": "новый файл",
 	"moreFiles": "новые файлы"
 }
-

--- a/libs/translations/src/languages/swe/channelTopbar.json
+++ b/libs/translations/src/languages/swe/channelTopbar.json
@@ -28,7 +28,7 @@
 	},
 	"directMessage": "Direktmeddelande",
 	"activeThreads": "Aktiva trådar",
-	"joinedThreadsLast30Days": "Anslutna trådar (senaste 30 dagarna)",
+	"joinedThreads": "Anslutna trådar",
 	"olderThreads": "Äldre trådar",
 	"loading": "Laddar...",
 	"topic": "Ämne",

--- a/libs/translations/src/languages/tt/channelTopbar.json
+++ b/libs/translations/src/languages/tt/channelTopbar.json
@@ -27,7 +27,7 @@
 	},
 	"directMessage": "Шәхси хәбәр",
 	"activeThreads": "Актив ботакламалар",
-	"joinedThreadsLast30Days": "Минем ботакламаларым (соңгы 30 көн)",
+	"joinedThreads": "Минем ботакламаларым",
 	"olderThreads": "Иске ботакламалар",
 	"loading": "Йөкләү...",
 	"topic": "Тема",

--- a/libs/translations/src/languages/vi/channelTopbar.json
+++ b/libs/translations/src/languages/vi/channelTopbar.json
@@ -28,7 +28,7 @@
 	},
 	"directMessage": "Tin nhắn trực tiếp",
 	"activeThreads": "Chủ đề đang hoạt động",
-	"joinedThreadsLast30Days": "Chủ đề đã tham gia (30 ngày qua)",
+	"joinedThreads": "Chủ đề đã tham gia",
 	"olderThreads": "Chủ đề cũ hơn",
 	"loading": "Đang tải...",
 	"topic": "Chủ đề",

--- a/libs/utils/src/lib/types/messageLine.ts
+++ b/libs/utils/src/lib/types/messageLine.ts
@@ -71,6 +71,11 @@ export interface IMarkdownOnMessage extends IMarkdown, IStartEndIndex {
 	description?: string;
 	index?: number;
 	language?: string;
+	url?: string;
+	member_count?: number;
+	clan_id?: string;
+	banner?: string;
+	is_community?: boolean;
 }
 export type ILinkVoiceRoomOnMessage = IStartEndIndex;
 export type ILinkYoutubeOnMessage = IStartEndIndex;


### PR DESCRIPTION
### Changes

- Add more data to ogp message

### Description 

- OGP data cannot show data clan invite because it select from store. Only who send has that data so need to put it in message for everyone can see it
- OGP url break when link has break down line. Put url data on message element so dont have to cut string 

### Test 

- Send ogp invite link then ctrl R
- Send ogp url with break down line then click ogp 
- Click join clan from ogp invite not joined
- Click join from ogp invite clan already joined

### Ticket

- [Desktop/Website] OGP bugs
https://github.com/mezonai/mezon/issues/13117 