### PR TITLE
260601 - WEB/DESKTOP - fix cache and state channel cate noti

### DIFF
--- a/libs/store/src/lib/notificationSetting/notificationSettingCategory.slice.ts
+++ b/libs/store/src/lib/notificationSetting/notificationSettingCategory.slice.ts
@@ -437,7 +437,10 @@ export const channelCategorySettingSlice = createSlice({
 					}
 
 					if (!fromCache) {
-						channelCategorySettingAdapter.setAll(state.byClans[clanId].list, notification_channel_category_settings_list);
+						state.byClans[clanId].list = channelCategorySettingAdapter.setAll(
+							state.byClans[clanId].list,
+							notification_channel_category_settings_list
+						);
 						state.byClans[clanId].cache = createCacheMetadata(CHANNEL_CATEGORY_SETTING_CACHE_TIME);
 					}
 

--- a/libs/store/src/lib/store.tsx
+++ b/libs/store/src/lib/store.tsx
@@ -206,14 +206,6 @@ const persistedEventMngtReducer = persistReducer(
 	eventManagementReducer
 );
 
-const persistedChannelCatSettingReducer = persistReducer(
-	{
-		key: 'notichannelcategorysetting',
-		storage
-	},
-	channelCategorySettingReducer
-);
-
 const persistedPinMsgReducer = persistReducer(
 	{
 		key: 'pinmessages',
@@ -351,7 +343,7 @@ const reducer = {
 	pinmessages: persistedPinMsgReducer,
 	defaultnotificationclan: defaultNotificationClanReducer,
 	defaultnotificationcategory: persistedDefaultNotiCatReducer,
-	notichannelcategorysetting: persistedChannelCatSettingReducer,
+	notichannelcategorysetting: channelCategorySettingReducer,
 	invite: inviteReducer,
 	isshow: IsShowReducer,
 	forwardmessage: popupForwardReducer,


### PR DESCRIPTION
### Changes 

- Remove persist of channel_cate_noti_setting : Because when call api and cached it, it never call again so data can be old and wrong
- Set update state from adapter

### Test 

- Call channel_cate_noti_setting_list 

- Remove cached when close current session use

 


