### PR TITLE
260612 - WEB/DESKTOP - remove fake message after fail

### DIFF
--- a/libs/store/src/lib/messages/messages.slice.ts
+++ b/libs/store/src/lib/messages/messages.slice.ts
@@ -1401,14 +1401,13 @@ export const sendMessage = createAsyncThunk('messages/sendMessage', async (paylo
 				);
 			}
 		} catch (error) {
-			if (error instanceof Error && error.name === 'SocketTimeoutError') {
+			if (error instanceof Error && (error.name === 'SocketTimeoutError' || error.name === 'SendTimeoutError')) {
 				thunkAPI.dispatch(
 					messagesActions.remove({
 						messageId: fakeMessage.id,
 						channelId: fakeMessage.channel_id
 					})
 				);
-				return;
 			}
 			const payload = originalSendPayload;
 			if (sendTimeoutMap.has(tempId)) {

--- a/libs/store/src/lib/messages/messages.slice.ts
+++ b/libs/store/src/lib/messages/messages.slice.ts
@@ -21,13 +21,13 @@ import {
 	getMobileUploadedAttachments,
 	getPublicKeys,
 	getWebUploadedAttachments,
-	mergePresignFinishContent,
-	withCreateTimeSecondsInUpdateContent,
 	isFacebookLink,
 	isTikTokLink,
 	isYouTubeLink,
+	mergePresignFinishContent,
 	revokePreSendAttachmentUrls,
-	toPublicMessageAttachments
+	toPublicMessageAttachments,
+	withCreateTimeSecondsInUpdateContent
 } from '@mezon/utils';
 import type { EntityState, GetThunkAPI, PayloadAction, Update } from '@reduxjs/toolkit';
 import { createAsyncThunk, createEntityAdapter, createSelector, createSelectorCreator, createSlice, weakMapMemoize } from '@reduxjs/toolkit';
@@ -1402,6 +1402,12 @@ export const sendMessage = createAsyncThunk('messages/sendMessage', async (paylo
 			}
 		} catch (error) {
 			if (error instanceof Error && error.name === 'SocketTimeoutError') {
+				thunkAPI.dispatch(
+					messagesActions.remove({
+						messageId: fakeMessage.id,
+						channelId: fakeMessage.channel_id
+					})
+				);
 				return;
 			}
 			const payload = originalSendPayload;


### PR DESCRIPTION
### Changes

- Remove message when end error catch 

### Ticket 

- [Desktop/Website] Send message in weak connection sorts incorrectly
https://github.com/mezonai/mezon/issues/13287

### Test 
- Send fail message when off connection 
- Send normal 
- Send fail then connect success send normal 
