### PR TITLE
feat(chat): defer attachment display until presign_finish sync

### DIFF
--- a/libs/components/src/lib/components/ChannelTopbar/GalleryModal.tsx
+++ b/libs/components/src/lib/components/ChannelTopbar/GalleryModal.tsx
@@ -23,6 +23,7 @@ import {
 	selectCurrentDM,
 	selectGalleryAttachmentsByChannel,
 	selectGalleryPaginationByChannel,
+	selectMessageByMessageId,
 	useAppDispatch,
 	useAppSelector,
 	type MediaFilterType
@@ -36,7 +37,9 @@ import {
 	convertDateStringI18n,
 	createImgproxyUrl,
 	generateE2eId,
-	getAttachmentDataForWindow
+	getAttachmentDataForWindow,
+	isAttachmentPresignPendingForMessage,
+	shouldHidePresignAttachment
 } from '@mezon/utils';
 import { endOfDay, format, getUnixTime, isSameDay, startOfDay } from 'date-fns';
 import isElectron from 'is-electron';
@@ -473,6 +476,15 @@ export function GalleryModal({ onClose, rootRef }: GalleryModalProps) {
 			const attachmentData = attachment;
 
 			if (!attachmentData) return;
+
+			const channelId = currentClanId !== '0' ? (currentChannelId as string) : (currentDmGroupId as string);
+			const sourceMessage =
+				attachmentData.message_id && channelId
+					? selectMessageByMessageId(state, channelId, attachmentData.message_id)
+					: undefined;
+			if (isAttachmentPresignPendingForMessage(attachmentData.url, sourceMessage)) return;
+			if (shouldHidePresignAttachment(attachmentData.url, sourceMessage)) return;
+
 			const enhancedAttachmentData = {
 				...attachmentData,
 				create_time: attachmentData.create_time || new Date().toISOString()
@@ -485,7 +497,6 @@ export function GalleryModal({ onClose, rootRef }: GalleryModalProps) {
 
 			if (isElectron()) {
 				const clanId = currentClanId === '0' ? '0' : (currentClanId as string);
-				const channelId = currentClanId !== '0' ? (currentChannelId as string) : (currentDmGroupId as string);
 
 				const messageTimestamp = enhancedAttachmentData.create_time
 					? Math.floor(new Date(enhancedAttachmentData.create_time).getTime() / 1000)
@@ -619,7 +630,6 @@ export function GalleryModal({ onClose, rootRef }: GalleryModalProps) {
 
 			if ((currentClanId && currentChannelId) || currentDmGroupId) {
 				const clanId = currentClanId === '0' ? '0' : (currentClanId as string);
-				const channelId = currentClanId !== '0' ? (currentChannelId as string) : (currentDmGroupId as string);
 				const messageTimestamp = enhancedAttachmentData.create_time
 					? Math.floor(new Date(enhancedAttachmentData.create_time).getTime() / 1000)
 					: undefined;
@@ -809,6 +819,7 @@ export function GalleryModal({ onClose, rootRef }: GalleryModalProps) {
 					) : (
 						<GalleryContent
 							virtualData={virtualData}
+							channelId={currentChannelId}
 							handleImageClick={handleImageClick}
 							formatDate={formatDate}
 							onLoadMore={handleLoadMoreAttachments}
@@ -824,8 +835,54 @@ export function GalleryModal({ onClose, rootRef }: GalleryModalProps) {
 	);
 }
 
+interface GalleryAttachmentTileProps {
+	attachment: AttachmentEntity;
+	channelId: string;
+	dateKey: string;
+	attachmentIndex: number;
+	onClick: (attachment: AttachmentEntity) => void;
+	t: (key: string, options?: any) => string;
+}
+
+const GalleryAttachmentTile = React.memo(({ attachment, channelId, dateKey, attachmentIndex, onClick, t }: GalleryAttachmentTileProps) => {
+	const sourceMessage = useAppSelector((state) =>
+		attachment.message_id && channelId ? selectMessageByMessageId(state, channelId, attachment.message_id) : undefined
+	);
+	const isPresignPending = isAttachmentPresignPendingForMessage(attachment.url, sourceMessage);
+	const isHidden = shouldHidePresignAttachment(attachment.url, sourceMessage);
+
+	if (isHidden) return null;
+
+	const cacheKey = attachment.id || attachment.message_id || `${dateKey}-${attachment.url}-${attachmentIndex}`;
+	const isVideo = attachment.filetype?.startsWith(ETypeLinkMedia.VIDEO_PREFIX);
+
+	if (isPresignPending) {
+		return <div key={cacheKey} className="aspect-square rounded-lg bg-bgLightSecondary dark:bg-bgSecondary" />;
+	}
+
+	return (
+		<ImageWithLoading
+			key={cacheKey}
+			cacheKey={cacheKey}
+			src={
+				isVideo
+					? attachment.url || ''
+					: createImgproxyUrl(attachment.url || '', { width: 120, height: 120, resizeType: 'fill' })
+			}
+			alt={attachment.filename || 'Media'}
+			onClick={() => onClick(attachment)}
+			isVideo={isVideo}
+			filetype={attachment.filetype}
+			t={t}
+		/>
+	);
+});
+
+GalleryAttachmentTile.displayName = 'GalleryAttachmentTile';
+
 interface GalleryContentProps {
 	virtualData: VirtualDataItem[];
+	channelId: string;
 	handleImageClick: (attachment: AttachmentEntity) => void;
 	formatDate: (date: Date) => string;
 	onLoadMore?: (direction: 'before' | 'after') => void;
@@ -990,6 +1047,7 @@ ImageWithLoading.displayName = 'ImageWithLoading';
 
 const GalleryContent = ({
 	virtualData,
+	channelId,
 	handleImageClick,
 	formatDate,
 	onLoadMore,
@@ -1050,26 +1108,17 @@ const GalleryContent = ({
 					if (item.type === 'imagesGrid') {
 						return (
 							<div key={`${item.dateKey}-grid`} className="gallery-item grid grid-cols-3 gap-3">
-								{item.attachments.map((attachment: AttachmentEntity, attachmentIndex: number) => {
-									const cacheKey = attachment.id || attachment.message_id || `${item.dateKey}-${attachment.url}-${attachmentIndex}`;
-									const isVideo = attachment.filetype?.startsWith(ETypeLinkMedia.VIDEO_PREFIX);
-									return (
-										<ImageWithLoading
-											key={cacheKey}
-											cacheKey={cacheKey}
-											src={
-												isVideo
-													? attachment.url || ''
-													: createImgproxyUrl(attachment.url || '', { width: 120, height: 120, resizeType: 'fill' })
-											}
-											alt={attachment.filename || 'Media'}
-											onClick={() => handleImageClick(attachment)}
-											isVideo={isVideo}
-											filetype={attachment.filetype}
-											t={t}
-										/>
-									);
-								})}
+								{item.attachments.map((attachment: AttachmentEntity, attachmentIndex: number) => (
+									<GalleryAttachmentTile
+										key={attachment.id || attachment.message_id || `${item.dateKey}-${attachment.url}-${attachmentIndex}`}
+										attachment={attachment}
+										channelId={channelId}
+										dateKey={item.dateKey}
+										attachmentIndex={attachmentIndex}
+										onClick={handleImageClick}
+										t={t}
+									/>
+								))}
 							</div>
 						);
 					}

--- a/libs/components/src/lib/components/MessageWithUser/Album.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/Album.tsx
@@ -15,6 +15,7 @@ type OwnProps = {
 	onContextMenu?: (event: React.MouseEvent<HTMLImageElement>) => void;
 	isInSearchMessage?: boolean;
 	isSending?: boolean;
+	isPresignPendingForUrl?: (url?: string) => boolean;
 	isMobile?: boolean;
 	messageId?: string;
 	images?: ApiMessageAttachment[];
@@ -31,6 +32,7 @@ const Album: FC<OwnProps> = ({
 	onContextMenu,
 	isInSearchMessage,
 	isSending,
+	isPresignPendingForUrl,
 	isMobile,
 	messageId,
 	images
@@ -61,6 +63,7 @@ const Album: FC<OwnProps> = ({
 				});
 
 			const attachmentId = messageId && images?.[index] ? generateAttachmentId(images[index], messageId) : `album-media-${index}`;
+			const isPresignPending = isPresignPendingForUrl?.(attachment?.url);
 			return (
 				<Photo
 					id={attachmentId}
@@ -74,6 +77,7 @@ const Album: FC<OwnProps> = ({
 					onClick={onClick}
 					onContextMenu={onContextMenu}
 					isSending={isSending}
+					isPresignPending={isPresignPending}
 					isInSearchMessage={isInSearchMessage}
 				/>
 			);

--- a/libs/components/src/lib/components/MessageWithUser/Album.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/Album.tsx
@@ -78,6 +78,7 @@ const Album: FC<OwnProps> = ({
 					onContextMenu={onContextMenu}
 					isSending={isSending}
 					isPresignPending={isPresignPending}
+					loadWhenUnpending={!isPresignPending}
 					isInSearchMessage={isInSearchMessage}
 				/>
 			);

--- a/libs/components/src/lib/components/MessageWithUser/MessageAttachment.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/MessageAttachment.tsx
@@ -14,14 +14,19 @@ import {
 	ETypeLinkMedia,
 	calculateAlbumLayout,
 	createImgproxyUrl,
+	filterExpiredPresignAttachments,
 	generateAttachmentId,
 	getAttachmentDataForWindow,
+	getPresignFinishFingerprint,
+	hasActivePresignPendingAttachments,
 	isMediaTypeNotSupported,
+	isPresignAttachmentPending,
+	parsePresignFinishKeys,
 	useAppLayout
 } from '@mezon/utils';
 import isElectron from 'is-electron';
 import type { ApiMessageAttachment, ChannelStreamMode } from 'mezon-js';
-import { memo, useCallback, useMemo } from 'react';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import Album from './Album';
 import { MessageAudio } from './MessageAudio/MessageAudio';
 import MessageLinkFile from './MessageLinkFile';
@@ -47,6 +52,22 @@ const getMessageCreateTimeSeconds = (message: IMessageWithUser): number | undefi
 	}
 	return undefined;
 };
+
+function usePresignExpiryNow(hasPresignPending: boolean): number {
+	const [nowSeconds, setNowSeconds] = useState(() => Math.floor(Date.now() / 1000));
+
+	useEffect(() => {
+		if (!hasPresignPending) return;
+
+		const interval = setInterval(() => {
+			setNowSeconds(Math.floor(Date.now() / 1000));
+		}, 30_000);
+
+		return () => clearInterval(interval);
+	}, [hasPresignPending]);
+
+	return nowSeconds;
+}
 
 const classifyAttachments = (attachments: ApiMessageAttachment[], message: IMessageWithUser) => {
 	const videos: ApiMessageAttachment[] = [];
@@ -115,6 +136,11 @@ const Attachments: React.FC<{
 		const classified = useMemo(() => classifyAttachments(attachments, message), [attachments, message]);
 
 		const { videos, images, documents, audio } = classified;
+		const presignFinishKeys = useMemo(() => parsePresignFinishKeys(message.content), [message.content]);
+		const isPresignPendingForUrl = useCallback(
+			(url?: string) => isPresignAttachmentPending(url, presignFinishKeys),
+			[presignFinishKeys]
+		);
 
 		const { isMobile } = useAppLayout();
 		return (
@@ -127,6 +153,7 @@ const Attachments: React.FC<{
 									attachmentData={video}
 									isMobile={isMobile}
 									isSending={message.isSending}
+									isPresignPending={isPresignPendingForUrl(video.url)}
 									observeIntersection={observeIntersectionForLoading}
 								/>
 							</div>
@@ -144,6 +171,7 @@ const Attachments: React.FC<{
 						isInSearchMessage={isInSearchMessage}
 						defaultMaxWidth={defaultMaxWidth}
 						isMobile={isMobile}
+						isPresignPendingForUrl={isPresignPendingForUrl}
 					/>
 				)}
 
@@ -161,6 +189,7 @@ const Attachments: React.FC<{
 		prev.message.id === next.message.id &&
 		prev.message.isSending === next.message.isSending &&
 		prev.message.attachments === next.message.attachments &&
+		getPresignFinishFingerprint(prev.message.content) === getPresignFinishFingerprint(next.message.content) &&
 		prev.mode === next.mode
 );
 
@@ -169,10 +198,26 @@ Attachments.displayName = 'Attachments';
 // TODO: refactor component for message lines
 const MessageAttachment = memo(
 	({ message, onContextMenu, mode, observeIntersectionForLoading, isInSearchMessage, defaultMaxWidth }: MessageAttachmentProps) => {
-		const validateAttachment = useMemo(
-			() => (message.attachments || [])?.filter((attachment) => Object.keys(attachment).length !== 0),
-			[message.attachments]
+		const hasPresignPending = useMemo(
+			() => hasActivePresignPendingAttachments(message.attachments, message.content),
+			[message.attachments, message.content]
 		);
+		const nowSeconds = usePresignExpiryNow(hasPresignPending);
+
+		const validateAttachment = useMemo(() => {
+			const rawAttachments = (message.attachments || []).filter((attachment) => Object.keys(attachment).length !== 0);
+			if (!rawAttachments.length) return null;
+
+			const messageCreateTimeSeconds = getMessageCreateTimeSeconds(message);
+			const visibleAttachments = filterExpiredPresignAttachments(
+				rawAttachments,
+				message.content,
+				messageCreateTimeSeconds,
+				nowSeconds
+			);
+
+			return visibleAttachments.length ? visibleAttachments : null;
+		}, [message.attachments, message.content, message.create_time_seconds, nowSeconds]);
 		if (!validateAttachment) return null;
 		return (
 			<Attachments
@@ -190,6 +235,7 @@ const MessageAttachment = memo(
 		prev.message.id === next.message.id &&
 		prev.message.attachments === next.message.attachments &&
 		prev.message.isSending === next.message.isSending &&
+		getPresignFinishFingerprint(prev.message.content) === getPresignFinishFingerprint(next.message.content) &&
 		prev.mode === next.mode
 );
 
@@ -204,7 +250,8 @@ const ImageAlbum = memo(
 		observeIntersectionForLoading,
 		isInSearchMessage,
 		defaultMaxWidth,
-		isMobile
+		isMobile,
+		isPresignPendingForUrl
 	}: {
 		images: ApiMessageAttachment[];
 		message: IMessageWithUser;
@@ -214,6 +261,7 @@ const ImageAlbum = memo(
 		isInSearchMessage?: boolean;
 		defaultMaxWidth?: number;
 		isMobile?: boolean;
+		isPresignPendingForUrl?: (url?: string) => boolean;
 	}) => {
 		const dispatch = useAppDispatch();
 
@@ -444,6 +492,7 @@ const ImageAlbum = memo(
 						onContextMenu={onContextMenu}
 						isInSearchMessage={isInSearchMessage}
 						isSending={message.isSending}
+						isPresignPendingForUrl={isPresignPendingForUrl}
 						isMobile={isMobile}
 						messageId={message.id}
 						images={images}
@@ -455,6 +504,7 @@ const ImageAlbum = memo(
 		if (images.length === 1 && photoProps) {
 			const firstImage = images[0];
 			const attachmentId = firstImage ? generateAttachmentId(firstImage, message.id) : message.id;
+			const isPresignPending = isPresignPendingForUrl?.(firstImage?.url);
 			return (
 				<div className="w-full py-1">
 					<Photo
@@ -467,6 +517,7 @@ const ImageAlbum = memo(
 						onContextMenu={onContextMenu}
 						isInSearchMessage={isInSearchMessage}
 						isSending={message.isSending}
+						isPresignPending={isPresignPending}
 						isMobile={isMobile}
 					/>
 				</div>
@@ -479,6 +530,7 @@ const ImageAlbum = memo(
 		prev.images === next.images &&
 		prev.message.id === next.message.id &&
 		prev.message.isSending === next.message.isSending &&
+		getPresignFinishFingerprint(prev.message.content) === getPresignFinishFingerprint(next.message.content) &&
 		prev.mode === next.mode &&
 		prev.isMobile === next.isMobile &&
 		prev.defaultMaxWidth === next.defaultMaxWidth

--- a/libs/components/src/lib/components/MessageWithUser/MessageAttachment.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/MessageAttachment.tsx
@@ -17,6 +17,8 @@ import {
 	filterExpiredPresignAttachments,
 	generateAttachmentId,
 	getAttachmentDataForWindow,
+	getMessageCreateTimeSeconds,
+	getPresignExpiryDelayMs,
 	getPresignFinishFingerprint,
 	hasActivePresignPendingAttachments,
 	isMediaTypeNotSupported,
@@ -43,28 +45,26 @@ type MessageAttachmentProps = {
 	defaultMaxWidth?: number;
 };
 
-const getMessageCreateTimeSeconds = (message: IMessageWithUser): number | undefined => {
-	if (message.create_time_seconds) return message.create_time_seconds;
-	const createTime = (message as any).create_time;
-	if (createTime) {
-		const parsed = new Date(createTime).getTime();
-		if (!isNaN(parsed)) return Math.floor(parsed / 1000);
-	}
-	return undefined;
-};
-
-function usePresignExpiryNow(hasPresignPending: boolean): number {
+function usePresignExpiryNow(hasPresignPending: boolean, messageCreateTimeSeconds?: number): number {
 	const [nowSeconds, setNowSeconds] = useState(() => Math.floor(Date.now() / 1000));
 
 	useEffect(() => {
 		if (!hasPresignPending) return;
 
-		const interval = setInterval(() => {
-			setNowSeconds(Math.floor(Date.now() / 1000));
-		}, 30_000);
+		const delay = getPresignExpiryDelayMs(messageCreateTimeSeconds);
+		if (delay === null) return;
 
-		return () => clearInterval(interval);
-	}, [hasPresignPending]);
+		if (delay === 0) {
+			setNowSeconds(Math.floor(Date.now() / 1000));
+			return;
+		}
+
+		const timeout = setTimeout(() => {
+			setNowSeconds(Math.floor(Date.now() / 1000));
+		}, delay);
+
+		return () => clearTimeout(timeout);
+	}, [hasPresignPending, messageCreateTimeSeconds]);
 
 	return nowSeconds;
 }
@@ -176,11 +176,16 @@ const Attachments: React.FC<{
 				)}
 
 				{documents.length > 0 &&
-					documents.map((document, index) => (
-						<MessageLinkFile key={`${index}_${document.url}`} attachmentData={document} mode={mode} message={message} />
-					))}
+					documents
+						.filter((document) => !isPresignPendingForUrl(document.url))
+						.map((document, index) => (
+							<MessageLinkFile key={`${index}_${document.url}`} attachmentData={document} mode={mode} message={message} />
+						))}
 
-				{audio.length > 0 && audio.map((audio, index) => <MessageAudio key={`${index}_${audio.url}`} audioUrl={audio.url || ''} />)}
+				{audio.length > 0 &&
+					audio
+						.filter((audioItem) => !isPresignPendingForUrl(audioItem.url))
+						.map((audioItem, index) => <MessageAudio key={`${index}_${audioItem.url}`} audioUrl={audioItem.url || ''} />)}
 			</>
 		);
 	},
@@ -198,17 +203,16 @@ Attachments.displayName = 'Attachments';
 // TODO: refactor component for message lines
 const MessageAttachment = memo(
 	({ message, onContextMenu, mode, observeIntersectionForLoading, isInSearchMessage, defaultMaxWidth }: MessageAttachmentProps) => {
+		const messageCreateTimeSeconds = useMemo(() => getMessageCreateTimeSeconds(message), [message]);
 		const hasPresignPending = useMemo(
 			() => hasActivePresignPendingAttachments(message.attachments, message.content),
 			[message.attachments, message.content]
 		);
-		const nowSeconds = usePresignExpiryNow(hasPresignPending);
+		const nowSeconds = usePresignExpiryNow(hasPresignPending, messageCreateTimeSeconds);
 
 		const validateAttachment = useMemo(() => {
 			const rawAttachments = (message.attachments || []).filter((attachment) => Object.keys(attachment).length !== 0);
 			if (!rawAttachments.length) return null;
-
-			const messageCreateTimeSeconds = getMessageCreateTimeSeconds(message);
 			const visibleAttachments = filterExpiredPresignAttachments(
 				rawAttachments,
 				message.content,
@@ -217,7 +221,7 @@ const MessageAttachment = memo(
 			);
 
 			return visibleAttachments.length ? visibleAttachments : null;
-		}, [message.attachments, message.content, message.create_time_seconds, nowSeconds]);
+		}, [message.attachments, message.content, messageCreateTimeSeconds, nowSeconds]);
 		if (!validateAttachment) return null;
 		return (
 			<Attachments

--- a/libs/components/src/lib/components/MessageWithUser/MessageAttachment.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/MessageAttachment.tsx
@@ -5,8 +5,10 @@ import {
 	selectCurrentChannel,
 	selectCurrentClanId,
 	selectCurrentDM,
+	selectMessageByMessageId,
 	selectMessageEntitiesByChannelId,
-	useAppDispatch
+	useAppDispatch,
+	useAppSelector
 } from '@mezon/store';
 import type { ApiPhoto, IImageWindowProps, IMessageWithUser, ObserveFn } from '@mezon/utils';
 import {
@@ -19,7 +21,6 @@ import {
 	getAttachmentDataForWindow,
 	getMessageCreateTimeSeconds,
 	getPresignExpiryDelayMs,
-	getPresignFinishFingerprint,
 	hasActivePresignPendingAttachments,
 	isMediaTypeNotSupported,
 	isPresignAttachmentPending,
@@ -37,6 +38,7 @@ import Photo from './Photo';
 
 type MessageAttachmentProps = {
 	message: IMessageWithUser;
+	channelId?: string;
 	onContextMenu?: (event: React.MouseEvent<HTMLImageElement>) => void;
 	mode: ChannelStreamMode;
 	observeIntersectionForLoading?: ObserveFn;
@@ -44,6 +46,26 @@ type MessageAttachmentProps = {
 	isTopic?: boolean;
 	defaultMaxWidth?: number;
 };
+
+function areAttachmentLiveFieldsEqual(prev: IMessageWithUser, next: IMessageWithUser): boolean {
+	return (
+		prev.attachments === next.attachments &&
+		prev.content === next.content &&
+		prev.isSending === next.isSending &&
+		prev.create_time_seconds === next.create_time_seconds
+	);
+}
+
+/** Redux subscription scoped to attachment/presign fields — re-renders without bumping message row memo. */
+function useLiveMessageForAttachments(messageProp: IMessageWithUser, channelId?: string): IMessageWithUser {
+	const resolvedChannelId = (channelId ?? messageProp.channel_id) as string;
+	const messageId = messageProp.id as string;
+
+	return useAppSelector(
+		(state) => selectMessageByMessageId(state, resolvedChannelId, messageId) ?? messageProp,
+		areAttachmentLiveFieldsEqual
+	);
+}
 
 function usePresignExpiryNow(hasPresignPending: boolean, messageCreateTimeSeconds?: number): number {
 	const [nowSeconds, setNowSeconds] = useState(() => Math.floor(Date.now() / 1000));
@@ -137,9 +159,10 @@ const Attachments: React.FC<{
 
 		const { videos, images, documents, audio } = classified;
 		const presignFinishKeys = useMemo(() => parsePresignFinishKeys(message.content), [message.content]);
+		const presignAttachmentSource = message.attachments ?? attachments;
 		const isPresignPendingForUrl = useCallback(
-			(url?: string) => isPresignAttachmentPending(url, presignFinishKeys),
-			[presignFinishKeys]
+			(url?: string) => isPresignAttachmentPending(url, presignFinishKeys, presignAttachmentSource),
+			[presignFinishKeys, presignAttachmentSource]
 		);
 
 		const { isMobile } = useAppLayout();
@@ -194,7 +217,7 @@ const Attachments: React.FC<{
 		prev.message.id === next.message.id &&
 		prev.message.isSending === next.message.isSending &&
 		prev.message.attachments === next.message.attachments &&
-		getPresignFinishFingerprint(prev.message.content) === getPresignFinishFingerprint(next.message.content) &&
+		prev.message.content === next.message.content &&
 		prev.mode === next.mode
 );
 
@@ -202,7 +225,16 @@ Attachments.displayName = 'Attachments';
 
 // TODO: refactor component for message lines
 const MessageAttachment = memo(
-	({ message, onContextMenu, mode, observeIntersectionForLoading, isInSearchMessage, defaultMaxWidth }: MessageAttachmentProps) => {
+	({
+		message: messageProp,
+		channelId,
+		onContextMenu,
+		mode,
+		observeIntersectionForLoading,
+		isInSearchMessage,
+		defaultMaxWidth
+	}: MessageAttachmentProps) => {
+		const message = useLiveMessageForAttachments(messageProp, channelId);
 		const messageCreateTimeSeconds = useMemo(() => getMessageCreateTimeSeconds(message), [message]);
 		const hasPresignPending = useMemo(
 			() => hasActivePresignPendingAttachments(message.attachments, message.content),
@@ -237,10 +269,10 @@ const MessageAttachment = memo(
 	},
 	(prev, next) =>
 		prev.message.id === next.message.id &&
-		prev.message.attachments === next.message.attachments &&
-		prev.message.isSending === next.message.isSending &&
-		getPresignFinishFingerprint(prev.message.content) === getPresignFinishFingerprint(next.message.content) &&
-		prev.mode === next.mode
+		prev.channelId === next.channelId &&
+		prev.mode === next.mode &&
+		prev.isInSearchMessage === next.isInSearchMessage &&
+		prev.defaultMaxWidth === next.defaultMaxWidth
 );
 
 MessageAttachment.displayName = 'MessageAttachment';
@@ -522,6 +554,7 @@ const ImageAlbum = memo(
 						isInSearchMessage={isInSearchMessage}
 						isSending={message.isSending}
 						isPresignPending={isPresignPending}
+						loadWhenUnpending={!isPresignPending}
 						isMobile={isMobile}
 					/>
 				</div>
@@ -534,7 +567,7 @@ const ImageAlbum = memo(
 		prev.images === next.images &&
 		prev.message.id === next.message.id &&
 		prev.message.isSending === next.message.isSending &&
-		getPresignFinishFingerprint(prev.message.content) === getPresignFinishFingerprint(next.message.content) &&
+		prev.message.content === next.message.content &&
 		prev.mode === next.mode &&
 		prev.isMobile === next.isMobile &&
 		prev.defaultMaxWidth === next.defaultMaxWidth

--- a/libs/components/src/lib/components/MessageWithUser/MessageModalImage/index.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/MessageModalImage/index.tsx
@@ -12,6 +12,7 @@ import {
 	selectDmChannelLabelById,
 	selectMemberClanByUserId,
 	selectMemberGroupByUserId,
+	selectMessageByMessageId,
 	selectMessageIdAttachment,
 	selectModeAttachment,
 	selectModeResponsive,
@@ -20,7 +21,15 @@ import {
 	useAppSelector
 } from '@mezon/store';
 import { Icons } from '@mezon/ui';
-import { ETypeLinkMedia, ModeResponsive, SHOW_POSITION, createImgproxyUrl, formatDateI18n, handleSaveImage } from '@mezon/utils';
+import {
+	ETypeLinkMedia,
+	ModeResponsive,
+	SHOW_POSITION,
+	createImgproxyUrl,
+	formatDateI18n,
+	handleSaveImage,
+	isAttachmentPresignPendingForMessage
+} from '@mezon/utils';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { AvatarImage } from '../../AvatarImage/AvatarImage';
 import type { MessageContextMenuProps } from '../../ContextMenu';
@@ -72,6 +81,41 @@ const MessageModalImage = () => {
 
 	const mode = useAppSelector(selectModeAttachment);
 	const messageId = useAppSelector(selectMessageIdAttachment);
+	const channelIdForAttachments = (directId ?? currentChannelId) as string;
+	const sourceMessage = useAppSelector((state) =>
+		currentAttachment?.message_id && channelIdForAttachments
+			? selectMessageByMessageId(state, channelIdForAttachments, currentAttachment.message_id)
+			: undefined
+	);
+	const isMainPresignPending = isAttachmentPresignPendingForMessage(urlImg ?? currentAttachment?.url, sourceMessage);
+
+	const getSourceMessageForAttachment = useCallback(
+		(att: (typeof attachments)[number] | undefined) => {
+			if (!att?.message_id || !channelIdForAttachments) return undefined;
+			return selectMessageByMessageId(getStore()?.getState(), channelIdForAttachments, att.message_id);
+		},
+		[channelIdForAttachments]
+	);
+
+	const isAttPresignPending = useCallback(
+		(att: (typeof attachments)[number] | undefined) =>
+			isAttachmentPresignPendingForMessage(att?.url, getSourceMessageForAttachment(att)),
+		[getSourceMessageForAttachment]
+	);
+
+	const findSelectableIndex = useCallback(
+		(fromIndex: number, step: number) => {
+			if (!attachments?.length) return fromIndex;
+			let index = fromIndex + step;
+			while (index >= 0 && index < attachments.length) {
+				if (!isAttPresignPending(attachments[index])) return index;
+				index += step;
+			}
+			return fromIndex;
+		},
+		[attachments, isAttPresignPending]
+	);
+
 	const dispatch = useAppDispatch();
 	const handleShowList = () => {
 		setShowList(!showList);
@@ -246,6 +290,7 @@ const MessageModalImage = () => {
 			if (!attachments) {
 				return;
 			}
+			if (isAttPresignPending(attachments[newIndex])) return;
 			setScale(1);
 			setRotate(0);
 			setPosition({ x: 0, y: 0 });
@@ -253,7 +298,7 @@ const MessageModalImage = () => {
 			setCurrentIndexAtt(newIndex);
 			dispatch(attachmentActions.setCurrentAttachment(attachments[newIndex]));
 		},
-		[attachments, dispatch]
+		[attachments, dispatch, isAttPresignPending]
 	);
 
 	const handleSelectNextImage = useCallback(() => {
@@ -261,18 +306,19 @@ const MessageModalImage = () => {
 			return;
 		}
 
-		const newIndex = currentIndexAtt < attachments.length - 1 ? currentIndexAtt + 1 : currentIndexAtt;
+		const newIndex =
+			currentIndexAtt < attachments.length - 1 ? findSelectableIndex(currentIndexAtt, 1) : currentIndexAtt;
 		if (newIndex !== currentIndexAtt) {
 			handleSelectImage(newIndex);
 		}
-	}, [attachments, currentIndexAtt, handleSelectImage]);
+	}, [attachments, currentIndexAtt, findSelectableIndex, handleSelectImage]);
 
 	const handleSelectPreviousImage = useCallback(() => {
-		const newIndex = currentIndexAtt > 0 ? currentIndexAtt - 1 : currentIndexAtt;
+		const newIndex = currentIndexAtt > 0 ? findSelectableIndex(currentIndexAtt, -1) : currentIndexAtt;
 		if (newIndex !== currentIndexAtt) {
 			handleSelectImage(newIndex);
 		}
-	}, [currentIndexAtt, handleSelectImage]);
+	}, [currentIndexAtt, findSelectableIndex, handleSelectImage]);
 
 	const handleKeyDown = useCallback(
 		(event: KeyboardEvent) => {
@@ -417,7 +463,17 @@ const MessageModalImage = () => {
 							<span className="sr-only">Loading...</span>
 						</div>
 					)}
-					{isVideo ? (
+					{isMainPresignPending ? (
+						<div
+							className="max-h-full max-w-full rounded-[10px] bg-bgLightSecondary dark:bg-bgSecondary animate-pulse"
+							style={{
+								width: currentAttachment?.width ? `${Math.min(currentAttachment.width, 480)}px` : '60%',
+								height: currentAttachment?.height ? `${Math.min(currentAttachment.height, 360)}px` : '60%',
+								maxWidth: '100%',
+								maxHeight: '100%'
+							}}
+						/>
+					) : isVideo ? (
 						<video
 							ref={videoRef}
 							src={urlImg ?? ''}
@@ -476,6 +532,7 @@ const MessageModalImage = () => {
 				{showList && (
 					<ListAttachment
 						attachments={attachments ? attachments : []}
+						channelId={channelIdForAttachments}
 						urlImg={urlImg}
 						setUrlImg={setUrlImg}
 						handleDrag={handleDrag}

--- a/libs/components/src/lib/components/MessageWithUser/MessageModalImage/itemAttachment.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/MessageModalImage/itemAttachment.tsx
@@ -1,9 +1,10 @@
 import type { AttachmentEntity } from '@mezon/store';
-import { attachmentActions, useAppDispatch } from '@mezon/store';
-import { EMimeTypes, ETypeLinkMedia, createImgproxyUrl } from '@mezon/utils';
+import { attachmentActions, selectMessageByMessageId, useAppDispatch, useAppSelector } from '@mezon/store';
+import { EMimeTypes, ETypeLinkMedia, createImgproxyUrl, isAttachmentPresignPendingForMessage } from '@mezon/utils';
 
 type ItemAttachmentProps = {
 	attachment: AttachmentEntity;
+	channelId: string;
 	previousDate: any;
 	selectedImageRef: React.MutableRefObject<HTMLDivElement | null>;
 	showDate: boolean;
@@ -15,10 +16,17 @@ type ItemAttachmentProps = {
 };
 
 const ItemAttachment = (props: ItemAttachmentProps) => {
-	const { attachment, previousDate, selectedImageRef, showDate, setUrlImg, handleDrag, setCurrentIndexAtt, index, currentIndexAtt } = props;
+	const { attachment, channelId, previousDate, selectedImageRef, showDate, setUrlImg, handleDrag, setCurrentIndexAtt, index, currentIndexAtt } =
+		props;
 	const dispatch = useAppDispatch();
 	const isSelected = index === currentIndexAtt;
+	const sourceMessage = useAppSelector((state) =>
+		attachment.message_id && channelId ? selectMessageByMessageId(state, channelId, attachment.message_id) : undefined
+	);
+	const isPresignPending = isAttachmentPresignPendingForMessage(attachment.url, sourceMessage);
+
 	const handleSelectImage = () => {
+		if (isPresignPending) return;
 		setUrlImg(attachment.url || '');
 		setCurrentIndexAtt(index);
 		dispatch(attachmentActions.setCurrentAttachment(attachment));
@@ -30,21 +38,27 @@ const ItemAttachment = (props: ItemAttachmentProps) => {
 		attachment.filetype?.includes(EMimeTypes.mp4) ||
 		attachment.filetype?.includes(EMimeTypes.mov);
 
+	const thumbnailClassName = `size-[88px] max-w-[88px] max-h-[88px] max-[480px]:size-16 w-full mx-auto gap-5 object-cover rounded-md ${
+		isPresignPending ? 'cursor-default' : 'cursor-pointer'
+	} ${isSelected ? '' : 'overlay'} border-2 ${isSelected ? 'dark:bg-slate-700 bg-bgLightModeButton border-colorTextLightMode' : 'border-transparent'}`;
+
 	return (
 		<div className={`attachment-item`} ref={isSelected ? selectedImageRef : null}>
 			{showDate && <div className={`dark:text-white text-black mb-1 text-center`}>{previousDate}</div>}
 			<div
-				className={`rounded-md cursor-pointer ${isSelected ? 'flex items-center border-2 border-white' : 'relative'}`}
+				className={`rounded-md ${isPresignPending ? 'cursor-default' : 'cursor-pointer'} ${isSelected ? 'flex items-center border-2 border-white' : 'relative'}`}
 				onClick={handleSelectImage}
 			>
-				{isVideo ? (
+				{isPresignPending ? (
+					<div className={`${thumbnailClassName} bg-bgLightSecondary dark:bg-bgSecondary`} />
+				) : isVideo ? (
 					<div className="relative">
 						<video
 							src={attachment.url ?? ''}
-							className={`size-[88px] max-w-[88px] max-h-[88px] max-[480px]:size-16 w-full mx-auto gap-5 object-cover rounded-md cursor-pointer ${isSelected ? '' : 'overlay'} border-2 ${isSelected ? 'dark:bg-slate-700 bg-bgLightModeButton border-colorTextLightMode' : 'border-transparent'}`}
+							className={thumbnailClassName}
 							muted
 							playsInline
-							preload="metadata"
+							preload="none"
 							onDragStart={handleDrag}
 							onKeyDown={(event) => {
 								if (event.key === 'Enter') {
@@ -62,7 +76,7 @@ const ItemAttachment = (props: ItemAttachmentProps) => {
 					<img
 						src={createImgproxyUrl(attachment.url ?? '', { width: 300, height: 300, resizeType: 'fit' })}
 						alt={attachment.url}
-						className={`size-[88px] max-w-[88px] max-h-[88px] max-[480px]:size-16 w-full mx-auto gap-5 object-cover rounded-md cursor-pointer ${isSelected ? '' : 'overlay'} border-2 ${isSelected ? 'dark:bg-slate-700 bg-bgLightModeButton border-colorTextLightMode' : 'border-transparent'}`}
+						className={thumbnailClassName}
 						onDragStart={handleDrag}
 						onKeyDown={(event) => {
 							if (event.key === 'Enter') {

--- a/libs/components/src/lib/components/MessageWithUser/MessageModalImage/listAttachment.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/MessageModalImage/listAttachment.tsx
@@ -7,6 +7,7 @@ import ItemAttachment from './itemAttachment';
 
 type ListAttachmentProps = {
 	attachments: AttachmentEntity[];
+	channelId: string;
 	urlImg: string;
 	setUrlImg: React.Dispatch<React.SetStateAction<string>>;
 	handleDrag: (e: any) => void;
@@ -28,6 +29,7 @@ type ListAttachmentProps = {
 const ListAttachment = (props: ListAttachmentProps) => {
 	const {
 		attachments,
+		channelId,
 		urlImg,
 		setUrlImg,
 		setScale,
@@ -182,6 +184,7 @@ const ListAttachment = (props: ListAttachmentProps) => {
 							<ItemAttachment
 								key={attachment.id}
 								attachment={attachment}
+								channelId={channelId}
 								previousDate={currentDate}
 								selectedImageRef={selectedImageRef}
 								showDate={showDate}

--- a/libs/components/src/lib/components/MessageWithUser/MessageVideo.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/MessageVideo.tsx
@@ -483,7 +483,7 @@ function MacElectronVideo({
 	const isUploading = isSending || isPresignPending;
 	const { status: probeStatus, errorMessage, codecInfo } = useVideoProbe(
 		attachmentData.url,
-		isIntersecting && !isPresignPending,
+		isIntersecting && activated && !isPresignPending,
 		attachmentData.filename
 	);
 	const { width, height, mediaStyle } = useVideoMediaDimensions(attachmentData, isMobile, isPreview);
@@ -646,11 +646,6 @@ function DefaultVideo({
 	const handlePlay = useCallback(() => {
 		if (isUploading) return;
 		requestPlay();
-		const video = videoRef.current;
-		if (video) {
-			video.preload = 'auto';
-			void video.play().catch(() => undefined);
-		}
 		setActivated(true);
 	}, [isUploading, requestPlay]);
 
@@ -696,26 +691,23 @@ function DefaultVideo({
 				<VideoPoster thumbnailUrl={thumbnailUrl} style={mediaStyle} onPlay={handlePlay} disablePlay={isUploading} isSending={isUploading} />
 			)}
 
-			{showMedia && (
+			{isVideoActive && (
 				<>
 					<video
-						controls={activated && showControl}
+						controls={showControl}
 						autoPlay={false}
-						style={{
-							...mediaStyle,
-							...(activated ? {} : { position: 'absolute', width: 0, height: 0, opacity: 0, pointerEvents: 'none' })
-						}}
+						style={mediaStyle}
 						ref={videoRef}
-						onCanPlay={activated ? handleOnCanPlay : undefined}
+						onCanPlay={handleOnCanPlay}
 						className="object-contain"
-						preload={activated ? 'auto' : 'none'}
+						preload="auto"
 						playsInline
 					>
 						<source src={attachmentData.url} />
 						{t('video.error.browserNotSupported')}
 					</video>
 
-					{activated && !showControl && (
+					{!showControl && (
 						<div
 							className="cursor-pointer absolute inset-0 flex items-center justify-center z-20 bg-black bg-opacity-30 group"
 							onClick={handleShowFullVideo}
@@ -724,17 +716,15 @@ function DefaultVideo({
 						</div>
 					)}
 
-					{activated && (
-						<div
-							className="group-hover:flex hidden top-2 right-1 cursor-pointer absolute bg-bgSurface rounded-md w-6 h-6  items-center justify-center z-30"
-							onClick={handleDownloadVideo}
-						>
-							<Icons.Download
-								defaultSize="!w-4 !h-4 "
-								defaultFill="dark:text-[#AEAEAE] text-[#535353] dark:hover:text-white hover:text-black"
-							/>
-						</div>
-					)}
+					<div
+						className="group-hover:flex hidden top-2 right-1 cursor-pointer absolute bg-bgSurface rounded-md w-6 h-6  items-center justify-center z-30"
+						onClick={handleDownloadVideo}
+					>
+						<Icons.Download
+							defaultSize="!w-4 !h-4 "
+							defaultFill="dark:text-[#AEAEAE] text-[#535353] dark:hover:text-white hover:text-black"
+						/>
+					</div>
 				</>
 			)}
 		</div>

--- a/libs/components/src/lib/components/MessageWithUser/MessageVideo.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/MessageVideo.tsx
@@ -5,6 +5,7 @@ import type { ApiMessageAttachment } from 'mezon-js';
 import type { Movie, Track } from 'mp4box';
 import { MP4BoxBuffer, createFile } from 'mp4box';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { flushSync } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { useDebouncedCallback } from 'use-debounce';
 import { AttachmentSendingIndicator } from './AttachmentSendingIndicator';
@@ -13,6 +14,7 @@ export type MessageImage = {
 	isMobile?: boolean;
 	isPreview?: boolean;
 	isSending?: boolean;
+	isPresignPending?: boolean;
 	observeIntersection?: ObserveFn;
 };
 export const MIN_WIDTH_VIDEO_SHOW = 200;
@@ -361,6 +363,36 @@ function useDownloadVideo(url?: string, filename?: string) {
 	}, [url, filename]);
 }
 
+function usePlayOnActivation(videoRef: React.RefObject<HTMLVideoElement | null>, shouldPlay: boolean) {
+	const pendingPlayRef = useRef(false);
+
+	const requestPlay = useCallback(() => {
+		pendingPlayRef.current = true;
+	}, []);
+
+	const tryPlay = useCallback(() => {
+		const video = videoRef.current;
+		if (!video || !pendingPlayRef.current || !shouldPlay) return;
+
+		void video
+			.play()
+			.then(() => {
+				pendingPlayRef.current = false;
+			})
+			.catch(() => {
+				pendingPlayRef.current = false;
+			});
+	}, [shouldPlay, videoRef]);
+
+	useEffect(() => {
+		if (shouldPlay) {
+			tryPlay();
+		}
+	}, [shouldPlay, tryPlay]);
+
+	return { requestPlay, tryPlay };
+}
+
 function useVideoCleanup(videoRef: React.RefObject<HTMLVideoElement | null>, isActive: boolean) {
 	const prevActiveRef = useRef(isActive);
 
@@ -436,33 +468,60 @@ function resolveVideoThumbnailUrl(attachmentData: ApiMessageAttachment, width: n
 	return createImgproxyUrl(thumb, { width: Math.round(width), height: Math.round(height), resizeType: 'fit' });
 }
 
-function MacElectronVideo({ attachmentData, isMobile = false, isPreview = false, isSending = false, observeIntersection }: MessageImage) {
+function MacElectronVideo({
+	attachmentData,
+	isMobile = false,
+	isPreview = false,
+	isSending = false,
+	isPresignPending = false,
+	observeIntersection
+}: MessageImage) {
 	const { t } = useTranslation('media');
 	const containerRef = useRef<HTMLDivElement>(null);
 	const isIntersecting = useIsIntersecting(containerRef, observeIntersection);
 	const [activated, setActivated] = useState(false);
-	const { status: probeStatus, errorMessage, codecInfo } = useVideoProbe(attachmentData.url, isIntersecting && activated, attachmentData.filename);
+	const isUploading = isSending || isPresignPending;
+	const { status: probeStatus, errorMessage, codecInfo } = useVideoProbe(
+		attachmentData.url,
+		isIntersecting && !isPresignPending,
+		attachmentData.filename
+	);
 	const { width, height, mediaStyle } = useVideoMediaDimensions(attachmentData, isMobile, isPreview);
 	const handleDownloadVideo = useDownloadVideo(attachmentData.url, attachmentData.filename);
 
 	const videoRef = useRef<HTMLVideoElement>(null);
 	const [showControl, setShowControl] = useState(true);
-	const shouldRenderVideo = activated && probeStatus === 'ready' && !isSending;
+	const shouldRenderVideo = activated && probeStatus === 'ready' && !isUploading;
+	const { requestPlay, tryPlay } = usePlayOnActivation(videoRef, shouldRenderVideo);
 
-	const thumbnailUrl = resolveVideoThumbnailUrl(attachmentData, width, height);
+	const thumbnailUrl = isPresignPending ? undefined : resolveVideoThumbnailUrl(attachmentData, width, height);
+
+	const playFromUserGesture = useCallback(() => {
+		const video = videoRef.current;
+		if (!video) return;
+		void video.play().catch(() => undefined);
+	}, []);
 
 	const handlePlay = useCallback(() => {
-		if (isSending) return;
-		setActivated(true);
-	}, [isSending]);
+		if (isUploading) return;
+		requestPlay();
+		flushSync(() => {
+			setActivated(true);
+		});
+		playFromUserGesture();
+	}, [isUploading, requestPlay, playFromUserGesture]);
 
 	useVideoCleanup(videoRef, shouldRenderVideo);
 
-	const handleOnCanPlay = useCallback((e: React.SyntheticEvent<HTMLVideoElement, Event>) => {
-		if (e.currentTarget.offsetWidth < MIN_WIDTH_VIDEO_SHOW) {
-			setShowControl(false);
-		}
-	}, []);
+	const handleOnCanPlay = useCallback(
+		(e: React.SyntheticEvent<HTMLVideoElement, Event>) => {
+			tryPlay();
+			if (e.currentTarget.offsetWidth < MIN_WIDTH_VIDEO_SHOW) {
+				setShowControl(false);
+			}
+		},
+		[tryPlay]
+	);
 
 	const handleShowFullVideo = useCallback(() => {
 		if (videoRef.current) {
@@ -481,19 +540,19 @@ function MacElectronVideo({ attachmentData, isMobile = false, isPreview = false,
 	useResizeObserver(videoRef, handleResize);
 
 	useEffect(() => {
-		if (!showControl && videoRef.current && !videoRef.current.paused) {
+		if (!showControl && !activated && videoRef.current && !videoRef.current.paused) {
 			videoRef.current.pause();
 		}
-	}, [showControl]);
+	}, [showControl, activated]);
 
-	const showMedia = isSending || isIntersecting;
+	const showMedia = isUploading || isIntersecting;
 
 	return (
 		<div ref={containerRef} className="relative overflow-hidden group rounded-lg max-w-full">
 			{!showMedia && <VideoSkeleton style={mediaStyle} />}
 
 			{showMedia && !activated && (
-				<VideoPoster thumbnailUrl={thumbnailUrl} style={mediaStyle} onPlay={handlePlay} disablePlay={isSending} isSending={isSending} />
+				<VideoPoster thumbnailUrl={thumbnailUrl} style={mediaStyle} onPlay={handlePlay} disablePlay={isUploading} isSending={isUploading} />
 			)}
 
 			{activated && (probeStatus === 'idle' || probeStatus === 'probing') && <VideoSkeleton style={mediaStyle} />}
@@ -560,31 +619,50 @@ function MacElectronVideo({ attachmentData, isMobile = false, isPreview = false,
 	);
 }
 
-function DefaultVideo({ attachmentData, isMobile = false, isPreview = false, isSending = false, observeIntersection }: MessageImage) {
+function DefaultVideo({
+	attachmentData,
+	isMobile = false,
+	isPreview = false,
+	isSending = false,
+	isPresignPending = false,
+	observeIntersection
+}: MessageImage) {
 	const { t } = useTranslation('media');
 	const containerRef = useRef<HTMLDivElement>(null);
 	const isIntersecting = useIsIntersecting(containerRef, observeIntersection);
 	const [activated, setActivated] = useState(false);
+	const isUploading = isSending || isPresignPending;
 	const { width, height, mediaStyle } = useVideoMediaDimensions(attachmentData, isMobile, isPreview);
 	const handleDownloadVideo = useDownloadVideo(attachmentData.url, attachmentData.filename);
-	const thumbnailUrl = resolveVideoThumbnailUrl(attachmentData, width, height);
+	const thumbnailUrl = isPresignPending ? undefined : resolveVideoThumbnailUrl(attachmentData, width, height);
 
 	const videoRef = useRef<HTMLVideoElement>(null);
 	const [showControl, setShowControl] = useState(true);
-	const shouldRenderVideo = activated && isIntersecting && !isSending;
+	const isVideoActive = activated && isIntersecting && !isUploading;
+	const { requestPlay, tryPlay } = usePlayOnActivation(videoRef, isVideoActive);
 
-	useVideoCleanup(videoRef, shouldRenderVideo);
+	useVideoCleanup(videoRef, isVideoActive);
 
 	const handlePlay = useCallback(() => {
-		if (isSending) return;
-		setActivated(true);
-	}, [isSending]);
-
-	const handleOnCanPlay = useCallback((e: React.SyntheticEvent<HTMLVideoElement, Event>) => {
-		if (e.currentTarget.offsetWidth < MIN_WIDTH_VIDEO_SHOW) {
-			setShowControl(false);
+		if (isUploading) return;
+		requestPlay();
+		const video = videoRef.current;
+		if (video) {
+			video.preload = 'auto';
+			void video.play().catch(() => undefined);
 		}
-	}, []);
+		setActivated(true);
+	}, [isUploading, requestPlay]);
+
+	const handleOnCanPlay = useCallback(
+		(e: React.SyntheticEvent<HTMLVideoElement, Event>) => {
+			tryPlay();
+			if (e.currentTarget.offsetWidth < MIN_WIDTH_VIDEO_SHOW) {
+				setShowControl(false);
+			}
+		},
+		[tryPlay]
+	);
 
 	const handleShowFullVideo = useCallback(() => {
 		if (videoRef.current) {
@@ -603,38 +681,41 @@ function DefaultVideo({ attachmentData, isMobile = false, isPreview = false, isS
 	useResizeObserver(videoRef, handleResize);
 
 	useEffect(() => {
-		if (!showControl && videoRef.current && !videoRef.current.paused) {
+		if (!showControl && !activated && videoRef.current && !videoRef.current.paused) {
 			videoRef.current.pause();
 		}
-	}, [showControl]);
+	}, [showControl, activated]);
 
-	const showMedia = isSending || isIntersecting;
+	const showMedia = isUploading || isIntersecting;
 
 	return (
 		<div ref={containerRef} className="relative overflow-hidden group rounded-lg max-w-full">
 			{!showMedia && <VideoSkeleton style={mediaStyle} />}
 
 			{showMedia && !activated && (
-				<VideoPoster thumbnailUrl={thumbnailUrl} style={mediaStyle} onPlay={handlePlay} disablePlay={isSending} isSending={isSending} />
+				<VideoPoster thumbnailUrl={thumbnailUrl} style={mediaStyle} onPlay={handlePlay} disablePlay={isUploading} isSending={isUploading} />
 			)}
 
-			{shouldRenderVideo && (
+			{showMedia && (
 				<>
 					<video
-						controls={showControl}
+						controls={activated && showControl}
 						autoPlay={false}
-						style={mediaStyle}
+						style={{
+							...mediaStyle,
+							...(activated ? {} : { position: 'absolute', width: 0, height: 0, opacity: 0, pointerEvents: 'none' })
+						}}
 						ref={videoRef}
-						onCanPlay={handleOnCanPlay}
+						onCanPlay={activated ? handleOnCanPlay : undefined}
 						className="object-contain"
-						preload="metadata"
+						preload={activated ? 'auto' : 'none'}
 						playsInline
 					>
 						<source src={attachmentData.url} />
 						{t('video.error.browserNotSupported')}
 					</video>
 
-					{!showControl && (
+					{activated && !showControl && (
 						<div
 							className="cursor-pointer absolute inset-0 flex items-center justify-center z-20 bg-black bg-opacity-30 group"
 							onClick={handleShowFullVideo}
@@ -643,15 +724,17 @@ function DefaultVideo({ attachmentData, isMobile = false, isPreview = false, isS
 						</div>
 					)}
 
-					<div
-						className="group-hover:flex hidden top-2 right-1 cursor-pointer absolute bg-bgSurface rounded-md w-6 h-6  items-center justify-center z-30"
-						onClick={handleDownloadVideo}
-					>
-						<Icons.Download
-							defaultSize="!w-4 !h-4 "
-							defaultFill="dark:text-[#AEAEAE] text-[#535353] dark:hover:text-white hover:text-black"
-						/>
-					</div>
+					{activated && (
+						<div
+							className="group-hover:flex hidden top-2 right-1 cursor-pointer absolute bg-bgSurface rounded-md w-6 h-6  items-center justify-center z-30"
+							onClick={handleDownloadVideo}
+						>
+							<Icons.Download
+								defaultSize="!w-4 !h-4 "
+								defaultFill="dark:text-[#AEAEAE] text-[#535353] dark:hover:text-white hover:text-black"
+							/>
+						</div>
+					)}
 				</>
 			)}
 		</div>

--- a/libs/components/src/lib/components/MessageWithUser/OgpEmbed.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/OgpEmbed.tsx
@@ -2,6 +2,7 @@ import { getStore, selectCurrentChannel, selectCurrentDM, selectCurrentUserId, s
 import { useMezon } from '@mezon/transport';
 import { Icons } from '@mezon/ui';
 import type { IMessageSendPayload } from '@mezon/utils';
+import { getMessageCreateTimeSeconds, withCreateTimeSecondsInUpdateContent } from '@mezon/utils';
 import { ChannelStreamMode, ChannelType } from 'mezon-js';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -97,11 +98,14 @@ const DeleteOgpButton = ({ messageId }: { messageId?: string }) => {
 							? ChannelStreamMode.STREAM_MODE_GROUP
 							: ChannelStreamMode.STREAM_MODE_CHANNEL;
 
-			const trimContent: IMessageSendPayload = {
+			let trimContent: IMessageSendPayload = {
 				...(message.content as IMessageSendPayload),
 				t: message.content?.t?.trim(),
 				mk: message.content?.mk?.slice(0, -1)
 			};
+			if (message.attachments?.length) {
+				trimContent = withCreateTimeSecondsInUpdateContent(trimContent, getMessageCreateTimeSeconds(message));
+			}
 
 			await client.updateChatMessage(
 				session,
@@ -112,7 +116,7 @@ const DeleteOgpButton = ({ messageId }: { messageId?: string }) => {
 				messageId,
 				trimContent,
 				message.mentions,
-				message.attachments,
+				undefined,
 				message.hide_editted,
 				message.topic_id || '0',
 				false

--- a/libs/components/src/lib/components/MessageWithUser/Photo.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/Photo.tsx
@@ -51,6 +51,7 @@ export type OwnProps<T> = {
 	isInSearchMessage?: boolean;
 	isSending?: boolean;
 	isPresignPending?: boolean;
+	loadWhenUnpending?: boolean;
 	isMobile?: boolean;
 };
 const Photo = <T,>({
@@ -80,6 +81,7 @@ const Photo = <T,>({
 	isInSearchMessage,
 	isSending,
 	isPresignPending = false,
+	loadWhenUnpending = false,
 	isMobile
 }: OwnProps<T>) => {
 	const ref = useRef<HTMLDivElement>(null);
@@ -88,7 +90,8 @@ const Photo = <T,>({
 
 	const isRecentlySent = !!(photo?.url && photo.url === lastSentUrl);
 	const isUploading = isSending || isPresignPending;
-	const shouldLoad = canAutoLoad && !isPresignPending && (isSending || isIntersecting || isRecentlySent);
+	const shouldLoad =
+		canAutoLoad && !isPresignPending && (isSending || isIntersecting || isRecentlySent || loadWhenUnpending);
 
 	if (isSending && photo?.url) {
 		lastSentUrl = photo.url;

--- a/libs/components/src/lib/components/MessageWithUser/Photo.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/Photo.tsx
@@ -14,6 +14,15 @@ import { AttachmentSendingIndicator } from './AttachmentSendingIndicator';
 
 let lastSentUrl: string | null = null;
 
+function ImageAttachmentSkeleton({ width, height }: { width: number; height: number }) {
+	return (
+		<div
+			style={{ width, height }}
+			className="max-w-full max-h-full absolute bottom-0 left-0 z-[1] rounded-md bg-bgLightSecondary dark:bg-bgSecondary"
+		/>
+	);
+}
+
 export type OwnProps<T> = {
 	id?: string;
 	photo: ApiPhoto | ApiMediaExtendedPreview;
@@ -41,6 +50,7 @@ export type OwnProps<T> = {
 	onCancelUpload?: (arg: T) => void;
 	isInSearchMessage?: boolean;
 	isSending?: boolean;
+	isPresignPending?: boolean;
 	isMobile?: boolean;
 };
 const Photo = <T,>({
@@ -69,6 +79,7 @@ const Photo = <T,>({
 	onContextMenu,
 	isInSearchMessage,
 	isSending,
+	isPresignPending = false,
 	isMobile
 }: OwnProps<T>) => {
 	const ref = useRef<HTMLDivElement>(null);
@@ -76,7 +87,8 @@ const Photo = <T,>({
 	const isIntersecting = useIsIntersecting(ref, observeIntersection);
 
 	const isRecentlySent = !!(photo?.url && photo.url === lastSentUrl);
-	const shouldLoad = canAutoLoad && (isSending || isIntersecting || isRecentlySent);
+	const isUploading = isSending || isPresignPending;
+	const shouldLoad = canAutoLoad && !isPresignPending && (isSending || isIntersecting || isRecentlySent);
 
 	if (isSending && photo?.url) {
 		lastSentUrl = photo.url;
@@ -114,11 +126,12 @@ const Photo = <T,>({
 		return 'fill';
 	})();
 
-	const shouldRenderSkeleton = !shouldLoad && !isSending;
+	const shouldRenderSkeleton = !shouldLoad && !isUploading;
+	const isNonInteractive = nonInteractive || isPresignPending;
 
 	const componentClassName = buildClassName(
 		'media-inner',
-		!nonInteractive && 'interactive',
+		!isNonInteractive && 'interactive',
 		isSmall && 'small-image',
 		(width === height || size === 'pictogram') && 'square-image',
 		height < MIN_MEDIA_HEIGHT && 'fix-min-height',
@@ -145,6 +158,11 @@ const Photo = <T,>({
 		return photo?.url?.endsWith('.gif') || photo?.url?.includes('.gif');
 	}, [photo?.url]);
 
+	const thumbnailDataUri = photo.thumbnail?.dataUri;
+	const hasThumbnail = !!thumbnailDataUri;
+	const showPresignSkeleton = isPresignPending && !hasThumbnail;
+	const canOpenViewer = !isPresignPending;
+
 	return (
 		<div
 			id={id}
@@ -152,6 +170,7 @@ const Photo = <T,>({
 			className={`relative max-w-full ${componentClassName}`}
 			style={style}
 			onClick={() => {
+				if (!canOpenViewer) return;
 				if ((photo as ApiPhoto & { filetype?: string })?.filetype === EMimeTypes.sticker) return;
 				onClick?.(photo?.url, id);
 			}}
@@ -169,8 +188,17 @@ const Photo = <T,>({
 					isInSearchMessage={isInSearchMessage}
 				/>
 			)}
+			{isPresignPending && hasThumbnail && (
+				<img
+					src={thumbnailDataUri}
+					alt=""
+					className="max-w-full max-h-full w-full h-full block object-cover absolute bottom-0 left-0 z-[1] rounded overflow-hidden"
+					style={{ width: displayWidth, height: displayHeight }}
+				/>
+			)}
+			{showPresignSkeleton && <ImageAttachmentSkeleton width={displayWidth} height={displayHeight} />}
 			{isSending && <AttachmentSendingIndicator />}
-			{!isSending && shouldRenderSkeleton && (
+			{!isUploading && shouldRenderSkeleton && (
 				<div
 					style={{ width: displayWidth, height: displayHeight }}
 					className="max-w-full max-h-full absolute bottom-0 left-0 rounded-md bg-[#0000001c] animate-pulse"

--- a/libs/components/src/lib/components/MessageWithUser/TimelineAttachment.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/TimelineAttachment.tsx
@@ -5,8 +5,11 @@ import {
 	EMimeTypes,
 	ETypeLinkMedia,
 	createImgproxyUrl,
+	filterExpiredPresignAttachments,
 	generateAttachmentId,
 	getAttachmentDataForWindow,
+	getMessageCreateTimeSeconds,
+	isAttachmentPresignPendingForMessage,
 	isMediaTypeNotSupported
 } from '@mezon/utils';
 import isElectron from 'is-electron';
@@ -59,9 +62,15 @@ const classifyAttachments = (attachments: ApiMessageAttachment[]) => {
 
 const TimelineAttachment = memo(({ message, maxThumbnails = 3, mode }: TimelineAttachmentProps) => {
 	const dispatch = useAppDispatch();
-	const validateAttachment = useMemo(
-		() => (message.attachments || [])?.filter((attachment) => Object.keys(attachment).length !== 0),
-		[message.attachments]
+	const messageCreateTimeSeconds = useMemo(() => getMessageCreateTimeSeconds(message), [message]);
+	const validateAttachment = useMemo(() => {
+		const rawAttachments = (message.attachments || []).filter((attachment) => Object.keys(attachment).length !== 0);
+		return filterExpiredPresignAttachments(rawAttachments, message.content, messageCreateTimeSeconds);
+	}, [message.attachments, message.content, messageCreateTimeSeconds]);
+
+	const isPresignPendingForUrl = useCallback(
+		(url?: string) => isAttachmentPresignPendingForMessage(url, message),
+		[message]
 	);
 
 	const { images, videos, audio } = useMemo(() => classifyAttachments(validateAttachment), [validateAttachment]);
@@ -73,6 +82,8 @@ const TimelineAttachment = memo(({ message, maxThumbnails = 3, mode }: TimelineA
 
 	const handleClick = useCallback(
 		async (attachmentData: ApiMessageAttachment) => {
+			if (isPresignPendingForUrl(attachmentData.url)) return;
+
 			const state = getStore()?.getState();
 			const currentClanId = selectCurrentClanId(state);
 			const currentDm = selectCurrentDM(state);
@@ -226,7 +237,7 @@ const TimelineAttachment = memo(({ message, maxThumbnails = 3, mode }: TimelineA
 
 			dispatch(attachmentActions.setMessageId(message.id));
 		},
-		[message, mode, dispatch]
+		[message, mode, dispatch, isPresignPendingForUrl]
 	);
 
 	if (mediaItems.length === 0 && audio.length === 0) return null;
@@ -240,37 +251,42 @@ const TimelineAttachment = memo(({ message, maxThumbnails = 3, mode }: TimelineA
 							item.filetype?.startsWith(ETypeLinkMedia.VIDEO_PREFIX) ||
 							item.filetype?.includes(EMimeTypes.mp4) ||
 							item.filetype?.includes(EMimeTypes.mov);
+						const isPresignPending = isPresignPendingForUrl(item.url);
 
-						const thumbnailUrl = isVideo
-							? item.thumbnail
-								? createImgproxyUrl(item.thumbnail, {
-										width: 120,
-										height: 120,
-										resizeType: 'fill'
-									})
-								: item.url
-									? createImgproxyUrl(item.url, {
+						const thumbnailUrl = isPresignPending
+							? undefined
+							: isVideo
+								? item.thumbnail
+									? createImgproxyUrl(item.thumbnail, {
 											width: 120,
 											height: 120,
 											resizeType: 'fill'
 										})
-									: undefined
-							: createImgproxyUrl(item.url || '', {
-									width: 120,
-									height: 120,
-									resizeType: 'fill'
-								});
+									: item.url
+										? createImgproxyUrl(item.url, {
+												width: 120,
+												height: 120,
+												resizeType: 'fill'
+											})
+										: undefined
+								: createImgproxyUrl(item.url || '', {
+										width: 120,
+										height: 120,
+										resizeType: 'fill'
+									});
 
 						return (
 							<div
 								key={`${item.url}-${index}`}
-								className="relative w-[50px] h-[50px] rounded-lg overflow-hidden cursor-pointer hover:opacity-90 transition-opacity"
+								className={`relative w-[50px] h-[50px] rounded-lg overflow-hidden transition-opacity ${
+									isPresignPending ? 'cursor-default' : 'cursor-pointer hover:opacity-90'
+								}`}
 								onClick={() => handleClick(item)}
 							>
 								{thumbnailUrl ? (
 									<img src={thumbnailUrl} alt="" className="w-full h-full object-cover" />
-								) : isVideo && item.url ? (
-									<video src={item.url} className="w-full h-full object-cover" muted playsInline />
+								) : isVideo && item.url && !isPresignPending ? (
+									<video src={item.url} className="w-full h-full object-cover" muted playsInline preload="none" />
 								) : (
 									<div className="w-full h-full bg-bgLightSecondary dark:bg-bgSecondary" />
 								)}
@@ -291,7 +307,10 @@ const TimelineAttachment = memo(({ message, maxThumbnails = 3, mode }: TimelineA
 					})}
 				</div>
 			)}
-			{audio.length > 0 && audio.map((audioItem, index) => <MessageAudio key={`${index}_${audioItem.url}`} audioUrl={audioItem.url || ''} />)}
+			{audio.length > 0 &&
+				audio
+					.filter((audioItem) => !isPresignPendingForUrl(audioItem.url))
+					.map((audioItem, index) => <MessageAudio key={`${index}_${audioItem.url}`} audioUrl={audioItem.url || ''} />)}
 		</div>
 	);
 });

--- a/libs/components/src/lib/components/MessageWithUser/index.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/index.tsx
@@ -401,6 +401,7 @@ function MessageWithUser({
 								observeIntersectionForLoading={observeIntersectionForLoading}
 								mode={mode}
 								message={message}
+								channelId={channelId || message.channel_id}
 								onContextMenu={onContextMenu}
 								isInSearchMessage={isSearchMessage}
 								defaultMaxWidth={isTopic ? TOPIC_MAX_WIDTH : undefined}

--- a/libs/core/src/lib/chat/hooks/useChatSending.ts
+++ b/libs/core/src/lib/chat/hooks/useChatSending.ts
@@ -6,6 +6,7 @@ import {
 	selectCurrentTopicId,
 	selectInitTopicMessageId,
 	selectMemberClanByUserId,
+	selectMessageByMessageId,
 	selectSearchChannelById,
 	selectTopicAnonymousMode,
 	topicsActions,
@@ -14,6 +15,7 @@ import {
 } from '@mezon/store';
 import { useMezon } from '@mezon/transport';
 import type { IMessageSendPayload } from '@mezon/utils';
+import { getMessageCreateTimeSeconds, withCreateTimeSecondsInUpdateContent } from '@mezon/utils';
 import type { ApiChannelDescription, ApiMessageAttachment, ApiMessageMention, ApiMessageRef, ApiSdTopic, ApiSdTopicRequest } from 'mezon-js';
 import { ChannelStreamMode } from 'mezon-js';
 import React, { useCallback, useMemo, useRef } from 'react';
@@ -261,12 +263,22 @@ export function useChatSending({ mode, channelOrDirect, fromTopic = false }: Use
 			if (!client || !session || !channelOrDirect) {
 				throw new Error('Client is not initialized');
 			}
-			const trimContent: IMessageSendPayload = {
+			const existingMessage = selectMessageByMessageId(getStore().getState(), channelIdOrDirectId ?? '', messageId);
+			const isAttachmentFieldUpdate = attachments !== undefined;
+			const hasExistingAttachments = (existingMessage?.attachments?.length ?? 0) > 0;
+			const messageCreateTimeSeconds = getMessageCreateTimeSeconds(existingMessage ?? {});
+
+			let trimContent: IMessageSendPayload = {
 				...content,
 				t: content.t?.trim()
 			};
+			if (hasExistingAttachments && !isAttachmentFieldUpdate) {
+				trimContent = withCreateTimeSecondsInUpdateContent(trimContent, messageCreateTimeSeconds);
+			}
+
 			const finalTopicId = topic_id || (isTopic ? currentTopicId || '0' : '0');
 			const updateChannelId = finalTopicId !== '0' ? finalTopicId : (channelIdOrDirectId ?? '0');
+			const updateAttachments = isAttachmentFieldUpdate ? attachments : undefined;
 			try {
 				await client.updateChannelMessage(
 					session,
@@ -277,7 +289,7 @@ export function useChatSending({ mode, channelOrDirect, fromTopic = false }: Use
 					messageId || '0',
 					JSON.stringify(trimContent),
 					mentions,
-					attachments,
+					updateAttachments,
 					hide_editted,
 					finalTopicId,
 					!!isTopic

--- a/libs/core/src/lib/chat/hooks/useEditMessage.ts
+++ b/libs/core/src/lib/chat/hooks/useEditMessage.ts
@@ -73,11 +73,11 @@ export const useEditMessage = (channelId: string, channelLabel: string, mode: nu
 
 	const handleSend = useCallback(
 		(editMessage: IMessageSendPayload, messageId: string, draftMention: ApiMessageMention[], topic_id: string, isTopic?: boolean) => {
-			editSendMessage(editMessage, messageId, draftMention, attachmentsOnMessage, false, topic_id, isTopic);
+			editSendMessage(editMessage, messageId, draftMention, undefined, false, topic_id, isTopic);
 			setChannelDraftMessage(channelId, messageId, editMessage, draftMention, attachmentsOnMessage ?? [], topic_id as string);
 			dispatch(referencesActions.setOpenEditMessageState(false));
 		},
-		[editSendMessage, attachmentsOnMessage, setChannelDraftMessage, channelId, dispatch, oldMentionsString]
+		[editSendMessage, setChannelDraftMessage, channelId, dispatch, oldMentionsString]
 	);
 
 	return {

--- a/libs/store/src/lib/messages/messages.slice.ts
+++ b/libs/store/src/lib/messages/messages.slice.ts
@@ -20,6 +20,7 @@ import {
 	getMobileUploadedAttachments,
 	getPublicKeys,
 	getWebUploadedAttachments,
+	mergePresignFinishContent,
 	isFacebookLink,
 	isTikTokLink,
 	isYouTubeLink,
@@ -1854,8 +1855,10 @@ export const messagesSlice = createSlice({
 				case TypeMessage.ChatUpdate:
 				case TypeMessage.UpdateEphemeralMsg: {
 					const updateTimeSeconds = action.payload.update_time_seconds;
+					const existingMessage = channelEntity?.entities?.[messageId];
+					const mergedContent = mergePresignFinishContent(existingMessage?.content, action.payload.content);
 					const changes: Partial<MessagesEntity> = {
-						content: action.payload.content,
+						content: mergedContent as MessagesEntity['content'],
 						mentions: action.payload.mentions,
 						hide_editted: action.payload.hide_editted,
 						update_time_seconds: updateTimeSeconds,

--- a/libs/store/src/lib/messages/messages.slice.ts
+++ b/libs/store/src/lib/messages/messages.slice.ts
@@ -17,10 +17,12 @@ import {
 	LIMIT_MESSAGE,
 	MessageCrypt,
 	TypeMessage,
+	getMessageCreateTimeSeconds,
 	getMobileUploadedAttachments,
 	getPublicKeys,
 	getWebUploadedAttachments,
 	mergePresignFinishContent,
+	withCreateTimeSecondsInUpdateContent,
 	isFacebookLink,
 	isTikTokLink,
 	isYouTubeLink,
@@ -1095,9 +1097,21 @@ export const editMessageViaApi = createAsyncThunk('messages/editMessageViaApi', 
 			...content,
 			t: content.t?.trim()
 		};
-		const stringifiedContent = JSON.stringify(trimContent);
+		const state = thunkAPI.getState() as RootState;
+		const existingMessage = selectMessageByMessageId(state, channelId, messageId);
+		const isAttachmentFieldUpdate = attachments !== undefined;
+		const hasExistingAttachments = (existingMessage?.attachments?.length ?? 0) > 0;
+		const messageCreateTimeSeconds = getMessageCreateTimeSeconds(existingMessage ?? {});
+
+		let contentForUpdate = trimContent;
+		if (hasExistingAttachments && !isAttachmentFieldUpdate) {
+			contentForUpdate = withCreateTimeSecondsInUpdateContent(trimContent, messageCreateTimeSeconds);
+		}
+
+		const stringifiedContent = JSON.stringify(contentForUpdate);
 		const finalTopicId = topicId || '0';
 		const updateChannelId = finalTopicId !== '0' ? finalTopicId : channelId || '0';
+		const updateAttachments = isAttachmentFieldUpdate ? attachments : undefined;
 
 		const res = await client.updateChannelMessage(
 			session,
@@ -1108,7 +1122,7 @@ export const editMessageViaApi = createAsyncThunk('messages/editMessageViaApi', 
 			messageId || '0',
 			stringifiedContent,
 			mentions,
-			attachments,
+			updateAttachments,
 			hideEditted,
 			finalTopicId,
 			!!isTopic
@@ -1851,7 +1865,7 @@ export const messagesSlice = createSlice({
 						update_time_seconds: updateTimeSeconds,
 						update_time: action.payload.update_time || (updateTimeSeconds ? new Date(updateTimeSeconds * 1000).toISOString() : undefined)
 					};
-					if (action.payload.attachments?.length !== channelEntity?.entities?.[messageId]?.attachments?.length) {
+					if (action.payload.attachments?.length) {
 						changes.attachments = action.payload.attachments;
 					}
 					channelMessagesAdapter.updateOne(channelEntity, {

--- a/libs/utils/src/lib/types/index.ts
+++ b/libs/utils/src/lib/types/index.ts
@@ -474,6 +474,7 @@ export interface IMessageSendPayload {
 	id?: number;
 	expire_at?: number;
 	type?: EPollType;
+	presign_finish?: string[];
 }
 
 export type IUser = {

--- a/libs/utils/src/lib/types/index.ts
+++ b/libs/utils/src/lib/types/index.ts
@@ -475,6 +475,7 @@ export interface IMessageSendPayload {
 	expire_at?: number;
 	type?: EPollType;
 	presign_finish?: string[];
+	create_time_seconds?: number;
 }
 
 export type IUser = {

--- a/libs/utils/src/lib/utils/index.ts
+++ b/libs/utils/src/lib/utils/index.ts
@@ -82,6 +82,7 @@ export * from './mediaDimensions';
 export * from './mergeRefs';
 export * from './sanitizeHtml';
 export * from './parseHtmlAsFormattedText';
+export * from './presignFinish';
 export * from './processEntitiesDirectly';
 export * from './resetScroll';
 export * from './schedulers';

--- a/libs/utils/src/lib/utils/presignFinish.ts
+++ b/libs/utils/src/lib/utils/presignFinish.ts
@@ -78,3 +78,56 @@ export function hasActivePresignPendingAttachments(
 
 	return attachments.some((attachment) => isPresignAttachmentPending(attachment.url, presignFinishKeys));
 }
+
+export function getPresignExpiryDelayMs(messageCreateTimeSeconds?: number, nowMs = Date.now()): number | null {
+	if (!messageCreateTimeSeconds) return null;
+
+	const expiresAtMs = (messageCreateTimeSeconds + PRESIGN_PENDING_MAX_AGE_SEC) * 1000;
+	const delay = expiresAtMs - nowMs;
+	return delay <= 0 ? 0 : delay;
+}
+
+export function getMessageCreateTimeSeconds(message: {
+	create_time_seconds?: number | string;
+	create_time?: string;
+	update_time_seconds?: number | string;
+}): number | undefined {
+	if (message.create_time_seconds !== undefined && message.create_time_seconds !== null) {
+		const seconds = Number(message.create_time_seconds);
+		if (Number.isFinite(seconds) && seconds > 0) return seconds;
+	}
+
+	if (message.create_time) {
+		const parsed = new Date(message.create_time).getTime();
+		if (!isNaN(parsed)) return Math.floor(parsed / 1000);
+	}
+
+	if (message.update_time_seconds !== undefined && message.update_time_seconds !== null) {
+		const seconds = Number(message.update_time_seconds);
+		if (Number.isFinite(seconds) && seconds > 0) return seconds;
+	}
+
+	return undefined;
+}
+
+export function isAttachmentPresignPendingForMessage(
+	url: string | undefined,
+	message: { content?: unknown } | null | undefined
+): boolean {
+	if (!message) return false;
+	return isPresignAttachmentPending(url, parsePresignFinishKeys(message.content));
+}
+
+export function shouldHidePresignAttachment(
+	url: string | undefined,
+	message: {
+		content?: unknown;
+		create_time_seconds?: number | string;
+		create_time?: string;
+		update_time_seconds?: number | string;
+	} | null | undefined,
+	nowSeconds = Math.floor(Date.now() / 1000)
+): boolean {
+	if (!message) return false;
+	return isExpiredPresignAttachment(url, parsePresignFinishKeys(message.content), getMessageCreateTimeSeconds(message), nowSeconds);
+}

--- a/libs/utils/src/lib/utils/presignFinish.ts
+++ b/libs/utils/src/lib/utils/presignFinish.ts
@@ -1,0 +1,80 @@
+import type { ApiMessageAttachment } from 'mezon-js';
+import { safeJSONParse } from 'mezon-js';
+import { FOR_10_MINUTES_SEC } from '../constant';
+import { isMezonCdnUrl } from './urlSanitization';
+
+export const PRESIGN_PENDING_MAX_AGE_SEC = FOR_10_MINUTES_SEC;
+
+export function getPresignKeyFromAttachmentUrl(url?: string): string | undefined {
+	if (!url || url.startsWith('blob:')) return undefined;
+
+	try {
+		const pathname = new URL(url).pathname;
+		const segment = pathname.split('/').filter(Boolean).pop();
+		if (!segment) return undefined;
+		return segment.replace(/\.[^/.]+$/, '');
+	} catch {
+		const segment = url.split('?')[0].split('/').filter(Boolean).pop();
+		return segment?.replace(/\.[^/.]+$/, '');
+	}
+}
+
+export function parsePresignFinishKeys(content: unknown): string[] | null {
+	const parsed = typeof content === 'string' ? safeJSONParse(content) : content;
+	if (!parsed || typeof parsed !== 'object') return null;
+	if (!('presign_finish' in parsed)) return null;
+
+	const keys = (parsed as { presign_finish?: unknown }).presign_finish;
+	if (!Array.isArray(keys)) return null;
+
+	return keys.filter((key): key is string => typeof key === 'string');
+}
+
+export function isPresignAttachmentPending(url: string | undefined, presignFinishKeys: string[] | null): boolean {
+	if (presignFinishKeys === null || !url || !isMezonCdnUrl(url)) return false;
+
+	const presignKey = getPresignKeyFromAttachmentUrl(url);
+	if (!presignKey) return false;
+
+	return !presignFinishKeys.includes(presignKey);
+}
+
+export function getPresignFinishFingerprint(content: unknown): string {
+	const keys = parsePresignFinishKeys(content);
+	return keys ? keys.join('\u0001') : '';
+}
+
+export function isExpiredPresignAttachment(
+	url: string | undefined,
+	presignFinishKeys: string[] | null,
+	messageCreateTimeSeconds?: number,
+	nowSeconds = Math.floor(Date.now() / 1000)
+): boolean {
+	if (!messageCreateTimeSeconds || presignFinishKeys === null) return false;
+	if (!isPresignAttachmentPending(url, presignFinishKeys)) return false;
+	return nowSeconds - messageCreateTimeSeconds >= PRESIGN_PENDING_MAX_AGE_SEC;
+}
+
+export function filterExpiredPresignAttachments(
+	attachments: ApiMessageAttachment[],
+	content: unknown,
+	messageCreateTimeSeconds?: number,
+	nowSeconds = Math.floor(Date.now() / 1000)
+): ApiMessageAttachment[] {
+	const presignFinishKeys = parsePresignFinishKeys(content);
+	if (presignFinishKeys === null || !messageCreateTimeSeconds) return attachments;
+
+	return attachments.filter(
+		(attachment) => !isExpiredPresignAttachment(attachment.url, presignFinishKeys, messageCreateTimeSeconds, nowSeconds)
+	);
+}
+
+export function hasActivePresignPendingAttachments(
+	attachments: ApiMessageAttachment[] | undefined,
+	content: unknown
+): boolean {
+	const presignFinishKeys = parsePresignFinishKeys(content);
+	if (presignFinishKeys === null || !attachments?.length) return false;
+
+	return attachments.some((attachment) => isPresignAttachmentPending(attachment.url, presignFinishKeys));
+}

--- a/libs/utils/src/lib/utils/presignFinish.ts
+++ b/libs/utils/src/lib/utils/presignFinish.ts
@@ -1,6 +1,7 @@
 import type { ApiMessageAttachment } from 'mezon-js';
 import { safeJSONParse } from 'mezon-js';
 import { FOR_10_MINUTES_SEC } from '../constant';
+import type { IMessageSendPayload } from '../types';
 import { isMezonCdnUrl } from './urlSanitization';
 
 export const PRESIGN_PENDING_MAX_AGE_SEC = FOR_10_MINUTES_SEC;
@@ -138,6 +139,17 @@ export function getPresignExpiryDelayMs(messageCreateTimeSeconds?: number, nowMs
 	const expiresAtMs = (messageCreateTimeSeconds + PRESIGN_PENDING_MAX_AGE_SEC) * 1000;
 	const delay = expiresAtMs - nowMs;
 	return delay <= 0 ? 0 : delay;
+}
+
+export function withCreateTimeSecondsInUpdateContent(
+	content: IMessageSendPayload,
+	messageCreateTimeSeconds: number | undefined
+): IMessageSendPayload {
+	if (!messageCreateTimeSeconds) {
+		return content;
+	}
+
+	return { ...content, create_time_seconds: messageCreateTimeSeconds };
 }
 
 export function getMessageCreateTimeSeconds(message: {

--- a/libs/utils/src/lib/utils/presignFinish.ts
+++ b/libs/utils/src/lib/utils/presignFinish.ts
@@ -5,6 +5,11 @@ import { isMezonCdnUrl } from './urlSanitization';
 
 export const PRESIGN_PENDING_MAX_AGE_SEC = FOR_10_MINUTES_SEC;
 
+export function normalizePresignKey(key: string): string {
+	const segment = key.split('?')[0].split('/').filter(Boolean).pop() || key;
+	return segment.replace(/\.[^/.]+$/, '');
+}
+
 export function getPresignKeyFromAttachmentUrl(url?: string): string | undefined {
 	if (!url || url.startsWith('blob:')) return undefined;
 
@@ -12,10 +17,10 @@ export function getPresignKeyFromAttachmentUrl(url?: string): string | undefined
 		const pathname = new URL(url).pathname;
 		const segment = pathname.split('/').filter(Boolean).pop();
 		if (!segment) return undefined;
-		return segment.replace(/\.[^/.]+$/, '');
+		return normalizePresignKey(segment);
 	} catch {
 		const segment = url.split('?')[0].split('/').filter(Boolean).pop();
-		return segment?.replace(/\.[^/.]+$/, '');
+		return segment ? normalizePresignKey(segment) : undefined;
 	}
 }
 
@@ -27,21 +32,69 @@ export function parsePresignFinishKeys(content: unknown): string[] | null {
 	const keys = (parsed as { presign_finish?: unknown }).presign_finish;
 	if (!Array.isArray(keys)) return null;
 
-	return keys.filter((key): key is string => typeof key === 'string');
+	return keys.filter((key): key is string => typeof key === 'string').map(normalizePresignKey);
 }
 
-export function isPresignAttachmentPending(url: string | undefined, presignFinishKeys: string[] | null): boolean {
+export function countPresignableAttachments(attachments: ApiMessageAttachment[] | undefined): number {
+	if (!attachments?.length) return 0;
+	return attachments.filter((attachment) => isMezonCdnUrl(attachment.url)).length;
+}
+
+export function areAllPresignAttachmentsFinished(
+	attachments: ApiMessageAttachment[] | undefined,
+	presignFinishKeys: string[] | null
+): boolean {
+	if (presignFinishKeys === null) return false;
+	const presignableCount = countPresignableAttachments(attachments);
+	if (presignableCount === 0) return false;
+	return presignFinishKeys.length >= presignableCount;
+}
+
+export function isPresignAttachmentPending(
+	url: string | undefined,
+	presignFinishKeys: string[] | null,
+	attachments?: ApiMessageAttachment[]
+): boolean {
 	if (presignFinishKeys === null || !url || !isMezonCdnUrl(url)) return false;
+	if (attachments && areAllPresignAttachmentsFinished(attachments, presignFinishKeys)) return false;
 
 	const presignKey = getPresignKeyFromAttachmentUrl(url);
 	if (!presignKey) return false;
 
-	return !presignFinishKeys.includes(presignKey);
+	const finishedKeys = new Set(presignFinishKeys);
+	return !finishedKeys.has(presignKey);
 }
 
 export function getPresignFinishFingerprint(content: unknown): string {
 	const keys = parsePresignFinishKeys(content);
 	return keys ? keys.join('\u0001') : '';
+}
+
+export function mergePresignFinishKeys(existingContent: unknown, incomingContent: unknown): string[] | null {
+	const incomingKeys = parsePresignFinishKeys(incomingContent);
+	if (incomingKeys === null) return null;
+
+	const existingKeys = parsePresignFinishKeys(existingContent);
+	return [...new Set([...(existingKeys ?? []), ...incomingKeys])];
+}
+
+export function mergePresignFinishContent(existingContent: unknown, incomingContent: unknown): unknown {
+	const incomingParsed = typeof incomingContent === 'string' ? safeJSONParse(incomingContent) : incomingContent;
+	if (!incomingParsed || typeof incomingParsed !== 'object') {
+		return incomingContent;
+	}
+
+	const mergedKeys = mergePresignFinishKeys(existingContent, incomingParsed);
+	if (mergedKeys === null) {
+		return incomingContent;
+	}
+
+	const merged = {
+		...(incomingParsed as Record<string, unknown>),
+		presign_finish: mergedKeys
+	};
+
+	return typeof incomingContent === 'string' ? JSON.stringify(merged) : merged;
 }
 
 export function isExpiredPresignAttachment(


### PR DESCRIPTION
## Summary

Aligns web attachment display with the Android presign upload flow ([mezon-android#246](https://github.com/mezonai/mezon-android/pull/246)). When a message includes `presign_finish` in `content`, CDN attachments stay in a pending state until their presign key appears in that array, avoiding imgproxy/CDN requests for files that are not uploaded yet.

- Show skeleton (not spinner) for pending images/videos; block image viewer and gallery clicks until upload finishes
- Hide unfinished attachments after 10 minutes
- Legacy messages without `presign_finish` keep existing behavior
- Extend the same guard to chat bubble, gallery, image modal, and timeline paths

## Changes

**`libs/utils/presignFinish.ts`** — parse presign keys, pending/expiry helpers, message timestamp fallback

**Chat bubble** — `Photo`, `Album`, `MessageAttachment`, `MessageVideo`: skeleton when pending, no early CDN/imgproxy, one-shot expiry timer

**Parallel paths** — `GalleryModal`, `MessageModalImage`, `TimelineAttachment`: skeleton/hide pending items, block navigation to unfinished media

## Test plan

- [ ] Receive Android message with `presign_finish: []` and CDN URLs → skeleton in chat, no broken imgproxy image
- [ ] After `ChatUpdate` adds keys to `presign_finish` → attachments render normally
- [ ] Pending attachment older than 10 minutes → hidden from message
- [ ] Click pending skeleton → viewer does not open
- [ ] Open gallery / image modal / timeline for pending message → skeleton, no early CDN load
- [ ] Legacy message without `presign_finish` → unchanged display