### PR TITLE
fix(chat): pass createTimeSeconds to updateChatMessage callsites

### DIFF
--- a/libs/components/src/lib/components/MessageWithUser/MessageModalImage/index.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/MessageModalImage/index.tsx
@@ -1,4 +1,5 @@
 import { useAppParams, useAttachments } from '@mezon/core';
+import type { AttachmentEntity } from '@mezon/store';
 import {
 	attachmentActions,
 	getStore,
@@ -90,7 +91,7 @@ const MessageModalImage = () => {
 	const isMainPresignPending = isAttachmentPresignPendingForMessage(urlImg ?? currentAttachment?.url, sourceMessage);
 
 	const getSourceMessageForAttachment = useCallback(
-		(att: (typeof attachments)[number] | undefined) => {
+		(att: AttachmentEntity | undefined) => {
 			if (!att?.message_id || !channelIdForAttachments) return undefined;
 			return selectMessageByMessageId(getStore()?.getState(), channelIdForAttachments, att.message_id);
 		},
@@ -98,7 +99,7 @@ const MessageModalImage = () => {
 	);
 
 	const isAttPresignPending = useCallback(
-		(att: (typeof attachments)[number] | undefined) =>
+		(att: AttachmentEntity | undefined) =>
 			isAttachmentPresignPendingForMessage(att?.url, getSourceMessageForAttachment(att)),
 		[getSourceMessageForAttachment]
 	);

--- a/libs/components/src/lib/components/MessageWithUser/OgpEmbed.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/OgpEmbed.tsx
@@ -117,6 +117,7 @@ const DeleteOgpButton = ({ messageId }: { messageId?: string }) => {
 				trimContent,
 				message.mentions,
 				undefined,
+				getMessageCreateTimeSeconds(message),
 				message.hide_editted,
 				message.topic_id || '0',
 				false

--- a/libs/store/src/lib/dmcall/dmcall.slice.ts
+++ b/libs/store/src/lib/dmcall/dmcall.slice.ts
@@ -1,8 +1,10 @@
 import type { IDMCall, IMessageSendPayload, IOtherCall, LoadingStatus } from '@mezon/utils';
+import { getMessageCreateTimeSeconds } from '@mezon/utils';
 import type { EntityState, PayloadAction } from '@reduxjs/toolkit';
 import { createAsyncThunk, createEntityAdapter, createSelector, createSlice } from '@reduxjs/toolkit';
 import type { WebrtcSignalingFwd } from 'mezon-js';
 import { ensureSession, getMezonCtx } from '../helpers';
+import { selectMessageByMessageId } from '../messages/messages.slice';
 import type { RootState } from '../store';
 
 export const DMCALL_FEATURE_KEY = 'dmcall';
@@ -40,7 +42,20 @@ export const updateCallLog = createAsyncThunk(
 			const state = thunkAPI.getState() as RootState;
 			const messageId = selectCallMessageId(state);
 			if (messageId) {
-				mezon.clientRef.current?.updateChatMessage(mezon.session, '0', channelId ?? '', 4, false, messageId, content, [], [], true);
+				const callMessage = selectMessageByMessageId(state, channelId ?? '', messageId);
+				mezon.clientRef.current?.updateChatMessage(
+					mezon.session,
+					'0',
+					channelId ?? '',
+					4,
+					false,
+					messageId,
+					content,
+					[],
+					[],
+					getMessageCreateTimeSeconds(callMessage ?? {}),
+					true
+				);
 			}
 		} catch (error) {
 			return thunkAPI.rejectWithValue(error);

--- a/libs/store/src/lib/messages/messages.slice.ts
+++ b/libs/store/src/lib/messages/messages.slice.ts
@@ -1123,6 +1123,7 @@ export const editMessageViaApi = createAsyncThunk('messages/editMessageViaApi', 
 			stringifiedContent,
 			mentions,
 			updateAttachments,
+			messageCreateTimeSeconds,
 			hideEditted,
 			finalTopicId,
 			!!isTopic


### PR DESCRIPTION
Align remaining edit-message paths with mezon-js 2.15.61 API and fix AttachmentEntity typing in MessageModalImage.