### PR TITLE
260520 - WEB/DESKTOP - Fix26b/web/fix ogp data

### DIFF
--- a/libs/components/src/lib/components/MessageBox/PreviewOgp.tsx
+++ b/libs/components/src/lib/components/MessageBox/PreviewOgp.tsx
@@ -84,7 +84,9 @@ function PreviewOgp({ contextId }: PreviewOgpProps) {
 						image: invite?.clan_logo || '',
 						banner: resolvedBanner,
 						is_community: Boolean((invite as InviteBannerData)?.is_community),
-						type: 'invite'
+						type: 'invite',
+						clan_id: invite?.clan_id,
+						member_count: invite?.member_count
 					};
 				} else {
 					const res = await fetch(`${process.env.NX_OGP_URL}`, {
@@ -112,7 +114,11 @@ function PreviewOgp({ contextId }: PreviewOgpProps) {
 						image: previewData?.image || '',
 						title: previewData?.title || '',
 						description: previewData?.description || '',
-						type: previewData?.type || ''
+						type: previewData?.type || '',
+						member_count: previewData.member_count,
+						clan_id: previewData.clan_id,
+						banner: previewData.banner,
+						is_community: previewData.is_community
 					})
 				);
 			} catch (error: unknown) {

--- a/libs/components/src/lib/components/MessageBox/PreviewOgp.tsx
+++ b/libs/components/src/lib/components/MessageBox/PreviewOgp.tsx
@@ -115,10 +115,10 @@ function PreviewOgp({ contextId }: PreviewOgpProps) {
 						title: previewData?.title || '',
 						description: previewData?.description || '',
 						type: previewData?.type || '',
-						member_count: previewData.member_count,
-						clan_id: previewData.clan_id,
-						banner: previewData.banner,
-						is_community: previewData.is_community
+						member_count: previewData?.member_count,
+						clan_id: previewData?.clan_id,
+						banner: previewData?.banner,
+						is_community: previewData?.is_community
 					})
 				);
 			} catch (error: unknown) {

--- a/libs/components/src/lib/components/MessageBox/types.ts
+++ b/libs/components/src/lib/components/MessageBox/types.ts
@@ -5,6 +5,8 @@ export type PreviewData = {
 	banner?: string;
 	is_community?: boolean;
 	type?: string;
+	clan_id?: string;
+	member_count?: number;
 };
 
 export type InviteBannerData = {

--- a/libs/components/src/lib/components/MessageWithUser/MessageLine.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/MessageLine.tsx
@@ -544,16 +544,7 @@ export const MessageLine = ({
 					);
 				} else if (element.type === EBacktickType.OGP_PREVIEW) {
 					if (!isSending) {
-						const url =
-							element.index !== undefined && t
-								? t.substring(
-										element.index,
-										Math.min(
-											t.indexOf(' ', element.index) === -1 ? t.length : t.indexOf(' ', element.index),
-											t.indexOf('\n', element.index) === -1 ? t.length : t.indexOf('\n', element.index)
-										)
-									)
-								: '';
+						const url = element.url || '';
 
 						if (INVITE_URL_REGEX.test(url || '')) {
 							formattedContent.push(<InvitePreviewCard key={`invite-${s}-${messageId}`} element={element} url={url} />);

--- a/libs/components/src/lib/components/MessageWithUser/MessageLine.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/MessageLine.tsx
@@ -50,7 +50,6 @@ export interface ElementToken {
 	title?: string;
 	image?: string;
 	description?: string;
-	clan_id?: string;
 	banner?: string;
 	index?: number;
 	language?: string;
@@ -189,7 +188,7 @@ const InvitePreviewCard = ({ element, url }: InvitePreviewCardProps) => {
 	const handleJoinOrGoTo = async (event: React.MouseEvent<HTMLButtonElement>) => {
 		event.stopPropagation();
 		if (isJoined && element?.clanId) {
-			navigate(`/chat/clans/${element?.clanId}/members-safe`);
+			navigate(`/chat/clans/${element?.clanId}/member-safety`);
 			return;
 		}
 		try {

--- a/libs/components/src/lib/components/MessageWithUser/MessageLine.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/MessageLine.tsx
@@ -54,6 +54,7 @@ export interface ElementToken {
 	index?: number;
 	language?: string;
 	member_count?: number;
+	is_community?: boolean;
 	url?: string;
 }
 
@@ -183,7 +184,7 @@ const InvitePreviewCard = ({ element, url }: InvitePreviewCardProps) => {
 	const isInvalidInvite = element.title === 'Invite Error';
 	const clanImage = element.image || '';
 	const clanInitial = (clanTitle || 'M').trim().charAt(0).toUpperCase();
-	const isCommunityEnabled = false;
+	const isCommunityEnabled = !!element?.is_community;
 
 	const handleJoinOrGoTo = async (event: React.MouseEvent<HTMLButtonElement>) => {
 		event.stopPropagation();

--- a/libs/components/src/lib/components/MessageWithUser/MessageLine.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/MessageLine.tsx
@@ -1,5 +1,5 @@
 // eslint-disable-next-line @nx/enforce-module-boundaries
-import { clansActions, getStore, inviteActions, selectCanvasIdsByChannelId, selectClanById, selectInviteById, useAppDispatch } from '@mezon/store';
+import { clansActions, getStore, inviteActions, selectCanvasIdsByChannelId, selectClanById, useAppDispatch } from '@mezon/store';
 import { Icons } from '@mezon/ui';
 import type { IExtendedMessage } from '@mezon/utils';
 import { EBacktickType, ETokenMessage, INVITE_URL_REGEX, TypeMessage, convertMarkdown } from '@mezon/utils';
@@ -50,8 +50,12 @@ export interface ElementToken {
 	title?: string;
 	image?: string;
 	description?: string;
+	clan_id?: string;
+	banner?: string;
 	index?: number;
 	language?: string;
+	member_count?: number;
+	url?: string;
 }
 
 export function extractIdsFromUrl(url: string) {
@@ -172,25 +176,20 @@ const InvitePreviewCard = ({ element, url }: InvitePreviewCardProps) => {
 	const navigate = useNavigate();
 	const [joining, setJoining] = useState(false);
 	const [error, setError] = useState('');
-	const [banner, setBanner] = useState('');
 	const inviteId = url.match(INVITE_URL_REGEX)?.[1] || '';
-	const inviteInfo = useSelector(selectInviteById(inviteId || ''));
-	const joinedClan = useSelector(selectClanById(inviteInfo?.clan_id || ''));
+	const joinedClan = useSelector(selectClanById(element?.clanId || ''));
 
-	const clanTitle = inviteInfo?.clan_name || element.title || t('unknownClan');
-	const memberCount = Number(inviteInfo?.member_count || 0);
-	const memberLabel = t('memberCount', { count: memberCount });
-	const isJoined = Boolean(inviteInfo?.user_joined || joinedClan);
+	const clanTitle = element.title || t('unknownClan');
+	const isJoined = Boolean(joinedClan);
 	const isInvalidInvite = element.title === 'Invite Error';
-	const clanImage = inviteInfo?.clan_logo || element.image || '';
+	const clanImage = element.image || '';
 	const clanInitial = (clanTitle || 'M').trim().charAt(0).toUpperCase();
-	const isCommunityEnabled = Boolean((inviteInfo as { is_community?: boolean })?.is_community);
+	const isCommunityEnabled = false;
 
 	const handleJoinOrGoTo = async (event: React.MouseEvent<HTMLButtonElement>) => {
 		event.stopPropagation();
-		if (!inviteId) return;
-		if (isJoined && inviteInfo?.clan_id) {
-			navigate(`/chat/clans/${inviteInfo.clan_id}/channels/${inviteInfo.channel_id || '0'}`);
+		if (isJoined && element?.clanId) {
+			navigate(`/chat/clans/${element?.clanId}/members-safe`);
 			return;
 		}
 		try {
@@ -229,7 +228,7 @@ const InvitePreviewCard = ({ element, url }: InvitePreviewCardProps) => {
 		<div className="flex flex-col gap-0.5 max-w-[350px]">
 			<div className="relative rounded-2xl overflow-hidden border border-theme-primary bg-item-theme">
 				<div className="h-[76px] relative overflow-hidden bg-theme-setting-nav bg-theme-chat">
-					{banner ? <img src={banner} className="absolute inset-0 w-full h-full object-cover" alt="" /> : null}
+					{element.banner ? <img src={element.banner} className="absolute inset-0 w-full h-full object-cover" alt="" /> : null}
 				</div>
 				<div className="absolute top-[40px] left-4 w-[72px] h-[72px] rounded-[22px] overflow-hidden border-4 border-theme-primary bg-theme-setting-primary shadow-lg">
 					<div className="w-full h-full">
@@ -256,7 +255,7 @@ const InvitePreviewCard = ({ element, url }: InvitePreviewCardProps) => {
 					<div className="mt-2 flex items-center gap-2 text-theme-primary text-sm">
 						<span className="inline-flex items-center gap-1">
 							<span className="w-2 h-2 rounded-full text-theme-primary-active bg-[#22c55e]" />
-							{memberLabel}
+							{t('memberCount', { count: element.member_count || 0 })}
 						</span>
 					</div>
 					{error ? <p className="mt-2 text-xs text-red-300">{error}</p> : null}

--- a/libs/store/src/lib/messages/messages.slice.ts
+++ b/libs/store/src/lib/messages/messages.slice.ts
@@ -1218,7 +1218,12 @@ export const sendMessage = createAsyncThunk('messages/sendMessage', async (paylo
 				s: content.t?.length || 0,
 				e: (content.t?.length || 0) + 1,
 				type: EBacktickType.OGP_PREVIEW,
-				index: ogpData.index
+				index: ogpData.index,
+				clan_id: ogpData.clan_id,
+				url: ogpData.url,
+				member_count: ogpData.member_count,
+				banner: ogpData.banner,
+				is_community: ogpData.is_community
 			});
 			content = {
 				...content,

--- a/libs/store/src/lib/messages/messages.slice.ts
+++ b/libs/store/src/lib/messages/messages.slice.ts
@@ -1219,7 +1219,7 @@ export const sendMessage = createAsyncThunk('messages/sendMessage', async (paylo
 				e: (content.t?.length || 0) + 1,
 				type: EBacktickType.OGP_PREVIEW,
 				index: ogpData.index,
-				clan_id: ogpData.clan_id,
+				clanId: ogpData.clan_id,
 				url: ogpData.url,
 				member_count: ogpData.member_count,
 				banner: ogpData.banner,

--- a/libs/store/src/lib/messages/references.slice.ts
+++ b/libs/store/src/lib/messages/references.slice.ts
@@ -46,6 +46,10 @@ export interface OgpEntity {
 	description?: string;
 	channel_id: string;
 	type?: string;
+	clan_id?: string;
+	member_count?: number;
+	banner?: string;
+	is_community?: boolean;
 }
 
 export const referencesAdapter = createEntityAdapter<ReferencesEntity>();
@@ -266,6 +270,10 @@ export const referencesSlice = createSlice({
 				description?: string;
 				channel_id: string;
 				type?: string;
+				clan_id?: string;
+				member_count?: number;
+				banner?: string;
+				is_community?: boolean;
 			} | null>
 		) {
 			state.ogpData = action.payload;

--- a/libs/utils/src/lib/types/messageLine.ts
+++ b/libs/utils/src/lib/types/messageLine.ts
@@ -73,7 +73,6 @@ export interface IMarkdownOnMessage extends IMarkdown, IStartEndIndex {
 	language?: string;
 	url?: string;
 	member_count?: number;
-	clan_id?: string;
 	banner?: string;
 	is_community?: boolean;
 }

--- a/libs/utils/src/lib/types/messageLine.ts
+++ b/libs/utils/src/lib/types/messageLine.ts
@@ -71,6 +71,11 @@ export interface IMarkdownOnMessage extends IMarkdown, IStartEndIndex {
 	description?: string;
 	index?: number;
 	language?: string;
+	url?: string;
+	member_count?: number;
+	clan_id?: string;
+	banner?: string;
+	is_community?: boolean;
 }
 export type ILinkVoiceRoomOnMessage = IStartEndIndex;
 export type ILinkYoutubeOnMessage = IStartEndIndex;


### PR DESCRIPTION
### Changes

- Add more data to ogp message

### Description 

- OGP data cannot show data clan invite because it select from store. Only who send has that data so need to put it in message for everyone can see it
- OGP url break when link has break down line. Put url data on message element so dont have to cut string 

### Test 

- Send ogp invite link then ctrl R
- Send ogp url with break down line then click ogp 
- Click join clan from ogp invite not joined
- Click join from ogp invite clan already joined

### Ticket

- [Desktop/Website] OGP bugs
https://github.com/mezonai/mezon/issues/13117 