### PR TITLE
260520 - HOTFIX - probe video codec incrementally for MOV on Electron Mac

### DIFF
--- a/libs/components/src/lib/components/MessageWithUser/MessageVideo.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/MessageVideo.tsx
@@ -559,7 +559,7 @@ function DefaultVideo({ attachmentData, isMobile = false, isPreview = false, obs
 }
 
 function MessageVideo(props: MessageImage) {
-	if (!isElectronMac()) {
+	if (isElectronMac()) {
 		return <MacElectronVideo {...props} />;
 	}
 	return <DefaultVideo {...props} />;

--- a/libs/components/src/lib/components/MessageWithUser/MessageVideo.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/MessageVideo.tsx
@@ -17,10 +17,17 @@ export type MessageImage = {
 export const MIN_WIDTH_VIDEO_SHOW = 200;
 export const DEFAULT_HEIGHT_VIDEO_SHOW = 150;
 
-type VideoProbeStatus = 'probing' | 'ready' | 'unsupported' | 'error';
+type VideoProbeStatus = 'idle' | 'probing' | 'ready' | 'unsupported' | 'error';
 
-const RANGE_PROBE_SIZE = 1024 * 1024;
+const INITIAL_PROBE_SIZE = 64 * 1024;
+const NEXT_PROBE_CHUNK_SIZE = 128 * 1024;
+const MAX_PROBE_BYTES = 512 * 1024;
 const MP4BOX_TIMEOUT_MS = 5000;
+
+function isLikelyQuickTimeUrl(url?: string, filename?: string): boolean {
+	const path = (filename || url || '').split('?')[0].toLowerCase();
+	return path.endsWith('.mov') || path.endsWith('.qt');
+}
 
 interface VideoCodecInfo {
 	codec: string;
@@ -30,92 +37,173 @@ interface VideoCodecInfo {
 	isAppleDevice: boolean;
 }
 
+interface VideoProbeRange {
+	buffer: MP4BoxBuffer;
+	start: number;
+	end: number;
+	totalSize: number | null;
+}
+
+interface ParsedContentRange {
+	start: number;
+	end: number;
+	totalSize: number | null;
+}
+
 function isElectronMac(): boolean {
 	return isElectron() && navigator.platform?.toLowerCase().includes('mac');
 }
 
+function parseContentRangeHeader(contentRange: string | null): ParsedContentRange | null {
+	if (!contentRange) return null;
+
+	const match = contentRange.match(/^bytes\s+(\d+)-(\d+)\/(\d+|\*)$/i);
+	if (!match) return null;
+
+	const start = Number(match[1]);
+	const end = Number(match[2]);
+	const totalSize = match[3] === '*' ? null : Number(match[3]);
+
+	if (!Number.isSafeInteger(start) || !Number.isSafeInteger(end)) return null;
+	if (totalSize !== null && !Number.isSafeInteger(totalSize)) return null;
+
+	return { start, end, totalSize };
+}
+
+async function fetchVideoProbeRange(url: string, start: number, end: number | undefined, signal?: AbortSignal): Promise<VideoProbeRange | null> {
+	const response = await fetch(url, {
+		headers: { Range: end === undefined ? `bytes=${start}-` : `bytes=${start}-${end}` },
+		signal
+	});
+
+	if (response.status !== 206) {
+		void response.body?.cancel().catch(() => undefined);
+		return null;
+	}
+
+	const arrayBuffer = await response.arrayBuffer();
+	const parsedContentRange = parseContentRangeHeader(response.headers.get('Content-Range'));
+	const responseStart = parsedContentRange?.start ?? start;
+	const totalSize = parsedContentRange?.totalSize ?? null;
+	const buffer = MP4BoxBuffer.fromArrayBuffer(arrayBuffer, responseStart);
+
+	return {
+		buffer,
+		start: responseStart,
+		end: responseStart + arrayBuffer.byteLength - 1,
+		totalSize
+	};
+}
+
+function parseCodecFromMovie(info: Movie): VideoCodecInfo | null {
+	const videoTrack: Track | undefined = info.videoTracks?.[0] || info.tracks?.find((t: Track) => t.type === 'video');
+	if (!videoTrack) {
+		return null;
+	}
+
+	const codec: string = videoTrack.codec || '';
+	const isHEVC = codec.startsWith('hev1') || codec.startsWith('hvc1');
+	const isDolbyVision = codec.startsWith('dvh1') || codec.startsWith('dvhe');
+	const profileMatch = isHEVC ? codec.match(/^(?:hev1|hvc1)\.(\d+)/) : null;
+	const isMain10 = profileMatch ? parseInt(profileMatch[1]) === 2 : false;
+
+	const appleTrackNames = ['core media video', 'core media audio'];
+	const appleBrands = ['mp42', 'qt  '];
+	const isAppleDevice =
+		appleTrackNames.some((name) => videoTrack.name?.toLowerCase().includes(name)) ||
+		(info.brands?.some((b: string) => appleBrands.includes(b)) && videoTrack.timescale === 600);
+
+	return { codec, isHEVC, isMain10, isDolbyVision, isAppleDevice };
+}
+
 async function probeVideoCodec(url: string, signal?: AbortSignal): Promise<VideoCodecInfo | null> {
-	let timeout: ReturnType<typeof setTimeout> | undefined;
-	let mp4boxFile: ReturnType<typeof createFile> | undefined;
+	return new Promise((resolve) => {
+		const mp4boxFile = createFile();
+		let resolved = false;
+		let bytesFetched = 0;
+		let lastProbeRange: VideoProbeRange | null = null;
+		let totalSize: number | null = null;
+		let nextBufferStart: number | undefined;
 
-	try {
-		const response = await fetch(url, {
-			headers: { Range: `bytes=0-${RANGE_PROBE_SIZE - 1}` },
-			signal
-		});
+		const timeout = setTimeout(() => finalize(null), MP4BOX_TIMEOUT_MS);
 
-		if (!response.ok && response.status !== 206) {
-			return null;
-		}
-
-		const arrayBuffer = await response.arrayBuffer();
-
-		return new Promise<VideoCodecInfo | null>((resolve) => {
-			mp4boxFile = createFile();
-			let resolved = false;
-
-			const cleanup = () => {
-				if (timeout) {
-					clearTimeout(timeout);
-					timeout = undefined;
-				}
-				if (mp4boxFile) {
-					mp4boxFile.onReady = undefined;
-					mp4boxFile.onError = undefined;
-					mp4boxFile.flush();
-					mp4boxFile = undefined;
-				}
-			};
-
-			const finalize = (result: VideoCodecInfo | null) => {
-				if (resolved) return;
-				resolved = true;
-				cleanup();
-				resolve(result);
-			};
-
-			timeout = setTimeout(() => finalize(null), MP4BOX_TIMEOUT_MS);
-
-			mp4boxFile.onReady = (info: Movie) => {
-				const videoTrack: Track | undefined = info.videoTracks?.[0] || info.tracks?.find((t: Track) => t.type === 'video');
-				if (!videoTrack) {
-					finalize(null);
-					return;
-				}
-
-				const codec: string = videoTrack.codec || '';
-				const isHEVC = codec.startsWith('hev1') || codec.startsWith('hvc1');
-				const isDolbyVision = codec.startsWith('dvh1') || codec.startsWith('dvhe');
-				const profileMatch = isHEVC ? codec.match(/^(?:hev1|hvc1)\.(\d+)/) : null;
-				const isMain10 = profileMatch ? parseInt(profileMatch[1]) === 2 : false;
-
-				const appleTrackNames = ['core media video', 'core media audio'];
-				const appleBrands = ['mp42'];
-				const isAppleDevice =
-					appleTrackNames.some((name) => videoTrack.name?.toLowerCase().includes(name)) ||
-					(info.brands?.some((b: string) => appleBrands.includes(b)) && videoTrack.timescale === 600);
-
-				finalize({ codec, isHEVC, isMain10, isDolbyVision, isAppleDevice });
-			};
-
-			mp4boxFile.onError = () => finalize(null);
-
-			try {
-				const mp4Buffer = MP4BoxBuffer.fromArrayBuffer(arrayBuffer, 0);
-				mp4boxFile.appendBuffer(mp4Buffer);
-			} catch {
-				finalize(null);
-			}
-		});
-	} catch {
-		if (timeout) clearTimeout(timeout);
-		if (mp4boxFile) {
+		function cleanup() {
+			clearTimeout(timeout);
 			mp4boxFile.onReady = undefined;
 			mp4boxFile.onError = undefined;
 			mp4boxFile.flush();
 		}
-		return null;
-	}
+
+		function finalize(result: VideoCodecInfo | null) {
+			if (resolved) return;
+			resolved = true;
+			cleanup();
+			resolve(result);
+		}
+
+		const flushAndFinalize = () => {
+			mp4boxFile.flush();
+			if (!resolved) {
+				finalize(null);
+			}
+		};
+
+		const appendRange = (range: VideoProbeRange) => {
+			lastProbeRange = range;
+			totalSize = range.totalSize ?? totalSize;
+			bytesFetched += range.end - range.start + 1;
+			nextBufferStart = mp4boxFile.appendBuffer(range.buffer);
+		};
+
+		const getNextRequestedStart = () => {
+			if (
+				typeof nextBufferStart === 'number' &&
+				Number.isSafeInteger(nextBufferStart) &&
+				(!lastProbeRange || nextBufferStart > lastProbeRange.end)
+			) {
+				return nextBufferStart;
+			}
+			return lastProbeRange ? lastProbeRange.end + 1 : 0;
+		};
+
+		mp4boxFile.onReady = (info: Movie) => finalize(parseCodecFromMovie(info));
+		mp4boxFile.onError = () => finalize(null);
+
+		const runProbe = async () => {
+			const firstRange = await fetchVideoProbeRange(url, 0, INITIAL_PROBE_SIZE - 1, signal);
+			if (!firstRange) {
+				finalize(null);
+				return;
+			}
+
+			appendRange(firstRange);
+
+			while (!resolved && bytesFetched < MAX_PROBE_BYTES) {
+				const requestedStart = getNextRequestedStart();
+				if (totalSize !== null && requestedStart > totalSize - 1) {
+					flushAndFinalize();
+					return;
+				}
+
+				const remainingBudget = MAX_PROBE_BYTES - bytesFetched;
+				const chunkSize = Math.min(NEXT_PROBE_CHUNK_SIZE, remainingBudget);
+				if (chunkSize <= 0) break;
+
+				const requestedEnd = totalSize === null ? requestedStart + chunkSize - 1 : Math.min(totalSize - 1, requestedStart + chunkSize - 1);
+				const probeRange = await fetchVideoProbeRange(url, requestedStart, requestedEnd, signal);
+				if (!probeRange) {
+					flushAndFinalize();
+					return;
+				}
+
+				appendRange(probeRange);
+			}
+
+			flushAndFinalize();
+		};
+
+		runProbe().catch(() => finalize(null));
+	});
 }
 
 function isUnsafeCodec(info: VideoCodecInfo): boolean {
@@ -125,14 +213,18 @@ function isUnsafeCodec(info: VideoCodecInfo): boolean {
 	return false;
 }
 
-function useVideoProbe(url: string | undefined, shouldProbe: boolean) {
-	const [status, setStatus] = useState<VideoProbeStatus>('probing');
+function useVideoProbe(url: string | undefined, shouldProbe: boolean, filename?: string) {
+	const [status, setStatus] = useState<VideoProbeStatus>('idle');
 	const [errorMessage, setErrorMessage] = useState('');
 	const [codecInfo, setCodecInfo] = useState<VideoCodecInfo | null>(null);
 	const { t } = useTranslation('media');
+	const strictProbe = isElectronMac();
 
 	useEffect(() => {
-		if (!shouldProbe) return;
+		if (!shouldProbe) {
+			setStatus('idle');
+			return;
+		}
 
 		if (!url) {
 			setStatus('error');
@@ -146,6 +238,7 @@ function useVideoProbe(url: string | undefined, shouldProbe: boolean) {
 
 		const abortController = new AbortController();
 		let cancelled = false;
+		const unsupportedMessage = strictProbe ? t('video.error.codecNotSupportedElectron') : t('video.error.codecNotSupported');
 
 		const runProbe = async () => {
 			const info = await probeVideoCodec(url, abortController.signal);
@@ -156,14 +249,20 @@ function useVideoProbe(url: string | undefined, shouldProbe: boolean) {
 				setCodecInfo(info);
 				if (isUnsafeCodec(info)) {
 					setStatus('unsupported');
-					setErrorMessage(t('video.error.codecNotSupportedElectron'));
+					setErrorMessage(unsupportedMessage);
 					return;
 				}
+				setStatus('ready');
+				return;
 			}
 
-			if (!cancelled) {
-				setStatus('ready');
+			if (strictProbe && isLikelyQuickTimeUrl(url, filename)) {
+				setStatus('unsupported');
+				setErrorMessage(unsupportedMessage);
+				return;
 			}
+
+			setStatus('ready');
 		};
 
 		runProbe();
@@ -172,7 +271,7 @@ function useVideoProbe(url: string | undefined, shouldProbe: boolean) {
 			cancelled = true;
 			abortController.abort();
 		};
-	}, [url, t, shouldProbe]);
+	}, [url, filename, t, shouldProbe, strictProbe]);
 
 	return { status, errorMessage, codecInfo };
 }
@@ -271,7 +370,7 @@ function MacElectronVideo({ attachmentData, isMobile = false, isPreview = false,
 	const { t } = useTranslation('media');
 	const containerRef = useRef<HTMLDivElement>(null);
 	const isIntersecting = useIsIntersecting(containerRef, observeIntersection);
-	const { status: probeStatus, errorMessage, codecInfo } = useVideoProbe(attachmentData.url, isIntersecting);
+	const { status: probeStatus, errorMessage, codecInfo } = useVideoProbe(attachmentData.url, isIntersecting, attachmentData.filename);
 	const { mediaStyle } = useVideoMediaDimensions(attachmentData, isMobile, isPreview);
 	const handleDownloadVideo = useDownloadVideo(attachmentData.url, attachmentData.filename);
 
@@ -311,9 +410,7 @@ function MacElectronVideo({ attachmentData, isMobile = false, isPreview = false,
 
 	return (
 		<div ref={containerRef} className="relative overflow-hidden group rounded-lg max-w-full">
-			{!isIntersecting && <VideoSkeleton style={mediaStyle} />}
-
-			{isIntersecting && probeStatus === 'probing' && <VideoSkeleton style={mediaStyle} />}
+			{(probeStatus === 'idle' || probeStatus === 'probing') && <VideoSkeleton style={mediaStyle} />}
 
 			{isIntersecting && (probeStatus === 'error' || probeStatus === 'unsupported') && (
 				<div
@@ -462,7 +559,7 @@ function DefaultVideo({ attachmentData, isMobile = false, isPreview = false, obs
 }
 
 function MessageVideo(props: MessageImage) {
-	if (isElectronMac()) {
+	if (!isElectronMac()) {
 		return <MacElectronVideo {...props} />;
 	}
 	return <DefaultVideo {...props} />;


### PR DESCRIPTION
Use ranged MP4Box probing with smaller initial fetch, QuickTime detection, and clearer unsupported codec messaging on macOS desktop.