### PR TITLE
fix(webdesk): restore macOS custom window controls in electron renderer

### DIFF
--- a/apps/chat/src/app/layouts/AppLayout.tsx
+++ b/apps/chat/src/app/layouts/AppLayout.tsx
@@ -1,12 +1,89 @@
 import { ToastController } from '@mezon/components';
 import { useCustomNavigate, useMezonNavigateEvent } from '@mezon/core';
 import { selectIsLogin } from '@mezon/store';
-import { MezonUiProvider } from '@mezon/ui';
+import { Icons, MezonUiProvider } from '@mezon/ui';
+import {
+	CLOSE_APP,
+	IMAGE_WINDOW_TITLE_BAR_ACTION,
+	MAXIMIZE_WINDOW,
+	MINIMIZE_WINDOW,
+	TITLE_BAR_ACTION,
+	UNMAXIMIZE_WINDOW,
+	isElectron,
+	isLinuxDesktop,
+	isMacDesktop,
+	isWindowsDesktop
+} from '@mezon/utils';
 import React, { useEffect } from 'react';
 import { useSelector } from 'react-redux';
-import { Outlet, useLoaderData } from 'react-router-dom';
+import { Outlet, useLoaderData, useLocation } from 'react-router-dom';
 import { useNotificationDisconnect } from '../hooks/useNotificationManagement';
 import type { IAppLoaderData } from '../loaders/appLoader';
+import { MacOSWindowControls } from './MacWindowsControl';
+
+type TitleBarProps = {
+	eventName: string;
+};
+
+const TitleBar: React.FC<TitleBarProps> = ({ eventName }) => {
+	const handleMinimize = () => {
+		window.electron.send(eventName, MINIMIZE_WINDOW);
+	};
+
+	useEffect(() => {
+		document.body.classList.add('overflow-hidden');
+	}, []);
+
+	const handleMaximize = () => {
+		window.dispatchEvent(new Event('resize'));
+		window.electron.send(eventName, MAXIMIZE_WINDOW);
+	};
+
+	const handleClose = () => {
+		window.electron.send(eventName, CLOSE_APP);
+	};
+
+	const handleDoubleClick = () => {
+		window.electron.send(eventName, UNMAXIMIZE_WINDOW);
+	};
+
+	return (
+		<header id="titlebar" className="bg-theme-primary" onDoubleClick={handleDoubleClick}>
+			<div id="drag-region">
+				<div className="text-theme-primary-active ml-3 text-[15.15px] leading-[26.58px] font-semibold ">Mezon</div>
+				<div id="window-controls">
+					<div
+						className="button window-hover cursor-pointer dark:hover:bg-bgModifierHover hover:bg-bgLightModeButton"
+						id="min-button"
+						onClick={handleMinimize}
+					>
+						<div className="w-fit flex flex-col items-center gap-2 text-textPrimaryLight dark:text-[#a8a6a6] group">
+							<Icons.WindowMinimize className="w-[14px]" />
+						</div>
+					</div>
+					<div
+						className="button window-hover cursor-pointer dark:hover:bg-bgModifierHover hover:bg-bgLightModeButton"
+						id="restore-button"
+						onClick={handleMaximize}
+					>
+						<div className="w-fit flex flex-col items-center gap-2 text-textPrimaryLight dark:text-[#a8a6a6] group">
+							<Icons.WindowZoom className="w-[10px]" />
+						</div>
+					</div>
+					<div
+						className="button window-hover-close cursor-pointer dark:hover:bg-bgModifierHover hover:bg-bgLightModeButton"
+						id="close-button"
+						onClick={handleClose}
+					>
+						<div className="w-fit flex flex-col items-center gap-2 text-textPrimaryLight dark:text-[#a8a6a6] group">
+							<Icons.CloseButton className="w-[14px]" />
+						</div>
+					</div>
+				</div>
+			</div>
+		</header>
+	);
+};
 
 const AppLayout = () => {
 	const isLogin = useSelector(selectIsLogin) ?? false;
@@ -26,13 +103,38 @@ const AppLayout = () => {
 
 const ViewModeHandler: React.FC = () => {
 	const navigate = useCustomNavigate();
-
+	const location = useLocation();
+	const viewMode = new URLSearchParams(location.search).get('viewMode');
 	const { redirectTo } = useLoaderData() as IAppLoaderData;
+
 	useEffect(() => {
 		if (redirectTo) {
 			navigate(redirectTo);
 		}
 	}, [redirectTo, navigate]);
+
+	useEffect(() => {
+		if (!isElectron() || viewMode !== 'image') {
+			return;
+		}
+
+		const handleKeyDown = (event: KeyboardEvent) => {
+			if (event.key === 'Escape') {
+				window.electron.send(IMAGE_WINDOW_TITLE_BAR_ACTION, CLOSE_APP);
+			}
+		};
+
+		document.addEventListener('keydown', handleKeyDown);
+		return () => document.removeEventListener('keydown', handleKeyDown);
+	}, [viewMode]);
+
+	if (isWindowsDesktop || isLinuxDesktop) {
+		return <TitleBar eventName={viewMode === 'image' ? IMAGE_WINDOW_TITLE_BAR_ACTION : TITLE_BAR_ACTION} />;
+	}
+
+	if (isMacDesktop) {
+		return <MacOSWindowControls />;
+	}
 
 	return null;
 };

--- a/apps/chat/src/app/layouts/MacWindowsControl.tsx
+++ b/apps/chat/src/app/layouts/MacWindowsControl.tsx
@@ -1,0 +1,86 @@
+import {
+	checkMaximizedState,
+	closeWindow,
+	listenToWindowStateChanges,
+	maximizeWindow,
+	minimizeWindow,
+	selectIsMaximized,
+	selectIsWindowFocused,
+	useAppDispatch,
+	useAppSelector,
+	windowControlsActions
+} from '@mezon/store';
+import { Icons } from '@mezon/ui';
+import React, { useCallback, useEffect } from 'react';
+import { WEBKIT_NO_DRAG } from '../styles/commonStyles';
+
+interface MacOSWindowControlsProps {
+	className?: string;
+}
+
+export const MacOSWindowControls: React.FC<MacOSWindowControlsProps> = ({ className }) => {
+	const dispatch = useAppDispatch();
+	const isMaximized = useAppSelector(selectIsMaximized);
+	const isWindowFocused = useAppSelector(selectIsWindowFocused);
+
+	// Listen for window focus/blur events
+	useEffect(() => {
+		const handleFocus = () => dispatch(windowControlsActions.setIsWindowFocused(true));
+		const handleBlur = () => dispatch(windowControlsActions.setIsWindowFocused(false));
+
+		window.addEventListener('focus', handleFocus);
+		window.addEventListener('blur', handleBlur);
+
+		return () => {
+			window.removeEventListener('focus', handleFocus);
+			window.removeEventListener('blur', handleBlur);
+		};
+	}, [dispatch]);
+
+	const handleMinimize = useCallback(() => {
+		dispatch(minimizeWindow());
+	}, [dispatch]);
+
+	const handleMaximize = useCallback(() => {
+		dispatch(maximizeWindow());
+	}, [dispatch]);
+
+	const handleClose = useCallback(() => {
+		dispatch(closeWindow());
+	}, [dispatch]);
+
+	useEffect(() => {
+		dispatch(checkMaximizedState());
+		dispatch(listenToWindowStateChanges());
+	}, [dispatch]);
+
+	const buttonBaseClass =
+		'w-3 h-3 rounded-full cursor-default border-none flex items-center justify-center transition-all duration-200 ease-in-out group';
+
+	const MacOSButton: React.FC<{
+		onClick: () => void;
+		buttonType?: string;
+		backgroundColor: string;
+		title?: string;
+		icon: React.ReactNode;
+	}> = ({ onClick, backgroundColor, title, icon }) => (
+		<button onClick={onClick} className={buttonBaseClass} title={title} style={{ backgroundColor }}>
+			<span
+				className={`opacity-0 ${isWindowFocused ? 'group-hover:opacity-100' : ''} transition-opacity duration-200 flex items-center justify-center w-full h-full overflow-hidden`}
+			>
+				{icon}
+			</span>
+		</button>
+	);
+
+	return (
+		<div
+			className={`fixed top-0 left-0 flex items-center gap-2 z-[9999] rounded-sm pl-3 px-2 py-3 backdrop-blur-sm ${className}`}
+			style={WEBKIT_NO_DRAG}
+		>
+			<MacOSButton onClick={handleClose} backgroundColor="#ff5f57" icon={<Icons.MacOSCloseIcon />} />
+			<MacOSButton onClick={handleMinimize} backgroundColor="#ffbd2e" icon={<Icons.MacOSMinimizeIcon />} />
+			<MacOSButton onClick={handleMaximize} backgroundColor="#28ca42" icon={<Icons.MacOSMaximizeIcon isMaximized={isMaximized} />} />
+		</div>
+	);
+};

--- a/libs/store/src/index.ts
+++ b/libs/store/src/index.ts
@@ -93,3 +93,4 @@ export * from './lib/wallet/transactionHistory.slice';
 export * from './lib/wallet/useWallet';
 export * from './lib/wallet/wallet.slice';
 export * from './lib/webhook/webhook.slice';
+export * from './lib/windowControls/windowControls.slice';

--- a/libs/store/src/lib/store.tsx
+++ b/libs/store/src/lib/store.tsx
@@ -82,6 +82,7 @@ import { toastListenerMiddleware } from './toasts/toasts.listener';
 import { TOASTS_FEATURE_KEY, toastsReducer } from './toasts/toasts.slice';
 import { topicsReducer } from './topicDiscussion/topicDiscussions.slice';
 import { voiceReducer } from './voice/voice.slice';
+import { WINDOW_CONTROLS_FEATURE_KEY, windowControlsReducer } from './windowControls/windowControls.slice';
 import { TRANSACTION_HISTORY_FEATURE_KEY, transactionHistoryReducer } from './wallet/transactionHistory.slice';
 import { WALLET_FEATURE_KEY, walletReducer } from './wallet/wallet.slice';
 import { integrationWebhookReducer } from './webhook/webhook.slice';
@@ -389,6 +390,7 @@ const reducer = {
 	groupCall: groupCallReducer,
 	[QUICK_MENU_FEATURE_KEY]: quickMenuReducer,
 	[COMUNITY_FEATURE_KEY]: persistedComunityReducer,
+	[WINDOW_CONTROLS_FEATURE_KEY]: windowControlsReducer,
 	[TRANSACTION_HISTORY_FEATURE_KEY]: transactionHistoryReducer,
 	[WALLET_FEATURE_KEY]: persistedWalletStore,
 	[USER_STATUS_FEATURE_KEY]: statusReducer,

--- a/libs/store/src/lib/windowControls/windowControls.slice.ts
+++ b/libs/store/src/lib/windowControls/windowControls.slice.ts
@@ -1,0 +1,106 @@
+import { GET_WINDOW_STATE, MAC_WINDOWS_ACTION, WINDOW_STATE_CHANGED, isElectron } from '@mezon/utils';
+import { PayloadAction, createAsyncThunk, createSelector, createSlice } from '@reduxjs/toolkit';
+
+export const WINDOW_CONTROLS_FEATURE_KEY = 'windowControls';
+
+// Enum for window control actions
+export enum WindowControlAction {
+	MINIMIZE = 'APP::MINIMIZE_WINDOW',
+	MAXIMIZE = 'APP::MAXIMIZE_WINDOW',
+	UNMAXIMIZE = 'APP::UNMAXIMIZE_WINDOW',
+	CLOSE = 'APP::CLOSE_APP'
+}
+
+export interface WindowControlsState {
+	isMaximized: boolean;
+	isWindowFocused: boolean;
+}
+
+export const initialWindowControlsState: WindowControlsState = {
+	isMaximized: false,
+	isWindowFocused: true
+};
+
+// Async thunks for window operations
+export const sendTitleBarAction = createAsyncThunk('windowControls/sendTitleBarAction', async (action: WindowControlAction) => {
+	if (typeof window !== 'undefined' && window.electron?.send) {
+		window.electron.send(MAC_WINDOWS_ACTION, action);
+	}
+	return action;
+});
+
+export const minimizeWindow = createAsyncThunk('windowControls/minimizeWindow', async (_, { dispatch }) => {
+	await dispatch(sendTitleBarAction(WindowControlAction.MINIMIZE));
+});
+
+export const maximizeWindow = createAsyncThunk('windowControls/maximizeWindow', async (_, { dispatch, getState }) => {
+	const state = getState() as { [WINDOW_CONTROLS_FEATURE_KEY]: WindowControlsState };
+	const { isMaximized } = state[WINDOW_CONTROLS_FEATURE_KEY];
+	const action = isMaximized ? WindowControlAction.UNMAXIMIZE : WindowControlAction.MAXIMIZE;
+	await dispatch(sendTitleBarAction(action));
+	return !isMaximized;
+});
+
+export const closeWindow = createAsyncThunk('windowControls/closeWindow', async (_, { dispatch }) => {
+	await dispatch(sendTitleBarAction(WindowControlAction.CLOSE));
+});
+
+export const checkMaximizedState = createAsyncThunk('windowControls/checkMaximizedState', async () => {
+	if (isElectron() && window.electron?.invoke) {
+		try {
+			const state = (await window.electron.invoke(GET_WINDOW_STATE)) as unknown as { isMaximized: boolean };
+			return state.isMaximized;
+		} catch (error) {
+			console.warn('Could not check window maximized state:', error);
+			return false;
+		}
+	}
+	return false;
+});
+
+// Action to listen for window state changes from main process
+export const listenToWindowStateChanges = () => (dispatch: (action: PayloadAction<boolean>) => void) => {
+	if (isElectron() && window.electron?.on) {
+		window.electron.on(WINDOW_STATE_CHANGED, (data: unknown) => {
+			const state = data as { isMaximized: boolean };
+			dispatch(windowControlsActions.setIsMaximized(state.isMaximized));
+		});
+	}
+};
+
+export const windowControlsSlice = createSlice({
+	name: WINDOW_CONTROLS_FEATURE_KEY,
+	initialState: initialWindowControlsState,
+	reducers: {
+		setIsMaximized: (state, action: PayloadAction<boolean>) => {
+			state.isMaximized = action.payload;
+		},
+		setIsWindowFocused: (state, action: PayloadAction<boolean>) => {
+			state.isWindowFocused = action.payload;
+		}
+	},
+	extraReducers: (builder) => {
+		builder
+			.addCase(maximizeWindow.fulfilled, (state, action) => {
+				state.isMaximized = action.payload;
+			})
+			.addCase(checkMaximizedState.fulfilled, (state, action) => {
+				state.isMaximized = action.payload;
+			});
+	}
+});
+
+// Selectors
+export const getWindowControlsState = (rootState: { [WINDOW_CONTROLS_FEATURE_KEY]: WindowControlsState }): WindowControlsState =>
+	rootState[WINDOW_CONTROLS_FEATURE_KEY];
+
+export const selectIsMaximized = createSelector(getWindowControlsState, (state) => state.isMaximized);
+
+export const selectIsWindowFocused = createSelector(getWindowControlsState, (state) => state.isWindowFocused);
+// Actions
+export const windowControlsActions = windowControlsSlice.actions;
+
+// Reducer
+export const windowControlsReducer = windowControlsSlice.reducer;
+
+export default windowControlsSlice.reducer;

--- a/libs/utils/src/index.ts
+++ b/libs/utils/src/index.ts
@@ -1,4 +1,5 @@
 export * from './lib/async';
+export * from './lib/bridge';
 export * from './lib/channel-app-launch';
 export * from './lib/clan';
 export * from './lib/constant';

--- a/libs/utils/src/lib/bridge/electron/constants.ts
+++ b/libs/utils/src/lib/bridge/electron/constants.ts
@@ -1,0 +1,10 @@
+// IMPORTANT: keep in sync with prod desktop `apps/desktop/src/app/events/constants.ts`
+export const TITLE_BAR_ACTION = 'APP::TITLE_BAR_ACTION';
+export const MAC_WINDOWS_ACTION = 'APP::MAC_WINDOWS_ACTION';
+export const IMAGE_WINDOW_TITLE_BAR_ACTION = 'APP::IMAGE_WINDOW_TITLE_BAR_ACTION';
+export const MINIMIZE_WINDOW = 'APP::MINIMIZE_WINDOW';
+export const UNMAXIMIZE_WINDOW = 'APP::UNMAXIMIZE_WINDOW';
+export const MAXIMIZE_WINDOW = 'APP::MAXIMIZE_WINDOW';
+export const CLOSE_APP = 'APP::CLOSE_APP';
+export const GET_WINDOW_STATE = 'APP::GET_WINDOW_STATE';
+export const WINDOW_STATE_CHANGED = 'APP::WINDOW_STATE_CHANGED';

--- a/libs/utils/src/lib/bridge/electron/index.ts
+++ b/libs/utils/src/lib/bridge/electron/index.ts
@@ -1,0 +1,2 @@
+export * from './constants';
+export * from './types';

--- a/libs/utils/src/lib/bridge/electron/types.ts
+++ b/libs/utils/src/lib/bridge/electron/types.ts
@@ -1,0 +1,13 @@
+export type ElectronBridgeHandler = (...args: unknown[]) => void;
+
+export type MezonElectronAPI = {
+	send: (eventName: string, ...params: unknown[]) => void;
+	invoke?: (channel: string, data?: unknown) => Promise<unknown>;
+	on: (eventName: string, callback: ElectronBridgeHandler) => void;
+};
+
+declare global {
+	interface Window {
+		electron: MezonElectronAPI;
+	}
+}

--- a/libs/utils/src/lib/bridge/index.ts
+++ b/libs/utils/src/lib/bridge/index.ts
@@ -1,0 +1,1 @@
+export * from './electron';

--- a/libs/utils/src/lib/utils/index.ts
+++ b/libs/utils/src/lib/utils/index.ts
@@ -26,6 +26,7 @@ import { ChannelStreamMode, ChannelType, safeJSONParse } from 'mezon-js';
 import type React from 'react';
 import Resizer from 'react-image-file-resizer';
 import { CURRENCY, ID_MENTION_HERE } from '../constant';
+import { Platform } from '../hooks/platform';
 import type {
 	ChannelMembersEntity,
 	IAttachmentEntity,
@@ -55,6 +56,7 @@ import { getLinkType } from './embed-social';
 import { getPreSendSourceFile, getPreSendThumbnailBlob } from './file';
 import { Foreman } from './foreman';
 import { isMezonCdnUrl, isTenorUrl } from './urlSanitization';
+import { getPlatform, isElectron } from './windowEnvironment';
 export * from './animateScroll';
 export * from './audio';
 export * from './buildClassName';
@@ -973,6 +975,10 @@ export const sortChannelsByLastActivity = (channels: IChannel[]): IChannel[] => 
 export const checkIsThread = (channel?: IChannel) => {
 	return channel?.type === ChannelType.CHANNEL_TYPE_THREAD || (channel?.parent_id && channel?.parent_id !== '0');
 };
+
+export const isWindowsDesktop = getPlatform() === Platform.WINDOWS && isElectron();
+export const isMacDesktop = getPlatform() === Platform.MACOS && isElectron();
+export const isLinuxDesktop = getPlatform() === Platform.LINUX && isElectron();
 
 type ImgproxyOptions = {
 	width?: number;

--- a/libs/utils/src/lib/utils/windowEnvironment.ts
+++ b/libs/utils/src/lib/utils/windowEnvironment.ts
@@ -1,3 +1,24 @@
+type ElectronRendererWindow = Window & { process?: { type?: string } };
+
+export function isElectron(): boolean {
+	if (typeof window !== 'undefined') {
+		const rendererWindow = window as ElectronRendererWindow;
+		if (typeof rendererWindow.process === 'object' && rendererWindow.process?.type === 'renderer') {
+			return true;
+		}
+	}
+
+	if (typeof process !== 'undefined' && typeof process.versions === 'object' && process.versions.electron) {
+		return true;
+	}
+
+	if (typeof navigator === 'object' && typeof navigator.userAgent === 'string' && navigator.userAgent.includes('Electron')) {
+		return true;
+	}
+
+	return false;
+}
+
 export function getPlatform(): any {
 	const { userAgent, platform } = window.navigator;
 


### PR DESCRIPTION
## Summary
- Restore Mac traffic-light controls (close/minimize/maximize) removed in `0c96a16c71` ("delete desktop electron")
- Re-add `MacWindowsControl`, `AppLayout` titlebar wiring, `windowControls` Redux slice, and electron renderer bridge
- Does **not** restore `apps/desktop/` — existing prod Electron builds keep the main process; only the chat renderer is updated

## Context
Commit `0c96a16c71` accidentally removed renderer-side window controls while desktop prod builds are still in use without rebuilding the Electron shell.

## Test plan
- [ ] `yarn build:chat` succeeds
- [ ] Open existing prod Electron app on macOS (or dev: `yarn dev:chat` + Electron pointing to localhost)
- [ ] Mac traffic-light buttons visible at top-left
- [ ] Close / minimize / maximize work via IPC
- [ ] Web browser (non-Electron): no window controls rendered
- [ ] Windows/Linux Electron: classic titlebar still renders (if applicable)

Made with [Cursor](https://cursor.com)