### PR TITLE
260706-WEB/DESKTOP-Fix(ui): improve UI/UX across multiple components

### DIFF
--- a/libs/components/src/lib/components/ChannelList/ChannelListComponents/index.tsx
+++ b/libs/components/src/lib/components/ChannelList/ChannelListComponents/index.tsx
@@ -121,7 +121,7 @@ export const Events = memo(() => {
 					to={serverGuidePath}
 					onClick={handleClose}
 					className={`self-stretch inline-flex cursor-pointer px-2 rounded h-[34px] ${
-						isGuidePath ? 'bg-button-secondary text-theme-primary-active' : ''
+						isGuidePath ? 'bg-[var(--bg-item-hover)] text-theme-primary-active' : ''
 					} bg-item-hover text-theme-primary text-theme-primary-hover ${
 						isGuidePath
 							? '[--guide-fill-1:var(--bg-icon-theme-active)] [--guide-fill-2:var(--bg-theme-secounnd)]'
@@ -168,7 +168,7 @@ export const Events = memo(() => {
 			<Link
 				to={memberPath}
 				onClick={handleClose}
-				className={`self-stretch inline-flex cursor-pointer px-2 rounded-lg h-[34px] ${isMemberPath ? 'bg-button-secondary border-theme-primary text-theme-primary-active' : ''} bg-item-hover text-theme-primary text-theme-primary-hover`}
+				className={`self-stretch inline-flex cursor-pointer px-2 rounded-lg h-[34px] ${isMemberPath ? 'bg-[var(--bg-item-hover)] text-theme-primary-active' : ''} bg-item-hover text-theme-primary text-theme-primary-hover`}
 			>
 				<div className="grow w-5 flex-row items-center gap-2 flex" data-e2e={generateE2eId('clan_page.side_bar.button.members')}>
 					<div className="w-5 h-5 relative flex flex-row items-center">
@@ -184,7 +184,7 @@ export const Events = memo(() => {
 					to={channelSettingPath}
 					onClick={handleClose}
 					className={`self-stretch inline-flex cursor-pointer px-2 rounded-lg h-[34px] ${
-						isSettingPath ? 'bg-button-secondary border-theme-primary text-theme-primary-active' : ''
+						isSettingPath ? 'bg-[var(--bg-item-hover)] text-theme-primary-active' : ''
 					} bg-item-hover text-theme-primary text-theme-primary-hover ${
 						isSettingPath
 							? '[--channel-browser-fill-1:var(--bg-icon-theme-active)] [--channel-browser-fill-2:var(--bg-theme-secounnd)]'

--- a/libs/components/src/lib/components/ClanSettings/ClanSettingOverview/SystemMessagesManagement/index.tsx
+++ b/libs/components/src/lib/components/ClanSettings/ClanSettingOverview/SystemMessagesManagement/index.tsx
@@ -81,7 +81,7 @@ const SystemMessagesManagement = ({
 					menuItems.push(
 						<Menu.Item
 							key={channel.id}
-							className="flex flex-row items-center rounded-sm text-sm w-full py-2 px-4 text-left cursor-pointer"
+							className="flex flex-row items-center rounded-sm text-sm w-full py-2 px-4 text-left cursor-pointer bg-item-hover transition-colors"
 							onClick={() => handleToggleSetting(true, ETypeUpdateSystemMessage.CHANNEL, channel.id)}
 						>
 							{renderChannelIcon(channel)}
@@ -103,9 +103,9 @@ const SystemMessagesManagement = ({
 	return (
 		<div className={'border-t-theme-primary mt-10 pt-10 flex flex-col '}>
 			<h3 className="text-sm font-bold uppercase mb-2">{t('systemMessages.title')}</h3>
-			<Menu menu={menu} className={'h-fit max-h-[200px] text-xs overflow-y-scroll customSmallScrollLightMode bg-theme-input px-2'}>
+			<Menu menu={menu} className={'h-fit max-h-[200px] text-xs overflow-y-auto customSmallScrollLightMode '}>
 				<div
-					className="w-full cursor-pointer  h-10 rounded-md flex flex-row p-3 justify-between items-center uppercase text-sm border border-theme-primary bg-theme-input "
+					className="w-full cursor-pointer  h-10 rounded-md flex flex-row p-3 justify-between items-center uppercase text-sm border border-theme-primary "
 					data-e2e={generateE2eId('clan_page.settings.overview.system_messages_channel')}
 				>
 					<div className={' flex flex-row items-center'}>

--- a/libs/components/src/lib/components/ModalInputMessageBuzz/index.tsx
+++ b/libs/components/src/lib/components/ModalInputMessageBuzz/index.tsx
@@ -111,7 +111,7 @@ const ModalInputMessageBuzz = ({ currentChannel, mode, closeBuzzModal }: ModalIn
 					/>
 					<button
 						onClick={handleSendBuzzMsg}
-						className="w-[70px] flex justify-center items-center px-4 py-2 btn-primary btn-primary-hover rounded-lg"
+						className="flex-shrink-0 flex justify-center items-center px-4 py-2 btn-primary btn-primary-hover rounded-lg whitespace-nowrap"
 						data-e2e={generateE2eId('chat.direct_message.message_buzz.button.send')}
 					>
 						{t('send')}

--- a/libs/components/src/lib/components/ThumbnailAttachmentRender/ThumbnailAttachmentRender.tsx
+++ b/libs/components/src/lib/components/ThumbnailAttachmentRender/ThumbnailAttachmentRender.tsx
@@ -93,23 +93,26 @@ export const AudioAttachment = ({ attachment, size, isFileList }: IAudioAttachme
 		}
 	};
 
-	const positionAndPadding = useMemo(() => {
+	const overlayStyle = useMemo(() => {
 		if (isFileList) {
-			return `border-[2px] top-[10px] right-[3.5px] p-[5px] ${isPlaying ? '' : 'pr-[3px] pl-[7px]'}`;
+			return { container: 'w-5 h-5', icon: 'w-2 h-2' };
 		}
-		return `border-[4px] top-[23px] right-[8px] p-[10px] ${isPlaying ? '' : 'pr-[8px] pl-[12px]'}`;
-	}, [isFileList, isPlaying]);
+		return { container: 'w-12 h-12', icon: 'w-5 h-5' };
+	}, [isFileList]);
 
 	return (
-		<div className="relative">
-			<div onClick={(e) => handleTogglePlay(e)} className={`absolute border-gray-600 bg-gray-400 rounded-full ${positionAndPadding}`}>
+		<div className="relative inline-flex items-center justify-center group">
+			<Icons.EmptyType defaultSize={size} />
+			<div
+				onClick={(e) => handleTogglePlay(e)}
+				className={`absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-black/40 group-hover:bg-black/60 text-white rounded-full flex items-center justify-center cursor-pointer transition-all ${overlayStyle.container}`}
+			>
 				{isPlaying ? (
-					<Icons.PauseButton className={isFileList ? 'w-3' : 'w-7'} />
+					<Icons.PauseButton className={overlayStyle.icon} />
 				) : (
-					<Icons.PlayButton className={isFileList ? 'w-3' : 'w-7'} />
+					<Icons.PlayButton className={`${overlayStyle.icon} ml-0.5`} />
 				)}
 			</div>
-			<Icons.EmptyType defaultSize={size} />
 			<MessageAudioControl
 				ref={audioControlRef}
 				audioUrl={attachment.url || ''}

--- a/libs/ui/src/lib/Pagination/index.tsx
+++ b/libs/ui/src/lib/Pagination/index.tsx
@@ -47,7 +47,7 @@ const Pagination: React.FC<PaginationProps> = ({ totalPages, currentPage, onPage
 				disabled={currentPage === 1}
 				onClick={() => onPageChange(currentPage - 1)}
 			>
-				<Icons.ArrowRight defaultSize="rotate-180 w-5 h-5 min-w-4" />
+				<Icons.ArrowRight className="rotate-180" />
 			</button>
 
 			{pages.map((p, idx) =>
@@ -74,3 +74,4 @@ const Pagination: React.FC<PaginationProps> = ({ totalPages, currentPage, onPage
 };
 
 export default Pagination;
+   


### PR DESCRIPTION
Ticket : https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-40
Bug : 
<img width="927" height="421" alt="image" src="https://github.com/user-attachments/assets/f5e98f98-afb0-446a-831d-3c7f44785479" />
<img width="467" height="183" alt="image" src="https://github.com/user-attachments/assets/fee78311-3fe6-4d87-850d-20724dda1ab3" />
<img width="716" height="403" alt="image" src="https://github.com/user-attachments/assets/35cce0f2-1e5f-4b18-9ff8-10c2bc33eb0c" />
<img width="648" height="372" alt="image" src="https://github.com/user-attachments/assets/ccaaf7bf-3ab2-4114-a121-615ab55f9965" />
<img width="284" height="139" alt="image" src="https://github.com/user-attachments/assets/7fa52356-9c3b-4ab9-abdc-a46d94e76afc" />

expetct: 
<img width="762" height="783" alt="image" src="https://github.com/user-attachments/assets/c2d2adf8-0c7a-4752-abd2-bf8379e3a75e" />
<img width="279" height="167" alt="image" src="https://github.com/user-attachments/assets/fac81112-06e4-4fda-9e6e-eb6a37b80af3" />
<img width="796" height="262" alt="image" src="https://github.com/user-attachments/assets/6c57a731-8500-435d-969a-4bf9dfd16bf3" />
<img width="558" height="327" alt="image" src="https://github.com/user-attachments/assets/bb406670-6c6c-4bf5-b251-f4fd131991a3" />
<img width="881" height="881" alt="image" src="https://github.com/user-attachments/assets/fb12a8f6-bad2-4711-9d03-05a88af0d97a" />

Test Case : 
1. Sidebar Menu Active State (Clan Guide, Members, Channels)

Action: Navigate into a Clan/Server and click on the "Clan Guide", "Members", or "Channels" options on the left sidebar.
Expectation: The active item is highlighted using the hover background color (var(--bg-item-hover)) and does NOT display a side border. The icon and text correctly change to their active colors. The "Events" item behavior remains unchanged (hover only).
2. Audio/MP3 Thumbnail Play Button UI

Action: Upload an audio/MP3 file into a chat channel. View it in the main chat, and then open the "Files" modal from the top-right bar to view it in the file list.
Expectation: The underlying file icon uses the default document icon (EmptyType). The Play/Pause button is perfectly centered over the document icon and uses a semi-transparent dark overlay (bg-black/40), mimicking standard video thumbnails. In the file list modal, the play button overlay is correctly scaled down (w-5 h-5).
3. Buzz Message Modal Send Button

Action: Open the "Buzz Message" modal. Type an extremely long string of text (100+ characters) into the text input area to force the input box to expand, or switch the app language to one with longer translated texts.
Expectation: The "Send" button strictly maintains its original width and shape without shrinking (flex-shrink-0), and the text "Send" remains cleanly on a single line without wrapping (whitespace-nowrap).
4. System Messages Dropdown Hover & Scroll

Action: Go to Clan Settings -> Overview -> System Messages. Click on the dropdown menu to select a channel. Scroll through the list and hover over different channel items.
Expectation: The dropdown list scrollbar looks clean and only appears when content exceeds the max height (overflow-y-auto). Hovering over any channel item successfully highlights it with a background color.
5. Pagination Prev/Next Arrows

Action: Go to any page that contains a table with pagination (e.g., Members list or Channel list in Admin settings).
Expectation: The "Previous" (left) arrow icon correctly points to the left, and the "Next" (right) arrow icon correctly points to the right without layout distortion.