### PR TITLE
fix(chat): socket reconnect wave, network probe, session persist

### DIFF
--- a/libs/components/src/lib/components/MessageWithUser/MessageVideo.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/MessageVideo.tsx
@@ -1,5 +1,5 @@
 import { Icons } from '@mezon/ui';
-import { calculateMediaDimensions, useIsIntersecting, useResizeObserver, type ObserveFn } from '@mezon/utils';
+import { calculateMediaDimensions, createImgproxyUrl, useIsIntersecting, useResizeObserver, type ObserveFn } from '@mezon/utils';
 import isElectron from 'is-electron';
 import type { ApiMessageAttachment } from 'mezon-js';
 import type { Movie, Track } from 'mp4box';
@@ -37,6 +37,12 @@ interface VideoCodecInfo {
 	isAppleDevice: boolean;
 }
 
+interface ProbeResult {
+	codec: VideoCodecInfo | null;
+	isFastStart: boolean | null;
+	reason: string;
+}
+
 interface VideoProbeRange {
 	buffer: MP4BoxBuffer;
 	start: number;
@@ -51,7 +57,8 @@ interface ParsedContentRange {
 }
 
 function isElectronMac(): boolean {
-	return isElectron() && navigator.platform?.toLowerCase().includes('mac');
+	return true;
+	// return isElectron() && navigator.platform?.toLowerCase().includes('mac');
 }
 
 function parseContentRangeHeader(contentRange: string | null): ParsedContentRange | null {
@@ -116,7 +123,7 @@ function parseCodecFromMovie(info: Movie): VideoCodecInfo | null {
 	return { codec, isHEVC, isMain10, isDolbyVision, isAppleDevice };
 }
 
-async function probeVideoCodec(url: string, signal?: AbortSignal): Promise<VideoCodecInfo | null> {
+async function probeVideoCodec(url: string, signal?: AbortSignal): Promise<ProbeResult> {
 	return new Promise((resolve) => {
 		const mp4boxFile = createFile();
 		let resolved = false;
@@ -124,8 +131,9 @@ async function probeVideoCodec(url: string, signal?: AbortSignal): Promise<Video
 		let lastProbeRange: VideoProbeRange | null = null;
 		let totalSize: number | null = null;
 		let nextBufferStart: number | undefined;
+		let moovBeforeMdat: boolean | null = null;
 
-		const timeout = setTimeout(() => finalize(null), MP4BOX_TIMEOUT_MS);
+		const timeout = setTimeout(() => finalize(null, 'timeout'), MP4BOX_TIMEOUT_MS);
 
 		function cleanup() {
 			clearTimeout(timeout);
@@ -134,17 +142,33 @@ async function probeVideoCodec(url: string, signal?: AbortSignal): Promise<Video
 			mp4boxFile.flush();
 		}
 
-		function finalize(result: VideoCodecInfo | null) {
+		const detectFastStart = () => {
+			if (moovBeforeMdat !== null) return;
+			const boxes = (mp4boxFile as unknown as { boxes?: Array<{ type: string }> }).boxes;
+			if (!boxes) return;
+			for (const box of boxes) {
+				if (box.type === 'moov') {
+					moovBeforeMdat = true;
+					return;
+				}
+				if (box.type === 'mdat') {
+					moovBeforeMdat = false;
+					return;
+				}
+			}
+		};
+
+		function finalize(result: VideoCodecInfo | null, reason: string) {
 			if (resolved) return;
 			resolved = true;
 			cleanup();
-			resolve(result);
+			resolve({ codec: result, isFastStart: moovBeforeMdat, reason });
 		}
 
-		const flushAndFinalize = () => {
+		const flushAndFinalize = (reason: string) => {
 			mp4boxFile.flush();
 			if (!resolved) {
-				finalize(null);
+				finalize(null, reason);
 			}
 		};
 
@@ -153,6 +177,7 @@ async function probeVideoCodec(url: string, signal?: AbortSignal): Promise<Video
 			totalSize = range.totalSize ?? totalSize;
 			bytesFetched += range.end - range.start + 1;
 			nextBufferStart = mp4boxFile.appendBuffer(range.buffer);
+			detectFastStart();
 		};
 
 		const getNextRequestedStart = () => {
@@ -166,13 +191,13 @@ async function probeVideoCodec(url: string, signal?: AbortSignal): Promise<Video
 			return lastProbeRange ? lastProbeRange.end + 1 : 0;
 		};
 
-		mp4boxFile.onReady = (info: Movie) => finalize(parseCodecFromMovie(info));
-		mp4boxFile.onError = () => finalize(null);
+		mp4boxFile.onReady = (info: Movie) => finalize(parseCodecFromMovie(info), 'mp4box-ready');
+		mp4boxFile.onError = () => finalize(null, 'mp4box-error');
 
 		const runProbe = async () => {
 			const firstRange = await fetchVideoProbeRange(url, 0, INITIAL_PROBE_SIZE - 1, signal);
 			if (!firstRange) {
-				finalize(null);
+				finalize(null, 'first-range-failed');
 				return;
 			}
 
@@ -181,7 +206,7 @@ async function probeVideoCodec(url: string, signal?: AbortSignal): Promise<Video
 			while (!resolved && bytesFetched < MAX_PROBE_BYTES) {
 				const requestedStart = getNextRequestedStart();
 				if (totalSize !== null && requestedStart > totalSize - 1) {
-					flushAndFinalize();
+					flushAndFinalize('reached-eof-no-moov');
 					return;
 				}
 
@@ -192,25 +217,22 @@ async function probeVideoCodec(url: string, signal?: AbortSignal): Promise<Video
 				const requestedEnd = totalSize === null ? requestedStart + chunkSize - 1 : Math.min(totalSize - 1, requestedStart + chunkSize - 1);
 				const probeRange = await fetchVideoProbeRange(url, requestedStart, requestedEnd, signal);
 				if (!probeRange) {
-					flushAndFinalize();
+					flushAndFinalize('chunk-range-failed');
 					return;
 				}
 
 				appendRange(probeRange);
 			}
 
-			flushAndFinalize();
+			flushAndFinalize('budget-exhausted');
 		};
 
-		runProbe().catch(() => finalize(null));
+		runProbe().catch(() => finalize(null, 'exception'));
 	});
 }
 
 function isUnsafeCodec(info: VideoCodecInfo): boolean {
-	if (info.isDolbyVision) return true;
-	if (info.isHEVC && info.isMain10) return true;
-	if (info.isAppleDevice) return true;
-	return false;
+	return info.isDolbyVision || (info.isHEVC && info.isMain10) || info.isAppleDevice;
 }
 
 function useVideoProbe(url: string | undefined, shouldProbe: boolean, filename?: string) {
@@ -241,22 +263,28 @@ function useVideoProbe(url: string | undefined, shouldProbe: boolean, filename?:
 		const unsupportedMessage = strictProbe ? t('video.error.codecNotSupportedElectron') : t('video.error.codecNotSupported');
 
 		const runProbe = async () => {
-			const info = await probeVideoCodec(url, abortController.signal);
+			const { codec: info, isFastStart } = await probeVideoCodec(url, abortController.signal);
 
 			if (cancelled) return;
 
 			if (info) {
 				setCodecInfo(info);
-				if (isUnsafeCodec(info)) {
-					setStatus('unsupported');
-					setErrorMessage(unsupportedMessage);
-					return;
-				}
-				setStatus('ready');
+			}
+
+			if (info && isUnsafeCodec(info)) {
+				setStatus('unsupported');
+				setErrorMessage(unsupportedMessage);
 				return;
 			}
 
-			if (strictProbe && isLikelyQuickTimeUrl(url, filename)) {
+			if (strictProbe && isFastStart === false) {
+				setStatus('unsupported');
+				setErrorMessage(unsupportedMessage);
+				return;
+			}
+
+			const quicktimeFallback = strictProbe && !info && isLikelyQuickTimeUrl(url, filename);
+			if (quicktimeFallback) {
 				setStatus('unsupported');
 				setErrorMessage(unsupportedMessage);
 				return;
@@ -366,17 +394,41 @@ function VideoSkeleton({ style }: { style: React.CSSProperties }) {
 	);
 }
 
+function VideoPoster({ thumbnailUrl, style, onPlay }: { thumbnailUrl?: string; style: React.CSSProperties; onPlay: () => void }) {
+	return (
+		<div
+			className="relative cursor-pointer overflow-hidden rounded-lg bg-bgLightSecondary dark:bg-bgSecondary flex items-center justify-center"
+			style={style}
+			onClick={onPlay}
+		>
+			{thumbnailUrl && <img src={thumbnailUrl} alt="" className="w-full h-full object-cover" loading="lazy" />}
+			<div className="absolute inset-0 flex items-center justify-center bg-black bg-opacity-30 group">
+				<div className="flex items-center justify-center w-12 h-12 rounded-full bg-black bg-opacity-50 transition-transform duration-150 group-hover:scale-110">
+					<Icons.PlayButton className="w-5 h-5 text-white" />
+				</div>
+			</div>
+		</div>
+	);
+}
+
 function MacElectronVideo({ attachmentData, isMobile = false, isPreview = false, observeIntersection }: MessageImage) {
 	const { t } = useTranslation('media');
 	const containerRef = useRef<HTMLDivElement>(null);
 	const isIntersecting = useIsIntersecting(containerRef, observeIntersection);
-	const { status: probeStatus, errorMessage, codecInfo } = useVideoProbe(attachmentData.url, isIntersecting, attachmentData.filename);
-	const { mediaStyle } = useVideoMediaDimensions(attachmentData, isMobile, isPreview);
+	const [activated, setActivated] = useState(false);
+	const { status: probeStatus, errorMessage, codecInfo } = useVideoProbe(attachmentData.url, isIntersecting && activated, attachmentData.filename);
+	const { width, height, mediaStyle } = useVideoMediaDimensions(attachmentData, isMobile, isPreview);
 	const handleDownloadVideo = useDownloadVideo(attachmentData.url, attachmentData.filename);
 
 	const videoRef = useRef<HTMLVideoElement>(null);
 	const [showControl, setShowControl] = useState(true);
-	const shouldRenderVideo = isIntersecting && probeStatus === 'ready';
+	const shouldRenderVideo = activated && probeStatus === 'ready';
+
+	const thumbnailUrl = attachmentData.thumbnail
+		? createImgproxyUrl(attachmentData.thumbnail, { width: Math.round(width), height: Math.round(height), resizeType: 'fit' })
+		: undefined;
+
+	const handlePlay = useCallback(() => setActivated(true), []);
 
 	useVideoCleanup(videoRef, shouldRenderVideo);
 
@@ -410,9 +462,13 @@ function MacElectronVideo({ attachmentData, isMobile = false, isPreview = false,
 
 	return (
 		<div ref={containerRef} className="relative overflow-hidden group rounded-lg max-w-full">
-			{(probeStatus === 'idle' || probeStatus === 'probing') && <VideoSkeleton style={mediaStyle} />}
+			{!isIntersecting && <VideoSkeleton style={mediaStyle} />}
 
-			{isIntersecting && (probeStatus === 'error' || probeStatus === 'unsupported') && (
+			{isIntersecting && !activated && <VideoPoster thumbnailUrl={thumbnailUrl} style={mediaStyle} onPlay={handlePlay} />}
+
+			{activated && (probeStatus === 'idle' || probeStatus === 'probing') && <VideoSkeleton style={mediaStyle} />}
+
+			{activated && (probeStatus === 'error' || probeStatus === 'unsupported') && (
 				<div
 					className="flex flex-col items-center justify-center gap-3 p-6 rounded-lg bg-bgLightSecondary dark:bg-bgSecondary"
 					style={mediaStyle}
@@ -438,12 +494,12 @@ function MacElectronVideo({ attachmentData, isMobile = false, isPreview = false,
 				<>
 					<video
 						controls={showControl}
-						autoPlay={false}
+						autoPlay
 						style={mediaStyle}
 						ref={videoRef}
 						onCanPlay={handleOnCanPlay}
 						className="object-contain"
-						preload="metadata"
+						preload="auto"
 						playsInline
 					>
 						<source src={attachmentData.url} />

--- a/libs/components/src/lib/components/MessageWithUser/MessageVideo.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/MessageVideo.tsx
@@ -57,8 +57,7 @@ interface ParsedContentRange {
 }
 
 function isElectronMac(): boolean {
-	return true;
-	// return isElectron() && navigator.platform?.toLowerCase().includes('mac');
+	return isElectron() && navigator.platform?.toLowerCase().includes('mac');
 }
 
 function parseContentRangeHeader(contentRange: string | null): ParsedContentRange | null {

--- a/libs/core/src/lib/chat/contexts/ChatContext.tsx
+++ b/libs/core/src/lib/chat/contexts/ChatContext.tsx
@@ -101,7 +101,7 @@ import {
 	walletActions,
 	webhookActions
 } from '@mezon/store';
-import { publishSessionUpdate, useMezon } from '@mezon/transport';
+import { probeNetworkReachability, publishSessionUpdate, RECONNECT_NETWORK_PROBE_TIMEOUT_MS, useMezon } from '@mezon/transport';
 import type { IMessageSendPayload, IUserProfileActivity, NotificationCategory } from '@mezon/utils';
 import {
 	ADD_ROLE_CHANNEL_STATUS,
@@ -193,10 +193,18 @@ import { ChannelStreamMode, ChannelType, Client, WebrtcSignalingType, safeJSONPa
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Observable, Subject } from 'rxjs';
-import { exhaustMap, filter, takeWhile } from 'rxjs/operators';
+import { auditTime, exhaustMap, filter, takeWhile, tap } from 'rxjs/operators';
 import { useAuth } from '../../auth/hooks/useAuth';
 import { useCustomNavigate } from '../hooks/useCustomNavigate';
-import { consumeSocketReconnectBudget, refundSocketReconnectBudgetSlot, resetSocketReconnectBudget } from '../utils/socketReconnectBudget';
+import {
+	beginReconnectWave,
+	consumeReconnectAttempt,
+	markNetworkProbeCompleted,
+	refundReconnectAttempt,
+	resetReconnectWave,
+	shouldProbeNetworkBeforeConnect,
+	waitForNetworkProbeSlot
+} from '../utils/socketReconnectBudget';
 import { handleGroupCallSocketEvent } from './groupCallSocketHandler';
 
 const MobileEventEmitter = new EventEmitter();
@@ -239,7 +247,9 @@ function reconnectJitterTicker$(): Observable<number> {
 	});
 }
 
-type ReconnectWaveTickResult = boolean | 'BUDGET_EXHAUSTED';
+type ReconnectWaveTickResult = boolean | 'ATTEMPTS_EXHAUSTED' | 'RECONNECTING' | 'NETWORK_DOWN' | 'SKIP';
+
+const RECONNECT_TRIGGER_MERGE_MS = 1000;
 
 type ChatContextProviderProps = {
 	children: React.ReactNode;
@@ -2547,7 +2557,7 @@ const ChatContextProvider: React.FC<ChatContextProviderProps> = ({ children, isM
 	}, []);
 
 	const runPostReconnectActions = useCallback(() => {
-		resetSocketReconnectBudget();
+		resetReconnectWave();
 		dispatch(toastActions.removeToast('SOCKET_RECONNECTING'));
 		dispatch(toastActions.removeToast('SOCKET_RECONNECTING_ERROR'));
 		dispatch(toastActions.removeToast('SOCKET_CONNECTION_ERROR'));
@@ -2558,7 +2568,6 @@ const ChatContextProvider: React.FC<ChatContextProviderProps> = ({ children, isM
 
 	const onServerDisconnectStreakLogout = useCallback(
 		(_evt: Event, streak: number) => {
-			console.error('[ReconnectFlow] Server disconnect streak logout', { streak });
 			captureSentryError(new Error(`serverDisconnectStreak=${String(streak)}`), 'SERVER_DISCONNECT_STREAK_LOGOUT');
 			resetRefreshState();
 			dispatch(authActions.setLogout());
@@ -2572,6 +2581,7 @@ const ChatContextProvider: React.FC<ChatContextProviderProps> = ({ children, isM
 		(socket: Client) => {
 			socket.onconnect = (_evt: Event) => {
 				socketState.status = 'connected';
+				runPostReconnectActions();
 			};
 
 			socket.onreconnect = (_evt: Event) => {
@@ -2766,15 +2776,6 @@ const ChatContextProvider: React.FC<ChatContextProviderProps> = ({ children, isM
 				return false;
 			}
 
-			if (!consumeSocketReconnectBudget()) {
-				socketState.status = 'disconnected';
-				resetRefreshState();
-				dispatch(authActions.setLogout());
-				dispatch(walletActions.setLogout());
-				publishSessionUpdate(null, 'logout');
-				return 'BUDGET_EXHAUSTED';
-			}
-
 			socketState.status = 'connecting';
 
 			let watchdogId: number | undefined;
@@ -2782,7 +2783,6 @@ const ChatContextProvider: React.FC<ChatContextProviderProps> = ({ children, isM
 				watchdogId = window.setTimeout(() => {
 					if (socketState.status === 'connecting') {
 						socketState.status = 'disconnected';
-						console.warn('[ReconnectFlow] connect watchdog elapsed while still connecting');
 					}
 				}, RECONNECT_CONNECT_WATCHDOG_MS);
 			}
@@ -2791,8 +2791,8 @@ const ChatContextProvider: React.FC<ChatContextProviderProps> = ({ children, isM
 				const result = await reconnectSocket();
 
 				if (result.status === 'RECONNECTING') {
-					refundSocketReconnectBudgetSlot();
-					return false;
+					refundReconnectAttempt();
+					return 'RECONNECTING';
 				}
 				if (result.status === 'MISSING_SESSION') {
 					socketState.status = 'disconnected';
@@ -2815,13 +2815,36 @@ const ChatContextProvider: React.FC<ChatContextProviderProps> = ({ children, isM
 	useEffect(() => {
 		const subscription = reconnect$
 			.pipe(
-				exhaustMap((socketType) =>
-					reconnectJitterTicker$().pipe(
-						filter(() => isUiActive() && (typeof navigator === 'undefined' || navigator.onLine !== false)),
+				auditTime(RECONNECT_TRIGGER_MERGE_MS),
+				exhaustMap((socketType) => {
+					beginReconnectWave();
+					return reconnectJitterTicker$().pipe(
+						filter(() => isUiActive()),
 						exhaustMap(async (): Promise<ReconnectWaveTickResult> => {
-							if (!clientRef.current) {
-								return false;
+							if (shouldProbeNetworkBeforeConnect()) {
+								await waitForNetworkProbeSlot();
+								const reachable = await probeNetworkReachability({
+									timeoutMs: RECONNECT_NETWORK_PROBE_TIMEOUT_MS
+								});
+								markNetworkProbeCompleted();
+								if (!reachable) {
+									return 'NETWORK_DOWN';
+								}
 							}
+
+							if (!clientRef.current) {
+								return 'SKIP';
+							}
+
+							if (!consumeReconnectAttempt()) {
+								socketState.status = 'disconnected';
+								resetRefreshState();
+								dispatch(authActions.setLogout());
+								dispatch(walletActions.setLogout());
+								publishSessionUpdate(null, 'logout');
+								return 'ATTEMPTS_EXHAUSTED';
+							}
+
 							try {
 								return await executeReconnect(socketType, clientRef.current);
 							} catch (error) {
@@ -2829,24 +2852,29 @@ const ChatContextProvider: React.FC<ChatContextProviderProps> = ({ children, isM
 								return false;
 							}
 						}),
-						takeWhile((result) => result !== true && result !== 'BUDGET_EXHAUSTED', true)
-					)
-				)
+						tap((result) => {
+							if (result === true) {
+								runPostReconnectActions();
+							}
+						}),
+						takeWhile((result) => result !== true && result !== 'ATTEMPTS_EXHAUSTED', true)
+					);
+				})
 			)
 			.subscribe();
 
 		return () => {
 			subscription.unsubscribe();
 		};
-	}, [reconnect$, executeReconnect, dispatch]);
+	}, [reconnect$, executeReconnect, clientRef, dispatch, runPostReconnectActions]);
 
 	useEffect(() => {
-		const onBudgetReset = () => {
+		const onWaveReset = () => {
 			dispatch(toastActions.removeToast('SOCKET_RECONNECT_BUDGET'));
 		};
-		window.addEventListener('mezon:socket-budget-reset', onBudgetReset);
+		window.addEventListener('mezon:reconnect-wave-reset', onWaveReset);
 		return () => {
-			window.removeEventListener('mezon:socket-budget-reset', onBudgetReset);
+			window.removeEventListener('mezon:reconnect-wave-reset', onWaveReset);
 		};
 	}, [dispatch]);
 

--- a/libs/core/src/lib/chat/contexts/ChatContext.tsx
+++ b/libs/core/src/lib/chat/contexts/ChatContext.tsx
@@ -249,7 +249,6 @@ function reconnectJitterTicker$(): Observable<number> {
 
 type ReconnectWaveTickResult = boolean | 'ATTEMPTS_EXHAUSTED' | 'RECONNECTING' | 'NETWORK_DOWN' | 'SKIP';
 
-const RECONNECT_TRIGGER_MERGE_MS = 1000;
 
 type ChatContextProviderProps = {
 	children: React.ReactNode;
@@ -268,6 +267,7 @@ const ChatContextProvider: React.FC<ChatContextProviderProps> = ({ children, isM
 	const { clientRef, sessionRef, mmnRef, reconnectSocket } = useMezon();
 	const { userId } = useAuth();
 	const dispatch = useAppDispatch();
+	const reconnectRecoveryPendingRef = useRef(false);
 
 	const navigate = useCustomNavigate();
 	// update later
@@ -2557,6 +2557,10 @@ const ChatContextProvider: React.FC<ChatContextProviderProps> = ({ children, isM
 	}, []);
 
 	const runPostReconnectActions = useCallback(() => {
+		if (!reconnectRecoveryPendingRef.current) {
+			return;
+		}
+		reconnectRecoveryPendingRef.current = false;
 		resetReconnectWave();
 		dispatch(toastActions.removeToast('SOCKET_RECONNECTING'));
 		dispatch(toastActions.removeToast('SOCKET_RECONNECTING_ERROR'));
@@ -2581,12 +2585,10 @@ const ChatContextProvider: React.FC<ChatContextProviderProps> = ({ children, isM
 		(socket: Client) => {
 			socket.onconnect = (_evt: Event) => {
 				socketState.status = 'connected';
-				runPostReconnectActions();
 			};
 
 			socket.onreconnect = (_evt: Event) => {
 				setCallbackEventFn(socket as Client);
-				runPostReconnectActions();
 				socketState.status = 'connected';
 			};
 
@@ -2815,7 +2817,6 @@ const ChatContextProvider: React.FC<ChatContextProviderProps> = ({ children, isM
 	useEffect(() => {
 		const subscription = reconnect$
 			.pipe(
-				auditTime(RECONNECT_TRIGGER_MERGE_MS),
 				exhaustMap((socketType) => {
 					beginReconnectWave();
 					return reconnectJitterTicker$().pipe(
@@ -2837,6 +2838,7 @@ const ChatContextProvider: React.FC<ChatContextProviderProps> = ({ children, isM
 							}
 
 							if (!consumeReconnectAttempt()) {
+								reconnectRecoveryPendingRef.current = false;
 								socketState.status = 'disconnected';
 								resetRefreshState();
 								dispatch(authActions.setLogout());
@@ -2880,6 +2882,7 @@ const ChatContextProvider: React.FC<ChatContextProviderProps> = ({ children, isM
 
 	const handleReconnect = useCallback(
 		(socketType: string) => {
+			reconnectRecoveryPendingRef.current = true;
 			reconnect$.next(socketType);
 		},
 		[reconnect$]

--- a/libs/core/src/lib/chat/hooks/useReconnectOnForeground.ts
+++ b/libs/core/src/lib/chat/hooks/useReconnectOnForeground.ts
@@ -2,7 +2,7 @@ import { isOnline$, socketState } from '@mezon/transport';
 import { isUiActive } from '@mezon/utils';
 import { useEffect, useRef } from 'react';
 
-import { resetSocketReconnectBudget } from '../utils/socketReconnectBudget';
+import { resetReconnectWave } from '../utils/socketReconnectBudget';
 
 export type UseReconnectOnForegroundOptions = {
 	scheduleReconnect: (reason: string) => void;
@@ -35,7 +35,7 @@ export function useReconnectOnForeground({ scheduleReconnect, debouncedScheduleM
 		};
 
 		const refreshAndReconnect = () => {
-			resetSocketReconnectBudget();
+			resetReconnectWave();
 			armReconnect();
 		};
 

--- a/libs/core/src/lib/chat/utils/socketReconnectBudget.ts
+++ b/libs/core/src/lib/chat/utils/socketReconnectBudget.ts
@@ -1,40 +1,65 @@
-const WINDOW_MS = 2 * 60 * 1000;
-const MAX_ATTEMPTS = 3;
+export const MIN_NETWORK_PROBE_INTERVAL_MS = 4000;
 
-let attemptTimes: number[] = [];
+export const MAX_RECONNECT_ATTEMPTS_PER_WAVE = 5;
 
-function prune(now: number) {
-	attemptTimes = attemptTimes.filter((t) => now - t < WINDOW_MS);
+let waveConnectAttempts = 0;
+let reconnectWaveId = 0;
+let lastNetworkProbeAt = 0;
+
+export function getReconnectWaveAttempts(): number {
+	return waveConnectAttempts;
 }
 
-export function msUntilSocketReconnectBudgetSlot(): number {
-	const now = Date.now();
-	prune(now);
-	if (attemptTimes.length < MAX_ATTEMPTS) {
-		return 0;
+export function getReconnectWaveId(): number {
+	return reconnectWaveId;
+}
+
+function delayMs(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function waitForNetworkProbeSlot(): Promise<void> {
+	const elapsed = Date.now() - lastNetworkProbeAt;
+	const waitMs = MIN_NETWORK_PROBE_INTERVAL_MS - elapsed;
+	if (waitMs <= 0) {
+		return;
 	}
-	return Math.max(0, attemptTimes[0] + WINDOW_MS - now);
+	await delayMs(waitMs);
 }
 
-export function consumeSocketReconnectBudget(): boolean {
-	const now = Date.now();
-	prune(now);
-	if (attemptTimes.length >= MAX_ATTEMPTS) {
+export function markNetworkProbeCompleted(): void {
+	lastNetworkProbeAt = Date.now();
+}
+
+export function beginReconnectWave(): void {
+	reconnectWaveId += 1;
+	waveConnectAttempts = 0;
+	lastNetworkProbeAt = 0;
+}
+
+export function shouldProbeNetworkBeforeConnect(): boolean {
+	return waveConnectAttempts >= 1;
+}
+
+export function consumeReconnectAttempt(): boolean {
+	if (waveConnectAttempts >= MAX_RECONNECT_ATTEMPTS_PER_WAVE) {
 		return false;
 	}
-	attemptTimes.push(now);
+	waveConnectAttempts += 1;
 	return true;
 }
 
-export function refundSocketReconnectBudgetSlot(): void {
-	if (attemptTimes.length > 0) {
-		attemptTimes.pop();
+export function refundReconnectAttempt(): void {
+	if (waveConnectAttempts > 0) {
+		waveConnectAttempts -= 1;
 	}
 }
 
-export function resetSocketReconnectBudget(): void {
-	attemptTimes = [];
+export function resetReconnectWave(): void {
+	waveConnectAttempts = 0;
 	if (typeof window !== 'undefined') {
-		window.dispatchEvent(new CustomEvent('mezon:socket-budget-reset'));
+		window.dispatchEvent(new CustomEvent('mezon:reconnect-wave-reset'));
 	}
 }
+
+export const resetSocketReconnectBudget = resetReconnectWave;

--- a/libs/store/src/lib/BootstrapGate.tsx
+++ b/libs/store/src/lib/BootstrapGate.tsx
@@ -1,4 +1,4 @@
-import { useMezon } from '@mezon/transport';
+import { probeNetworkReachability, RECONNECT_NETWORK_PROBE_TIMEOUT_MS, useMezon } from '@mezon/transport';
 import type { ApiSession } from 'mezon-js';
 import type { ReactNode } from 'react';
 import { useEffect, useState } from 'react';
@@ -77,6 +77,19 @@ export function BootstrapGate({ children, persistor, fallback }: Props) {
 					// Retry call connect socket if it fail with MAX_RETRIES time
 					for (let i = 0; i <= MAX_RETRIES; i++) {
 						setRetryCount(i);
+
+						if (i > 0) {
+							const reachable = await probeNetworkReachability({
+								timeoutMs: RECONNECT_NETWORK_PROBE_TIMEOUT_MS
+							});
+							if (!reachable) {
+								console.error(`Network probe failed before bootstrap retry ${i}`);
+								if (i === MAX_RETRIES) break;
+								const baseDelay = INITIAL_DELAY * Math.pow(2, i);
+								await delay(baseDelay + Math.random() * 500);
+								continue;
+							}
+						}
 
 						try {
 							await connectSocket();

--- a/libs/transport/src/index.ts
+++ b/libs/transport/src/index.ts
@@ -3,6 +3,7 @@ export * from './lib/hooks/useMezon';
 export * from './lib/mezon';
 export * from './lib/minio';
 export * from './lib/network';
+export * from './lib/networkProbe';
 export * from './lib/sessionBridge';
 export * from './lib/socketState';
 export * from './lib/utils';

--- a/libs/transport/src/lib/contexts/MezonContext.tsx
+++ b/libs/transport/src/lib/contexts/MezonContext.tsx
@@ -190,6 +190,7 @@ const MezonContextProvider: React.FC<MezonContextProviderProps> = ({ children, m
 	const dongRef = React.useRef<DongClient | null>(null);
 	const mmnRef = React.useRef<MmnClient | null>(null);
 	const indexerRef = React.useRef<IndexerClient | null>(null);
+	const lastPersistedSidRef = React.useRef<string | null>(null);
 
 	React.useEffect(() => {
 		const unsubscribe = subscribeSessionUpdate(({ session, source }) => {
@@ -273,30 +274,28 @@ const MezonContextProvider: React.FC<MezonContextProviderProps> = ({ children, m
 		client.onrefreshsession = (sessionNew: ApiSession) => {
 			const prev = sessionRef.current;
 			const nextSid = sessionNew?.session_id;
-			console.log('[SessionFix] onrefreshsession fired');
-			if (!nextSid) {
-				console.warn('[SessionFix] onrefreshsession skipped: empty nextSid');
+			if (!prev || !nextSid) {
 				return;
 			}
-			if (prev && prev.session_id === nextSid) {
-				console.log('[SessionFix] onrefreshsession skipped: same session_id');
-				return;
-			}
-			const base = prev ?? sessionNew;
-			const updated: ApiSession = { ...base, session_id: nextSid };
-			sessionRef.current = updated;
 
-			try {
-				const raw = localStorage.getItem('persist:auth');
-				const outer = raw ? JSON.parse(raw) : {};
-				outer.session = JSON.stringify(updated);
-				localStorage.setItem('persist:auth', JSON.stringify(outer));
-				console.log('[SessionFix] onrefreshsession persisted to localStorage');
-			} catch (err) {
-				console.error('[SessionFix] onrefreshsession localStorage write failed');
+			const updated: ApiSession = { ...prev, session_id: nextSid };
+
+			if (lastPersistedSidRef.current !== nextSid) {
+				try {
+					const raw = localStorage.getItem('persist:auth');
+					const outer = raw ? JSON.parse(raw) : {};
+					outer.session = JSON.stringify(updated);
+					localStorage.setItem('persist:auth', JSON.stringify(outer));
+					lastPersistedSidRef.current = nextSid;
+				} catch (err) {
+					console.error('[SessionFix] onrefreshsession localStorage write failed', err);
+				}
 			}
 
-			publishSessionUpdate(updated, 'refresh');
+			if (prev.session_id !== nextSid) {
+				sessionRef.current = updated;
+				publishSessionUpdate(updated, 'refresh');
+			}
 		};
 
 		createZkClient();

--- a/libs/transport/src/lib/contexts/MezonContext.tsx
+++ b/libs/transport/src/lib/contexts/MezonContext.tsx
@@ -452,14 +452,7 @@ const MezonContextProvider: React.FC<MezonContextProviderProps> = ({ children, m
 
 			socketState.status = 'connected';
 			return sessionRef.current;
-		})()
-			.catch((error) => {
-				console.log('[ReconnectFlow] connectSocket failed', {
-					error: error instanceof Error ? error.message : String(error)
-				});
-				throw error;
-			})
-			.finally(() => {
+		})().finally(() => {
 				connectInFlight = null;
 			});
 

--- a/libs/transport/src/lib/networkProbe.ts
+++ b/libs/transport/src/lib/networkProbe.ts
@@ -1,0 +1,40 @@
+const FALLBACK_PROBE_ORIGIN = 'https://mezon.ai';
+
+
+function resolveDefaultProbeUrl(): string {
+	const origin = (process.env.NX_CHAT_APP_REDIRECT_URI ?? FALLBACK_PROBE_ORIGIN).replace(/\/$/, '');
+	return `${origin}/assets/favicon.ico`;
+}
+
+export const RECONNECT_NETWORK_PROBE_TIMEOUT_MS = 4000;
+
+export type ProbeNetworkOptions = {
+	url?: string;
+	timeoutMs?: number;
+};
+
+
+export function probeNetworkReachability(options: ProbeNetworkOptions = {}): Promise<boolean> {
+	if (typeof window === 'undefined') {
+		return Promise.resolve(true);
+	}
+
+	const baseUrl = options.url ?? resolveDefaultProbeUrl();
+	const timeoutMs = options.timeoutMs ?? RECONNECT_NETWORK_PROBE_TIMEOUT_MS;
+	const url = `${baseUrl}${baseUrl.includes('?') ? '&' : '?'}t=${Date.now()}`;
+
+	const controller = new AbortController();
+	const timerId = setTimeout(() => controller.abort(), timeoutMs);
+
+	return fetch(url, {
+		method: 'HEAD',
+		mode: 'no-cors',
+		cache: 'no-store',
+		signal: controller.signal
+	})
+		.then(() => true)
+		.catch(() => false)
+		.finally(() => {
+			clearTimeout(timerId);
+		});
+}


### PR DESCRIPTION
## Summary
Hotfix cherry-pick from `fix26m/web/socket-reconnect-wave-network-probe`:
- Per-wave socket reconnect (5 attempts) with HEAD network probe before retry
- Bootstrap connect retries use the same probe
- Post-reconnect cleanup only after app-driven reconnect (no refresh on initial login)
- Dedupe `onrefreshsession` writes to `persist:auth` when `session_id` unchanged

## Commits
- fix(chat): per-wave socket reconnect with HEAD network probe
- fix(chat): guard reconnect cleanup and dedupe session_id persist

## Test plan
- [ ] F5 with valid session: stays logged in when network OK
- [ ] Disconnect/reconnect: single refresh, toasts cleared
- [ ] Offline: probe fails, no logout until connect attempts exhausted
- [ ] Session refresh from server: `persist:auth` updated once per new `session_id`
