### PR TITLE
260528 - WEB/DESKTOP - fix send invite link to group

### DIFF
--- a/libs/core/src/lib/chat/hooks/useDMInvite.ts
+++ b/libs/core/src/lib/chat/hooks/useDMInvite.ts
@@ -39,6 +39,8 @@ export function useDMInvite(channelID?: string) {
 			) {
 				listId.add(item.user_ids[0]);
 				return true;
+			} else if (item.type === ChannelType.CHANNEL_TYPE_GROUP) {
+				return true;
 			}
 			return false;
 		});


### PR DESCRIPTION
### Changes

- Not filter group from invite list 

### Test 
- Send invite to group 
- Send invite to multiple group 
- Close and re-open 
- Search group name 

### Ticket 

- [Desktop/Website] Group chat disappears after sending invite link via Invite modal
https://github.com/mezonai/mezon/issues/13164