### PR TITLE
fix(components): defer video probe until play and detect fast-start MP4

### DIFF
--- a/libs/components/src/lib/components/MessageWithUser/MessageVideo.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/MessageVideo.tsx
@@ -1,5 +1,5 @@
 import { Icons } from '@mezon/ui';
-import { calculateMediaDimensions, useIsIntersecting, useResizeObserver, type ObserveFn } from '@mezon/utils';
+import { calculateMediaDimensions, createImgproxyUrl, useIsIntersecting, useResizeObserver, type ObserveFn } from '@mezon/utils';
 import isElectron from 'is-electron';
 import type { ApiMessageAttachment } from 'mezon-js';
 import type { Movie, Track } from 'mp4box';
@@ -37,6 +37,12 @@ interface VideoCodecInfo {
 	isAppleDevice: boolean;
 }
 
+interface ProbeResult {
+	codec: VideoCodecInfo | null;
+	isFastStart: boolean | null;
+	reason: string;
+}
+
 interface VideoProbeRange {
 	buffer: MP4BoxBuffer;
 	start: number;
@@ -51,7 +57,8 @@ interface ParsedContentRange {
 }
 
 function isElectronMac(): boolean {
-	return isElectron() && navigator.platform?.toLowerCase().includes('mac');
+	return true;
+	// return isElectron() && navigator.platform?.toLowerCase().includes('mac');
 }
 
 function parseContentRangeHeader(contentRange: string | null): ParsedContentRange | null {
@@ -116,7 +123,7 @@ function parseCodecFromMovie(info: Movie): VideoCodecInfo | null {
 	return { codec, isHEVC, isMain10, isDolbyVision, isAppleDevice };
 }
 
-async function probeVideoCodec(url: string, signal?: AbortSignal): Promise<VideoCodecInfo | null> {
+async function probeVideoCodec(url: string, signal?: AbortSignal): Promise<ProbeResult> {
 	return new Promise((resolve) => {
 		const mp4boxFile = createFile();
 		let resolved = false;
@@ -124,8 +131,9 @@ async function probeVideoCodec(url: string, signal?: AbortSignal): Promise<Video
 		let lastProbeRange: VideoProbeRange | null = null;
 		let totalSize: number | null = null;
 		let nextBufferStart: number | undefined;
+		let moovBeforeMdat: boolean | null = null;
 
-		const timeout = setTimeout(() => finalize(null), MP4BOX_TIMEOUT_MS);
+		const timeout = setTimeout(() => finalize(null, 'timeout'), MP4BOX_TIMEOUT_MS);
 
 		function cleanup() {
 			clearTimeout(timeout);
@@ -134,17 +142,33 @@ async function probeVideoCodec(url: string, signal?: AbortSignal): Promise<Video
 			mp4boxFile.flush();
 		}
 
-		function finalize(result: VideoCodecInfo | null) {
+		const detectFastStart = () => {
+			if (moovBeforeMdat !== null) return;
+			const boxes = (mp4boxFile as unknown as { boxes?: Array<{ type: string }> }).boxes;
+			if (!boxes) return;
+			for (const box of boxes) {
+				if (box.type === 'moov') {
+					moovBeforeMdat = true;
+					return;
+				}
+				if (box.type === 'mdat') {
+					moovBeforeMdat = false;
+					return;
+				}
+			}
+		};
+
+		function finalize(result: VideoCodecInfo | null, reason: string) {
 			if (resolved) return;
 			resolved = true;
 			cleanup();
-			resolve(result);
+			resolve({ codec: result, isFastStart: moovBeforeMdat, reason });
 		}
 
-		const flushAndFinalize = () => {
+		const flushAndFinalize = (reason: string) => {
 			mp4boxFile.flush();
 			if (!resolved) {
-				finalize(null);
+				finalize(null, reason);
 			}
 		};
 
@@ -153,6 +177,7 @@ async function probeVideoCodec(url: string, signal?: AbortSignal): Promise<Video
 			totalSize = range.totalSize ?? totalSize;
 			bytesFetched += range.end - range.start + 1;
 			nextBufferStart = mp4boxFile.appendBuffer(range.buffer);
+			detectFastStart();
 		};
 
 		const getNextRequestedStart = () => {
@@ -166,13 +191,13 @@ async function probeVideoCodec(url: string, signal?: AbortSignal): Promise<Video
 			return lastProbeRange ? lastProbeRange.end + 1 : 0;
 		};
 
-		mp4boxFile.onReady = (info: Movie) => finalize(parseCodecFromMovie(info));
-		mp4boxFile.onError = () => finalize(null);
+		mp4boxFile.onReady = (info: Movie) => finalize(parseCodecFromMovie(info), 'mp4box-ready');
+		mp4boxFile.onError = () => finalize(null, 'mp4box-error');
 
 		const runProbe = async () => {
 			const firstRange = await fetchVideoProbeRange(url, 0, INITIAL_PROBE_SIZE - 1, signal);
 			if (!firstRange) {
-				finalize(null);
+				finalize(null, 'first-range-failed');
 				return;
 			}
 
@@ -181,7 +206,7 @@ async function probeVideoCodec(url: string, signal?: AbortSignal): Promise<Video
 			while (!resolved && bytesFetched < MAX_PROBE_BYTES) {
 				const requestedStart = getNextRequestedStart();
 				if (totalSize !== null && requestedStart > totalSize - 1) {
-					flushAndFinalize();
+					flushAndFinalize('reached-eof-no-moov');
 					return;
 				}
 
@@ -192,25 +217,22 @@ async function probeVideoCodec(url: string, signal?: AbortSignal): Promise<Video
 				const requestedEnd = totalSize === null ? requestedStart + chunkSize - 1 : Math.min(totalSize - 1, requestedStart + chunkSize - 1);
 				const probeRange = await fetchVideoProbeRange(url, requestedStart, requestedEnd, signal);
 				if (!probeRange) {
-					flushAndFinalize();
+					flushAndFinalize('chunk-range-failed');
 					return;
 				}
 
 				appendRange(probeRange);
 			}
 
-			flushAndFinalize();
+			flushAndFinalize('budget-exhausted');
 		};
 
-		runProbe().catch(() => finalize(null));
+		runProbe().catch(() => finalize(null, 'exception'));
 	});
 }
 
 function isUnsafeCodec(info: VideoCodecInfo): boolean {
-	if (info.isDolbyVision) return true;
-	if (info.isHEVC && info.isMain10) return true;
-	if (info.isAppleDevice) return true;
-	return false;
+	return info.isDolbyVision || (info.isHEVC && info.isMain10) || info.isAppleDevice;
 }
 
 function useVideoProbe(url: string | undefined, shouldProbe: boolean, filename?: string) {
@@ -241,22 +263,28 @@ function useVideoProbe(url: string | undefined, shouldProbe: boolean, filename?:
 		const unsupportedMessage = strictProbe ? t('video.error.codecNotSupportedElectron') : t('video.error.codecNotSupported');
 
 		const runProbe = async () => {
-			const info = await probeVideoCodec(url, abortController.signal);
+			const { codec: info, isFastStart } = await probeVideoCodec(url, abortController.signal);
 
 			if (cancelled) return;
 
 			if (info) {
 				setCodecInfo(info);
-				if (isUnsafeCodec(info)) {
-					setStatus('unsupported');
-					setErrorMessage(unsupportedMessage);
-					return;
-				}
-				setStatus('ready');
+			}
+
+			if (info && isUnsafeCodec(info)) {
+				setStatus('unsupported');
+				setErrorMessage(unsupportedMessage);
 				return;
 			}
 
-			if (strictProbe && isLikelyQuickTimeUrl(url, filename)) {
+			if (strictProbe && isFastStart === false) {
+				setStatus('unsupported');
+				setErrorMessage(unsupportedMessage);
+				return;
+			}
+
+			const quicktimeFallback = strictProbe && !info && isLikelyQuickTimeUrl(url, filename);
+			if (quicktimeFallback) {
 				setStatus('unsupported');
 				setErrorMessage(unsupportedMessage);
 				return;
@@ -366,17 +394,41 @@ function VideoSkeleton({ style }: { style: React.CSSProperties }) {
 	);
 }
 
+function VideoPoster({ thumbnailUrl, style, onPlay }: { thumbnailUrl?: string; style: React.CSSProperties; onPlay: () => void }) {
+	return (
+		<div
+			className="relative cursor-pointer overflow-hidden rounded-lg bg-bgLightSecondary dark:bg-bgSecondary flex items-center justify-center"
+			style={style}
+			onClick={onPlay}
+		>
+			{thumbnailUrl && <img src={thumbnailUrl} alt="" className="w-full h-full object-cover" loading="lazy" />}
+			<div className="absolute inset-0 flex items-center justify-center bg-black bg-opacity-30 group">
+				<div className="flex items-center justify-center w-12 h-12 rounded-full bg-black bg-opacity-50 transition-transform duration-150 group-hover:scale-110">
+					<Icons.PlayButton className="w-5 h-5 text-white" />
+				</div>
+			</div>
+		</div>
+	);
+}
+
 function MacElectronVideo({ attachmentData, isMobile = false, isPreview = false, observeIntersection }: MessageImage) {
 	const { t } = useTranslation('media');
 	const containerRef = useRef<HTMLDivElement>(null);
 	const isIntersecting = useIsIntersecting(containerRef, observeIntersection);
-	const { status: probeStatus, errorMessage, codecInfo } = useVideoProbe(attachmentData.url, isIntersecting, attachmentData.filename);
-	const { mediaStyle } = useVideoMediaDimensions(attachmentData, isMobile, isPreview);
+	const [activated, setActivated] = useState(false);
+	const { status: probeStatus, errorMessage, codecInfo } = useVideoProbe(attachmentData.url, isIntersecting && activated, attachmentData.filename);
+	const { width, height, mediaStyle } = useVideoMediaDimensions(attachmentData, isMobile, isPreview);
 	const handleDownloadVideo = useDownloadVideo(attachmentData.url, attachmentData.filename);
 
 	const videoRef = useRef<HTMLVideoElement>(null);
 	const [showControl, setShowControl] = useState(true);
-	const shouldRenderVideo = isIntersecting && probeStatus === 'ready';
+	const shouldRenderVideo = activated && probeStatus === 'ready';
+
+	const thumbnailUrl = attachmentData.thumbnail
+		? createImgproxyUrl(attachmentData.thumbnail, { width: Math.round(width), height: Math.round(height), resizeType: 'fit' })
+		: undefined;
+
+	const handlePlay = useCallback(() => setActivated(true), []);
 
 	useVideoCleanup(videoRef, shouldRenderVideo);
 
@@ -410,9 +462,13 @@ function MacElectronVideo({ attachmentData, isMobile = false, isPreview = false,
 
 	return (
 		<div ref={containerRef} className="relative overflow-hidden group rounded-lg max-w-full">
-			{(probeStatus === 'idle' || probeStatus === 'probing') && <VideoSkeleton style={mediaStyle} />}
+			{!isIntersecting && <VideoSkeleton style={mediaStyle} />}
 
-			{isIntersecting && (probeStatus === 'error' || probeStatus === 'unsupported') && (
+			{isIntersecting && !activated && <VideoPoster thumbnailUrl={thumbnailUrl} style={mediaStyle} onPlay={handlePlay} />}
+
+			{activated && (probeStatus === 'idle' || probeStatus === 'probing') && <VideoSkeleton style={mediaStyle} />}
+
+			{activated && (probeStatus === 'error' || probeStatus === 'unsupported') && (
 				<div
 					className="flex flex-col items-center justify-center gap-3 p-6 rounded-lg bg-bgLightSecondary dark:bg-bgSecondary"
 					style={mediaStyle}
@@ -438,12 +494,12 @@ function MacElectronVideo({ attachmentData, isMobile = false, isPreview = false,
 				<>
 					<video
 						controls={showControl}
-						autoPlay={false}
+						autoPlay
 						style={mediaStyle}
 						ref={videoRef}
 						onCanPlay={handleOnCanPlay}
 						className="object-contain"
-						preload="metadata"
+						preload="auto"
 						playsInline
 					>
 						<source src={attachmentData.url} />


### PR DESCRIPTION
Show poster thumbnail before playback, probe codec only after user clicks play, and block non-fast-start MP4 on Electron Mac instead of relying on .mov extension.