### PR TITLE
260605 - WEB/DESKTOP - fix show avatar group in invite

### DIFF
--- a/libs/components/src/lib/components/ListMemberInvite/ListMemberInviteItem.tsx
+++ b/libs/components/src/lib/components/ListMemberInvite/ListMemberInviteItem.tsx
@@ -100,7 +100,9 @@ const ListMemberInviteItem = (props: ItemPorp) => {
 		<ItemInviteDM
 			channelID={dmGroup.channel_id}
 			type={Number(dmGroup.type)}
-			avatar={dmGroup.type === ChannelType.CHANNEL_TYPE_GROUP ? dmGroup.topic || '/assets/images/avatar-group.png' : dmGroup.avatars?.at(0)}
+			avatar={
+				dmGroup.type === ChannelType.CHANNEL_TYPE_GROUP ? dmGroup.channel_avatar || '/assets/images/avatar-group.png' : dmGroup.avatars?.at(0)
+			}
 			label={dmGroup.channel_label}
 			isInviteSent={isInviteSent}
 			onHandle={() => handleButtonClick(dmGroup.channel_id || '0', dmGroup.type || 0, dmGroup.user_ids?.at(0))}


### PR DESCRIPTION
### Changes

- use channel_avatar instread of channel.topic on show avatar group on modal invite to clan 

### Description 

- Older code we save avatar group on topic key 

### Ticket 

- [Desktop/Website] Group chat disappears after sending invite link via Invite modal
https://github.com/mezonai/mezon/issues/13164

### Test 

- Show avatar in invite modal 
<img width="637" height="602" alt="image" src="https://github.com/user-attachments/assets/b89f880c-8815-421d-a31e-f36113dfb56a" />
