### PR TITLE
260528 - WEB/DESKTOP - fix not navigate if thread delete

### DIFF
--- a/libs/components/src/lib/components/MessageWithUser/MessageLineSystem.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/MessageLineSystem.tsx
@@ -115,14 +115,16 @@ const RenderContentSystem = ({ message, data, mode, isSearchMessage, isJumMessag
 
 	const handelJumpToChannel = async () => {
 		if (threadId) {
-			await dispatch(
+			const result = await dispatch(
 				channelsActions.addThreadToChannels({
 					channelId: threadId,
 					clanId: message?.clan_id as string,
 					parentChannelId: message?.channel_id
 				})
-			);
-			navigate(`/chat/clans/${message?.clan_id}/channels/${threadId}`);
+			).unwrap();
+			if (result) {
+				navigate(`/chat/clans/${message?.clan_id}/channels/${threadId}`);
+			}
 		}
 	};
 

--- a/libs/store/src/lib/channels/channels.slice.ts
+++ b/libs/store/src/lib/channels/channels.slice.ts
@@ -696,33 +696,39 @@ export const addThreadToChannels = createAsyncThunk(
 			const channelIdToFetch = parentChannelId || currentChannelId;
 
 			if (!channelIdToFetch || channelIdToFetch === channelId) {
-				return;
+				return true;
 			}
 
-			const data = await thunkAPI
-				.dispatch(
-					threadsActions.fetchThread({
-						channelId: channelIdToFetch,
-						clanId,
-						threadId: channelId
-					})
-				)
-				.unwrap();
+			try {
+				const data = await thunkAPI
+					.dispatch(
+						threadsActions.fetchThread({
+							channelId: channelIdToFetch,
+							clanId,
+							threadId: channelId
+						})
+					)
+					.unwrap();
 
-			const matchedThread = data?.threads?.find((thread) => thread.id === channelId || thread.channel_id === channelId);
+				const matchedThread = data?.threads?.find((thread) => thread.id === channelId || thread.channel_id === channelId);
 
-			if (matchedThread) {
-				thunkAPI.dispatch(
-					channelsActions.upsertOne({
-						clanId,
-						channel: {
-							...matchedThread,
-							active: matchedThread.active ? ThreadStatus.joined : ThreadStatus.activePublic
-						} as ChannelsEntity
-					})
-				);
+				if (matchedThread) {
+					thunkAPI.dispatch(
+						channelsActions.upsertOne({
+							clanId,
+							channel: {
+								...matchedThread,
+								active: matchedThread.active ? ThreadStatus.joined : ThreadStatus.activePublic
+							} as ChannelsEntity
+						})
+					);
+				}
+				return true;
+			} catch (error) {
+				return false;
 			}
 		}
+		return true;
 	}
 );
 


### PR DESCRIPTION
### Changes

- Check if thread has been deleted, dont navigate use to error thread

### Test

- This function call in 2 case : 

1. On loader channel route : When not delete can join as normal. If deleted show error modal 
2. On click in system message : When not delete can join as normal. If deleted show error modal but not navigate user to that thread

### Ticket 

- [Desktop/Website] Adjust behav click on deleted thread on system message
https://github.com/mezonai/mezon/issues/13160