### PR TITLE
260522 - WEB/DESKTOP - fix disable edit message transaction

### DIFF
--- a/libs/store/src/lib/messages/messages.slice.ts
+++ b/libs/store/src/lib/messages/messages.slice.ts
@@ -2476,7 +2476,7 @@ export const selectMessageEntityById = createCachedSelector(
 export const selectLassSendMessageEntityBySenderId = createCachedSelector(
 	[selectMessageEntitiesByChannelId, selectMessageIdsByChannelId, (_, __, senderId) => senderId],
 	(entities, ids, senderId) => {
-		const matchedId = [...ids].reverse().find((id) => entities?.[id]?.sender_id === senderId);
+		const matchedId = [...ids].reverse().find((id) => entities?.[id]?.sender_id === senderId && entities?.[id]?.code !== TypeMessage.SendToken);
 		return matchedId ? entities[matchedId] : null;
 	}
 );


### PR DESCRIPTION
### Changes

- Fix enable edit message type SendToken

### Description 

- ArrowUp key down select lastMessage them self but not filter type of message 
- Only DM has type SendToken message

### Test

- Press keyup on DM

### Ticket

- [Desktop/Website] Disable message editing via Up Arrow key for transaction/banking messages
https://github.com/mezonai/mezon/issues/13146