### PR TITLE
260521 - WEB/DESKTOP - fix marks as read channel

### DIFF
--- a/libs/core/src/lib/chat/contexts/ChatContext.tsx
+++ b/libs/core/src/lib/chat/contexts/ChatContext.tsx
@@ -2509,7 +2509,7 @@ const ChatContextProvider: React.FC<ChatContextProviderProps> = ({ children, isM
 		badgeService.markAsReadChannel(
 			markAsReadEvent.clan_id as string,
 			markAsReadEvent.channel_id,
-			[markAsReadEvent.channel_id, ...channelIds],
+			[...channelIds],
 			channelUpdates,
 			relatedChannels.map((channel) => ({
 				channelId: channel.id,

--- a/libs/core/src/lib/chat/contexts/ChatContext.tsx
+++ b/libs/core/src/lib/chat/contexts/ChatContext.tsx
@@ -2496,12 +2496,16 @@ const ChatContextProvider: React.FC<ChatContextProviderProps> = ({ children, isM
 			badgeService.markAsReadCategory(markAsReadEvent.clan_id as string, markAsReadEvent.category_id, channelIds, channelUpdates);
 			return;
 		}
-		const relatedChannels = channels.filter((channel) => channel.parent_id === markAsReadEvent.channel_id);
+		const relatedChannels = channels.filter(
+			(channel) => channel.parent_id === markAsReadEvent.channel_id || channel.channel_id === markAsReadEvent.channel_id
+		);
+		const channelMeta = selectChannelMetaEntities(store.getState());
 		const channelIds = relatedChannels.map((channel) => channel.id);
 		const channelUpdates = channelIds.map((channelId) => ({
 			channelId,
 			messageId: selectLatestMessageId(store.getState(), channelId) || undefined
 		}));
+
 		badgeService.markAsReadChannel(
 			markAsReadEvent.clan_id as string,
 			markAsReadEvent.channel_id,
@@ -2509,7 +2513,7 @@ const ChatContextProvider: React.FC<ChatContextProviderProps> = ({ children, isM
 			channelUpdates,
 			relatedChannels.map((channel) => ({
 				channelId: channel.id,
-				count: (channel.count_mess_unread ?? 0) * -1
+				count: (channelMeta?.[channel.id]?.count_mess_unread ?? 0) * -1
 			}))
 		);
 

--- a/libs/core/src/lib/chat/contexts/ChatContext.tsx
+++ b/libs/core/src/lib/chat/contexts/ChatContext.tsx
@@ -2516,15 +2516,6 @@ const ChatContextProvider: React.FC<ChatContextProviderProps> = ({ children, isM
 				count: (channelMeta?.[channel.id]?.count_mess_unread ?? 0) * -1
 			}))
 		);
-
-		const threadIds = relatedChannels.flatMap((channel) => channel.threadIds || []);
-		if (threadIds.length) {
-			const threadUpdates = threadIds.map((channelId) => ({
-				channelId,
-				messageId: selectLatestMessageId(store.getState(), channelId) || undefined
-			}));
-			dispatch(channelMetaActions.setChannelsLastSeenTimestamp(threadUpdates));
-		}
 	}, []);
 
 	const onaddfriend = useCallback((user: AddFriend) => {


### PR DESCRIPTION
### Changes

- Change filter to get channel not just only thread

### Description
- Old logic get count from channelEntity. New logic haft years ago get unread and count_unread from channelMeta 
- Use channelMeta instead of channelEntity to get badge count for case markAsRead

### Test Case

- Mark as read Clan 
- Mark as read Channel 
- Mark as read Cate 
- Refresh for each case mark as read 