### PR TITLE
fix(components): restore Electron Mac check for message video probe

### DIFF
--- a/libs/components/src/lib/components/MessageWithUser/MessageVideo.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/MessageVideo.tsx
@@ -57,8 +57,7 @@ interface ParsedContentRange {
 }
 
 function isElectronMac(): boolean {
-	return true;
-	// return isElectron() && navigator.platform?.toLowerCase().includes('mac');
+	return isElectron() && navigator.platform?.toLowerCase().includes('mac');
 }
 
 function parseContentRangeHeader(contentRange: string | null): ParsedContentRange | null {


### PR DESCRIPTION
## Summary
- Cherry-pick `fix check electron` from #13212 (`fix26m/webdesktop/message-video-poster-faststart`) into `main`.
- Restores `isElectronMac()` to use real Electron + macOS detection instead of hardcoded `return true` left after #13208 landed on `main`.
- #13208 (poster thumbnail + deferred probe + fast-start MP4 detection) is already on `main`; this PR completes the remaining follow-up.

## Test plan
- [ ] Open a channel with video attachments on Electron macOS — non-fast-start MP4 should show unsupported message only on Mac desktop.
- [ ] Open the same videos on web browser — playback/probe behavior unchanged.
- [ ] Confirm video poster thumbnail still shows before play on supported videos.