### PR TITLE
260707-WEB/DESKTOP-Fix/chat and notification issues

### DIFF
--- a/libs/components/src/lib/components/NotificationList/AllNotificationItem.tsx
+++ b/libs/components/src/lib/components/NotificationList/AllNotificationItem.tsx
@@ -192,7 +192,7 @@ interface IMentionTabContent {
 
 function AllTabContent({ message, subject, category, senderId, embed }: IMentionTabContent) {
 	const { t } = useTranslation('channelTopbar');
-	const { priorityAvatar } = useGetPriorityNameFromUserClan(message.sender_id || '');
+	const { priorityAvatar, namePriority, usernameSender } = useGetPriorityNameFromUserClan(senderId || message.sender_id || '');
 
 	const currentChannel = useAppSelector((state) => selectChannelById(state, message.channel_id || '0')) || {};
 	const parentChannel = useAppSelector((state) => selectChannelById(state, currentChannel.parent_id || '')) || {};
@@ -200,10 +200,10 @@ function AllTabContent({ message, subject, category, senderId, embed }: IMention
 	const clan = useAppSelector(selectClanById(message.clan_id as string));
 	const user = useAppSelector((state) => selectMemberDMByUserId(state, senderId ?? ''));
 
-	const username = message.username || user?.username || '';
+	const username = message.username || user?.username || usernameSender || '';
 	let subjectText = subject;
 
-	if (username) {
+	if (username && subject?.startsWith(username)) {
 		const usernameLenght = username.length;
 		subjectText = subject?.slice(usernameLenght);
 	}
@@ -352,7 +352,7 @@ function AllTabContent({ message, subject, category, senderId, embed }: IMention
 					) : (
 						<div className="flex flex-col gap-1 justify-center">
 							<div>
-								<span className="font-bold">{user?.display_name || username}</span>
+								<span className="font-bold">{namePriority || user?.display_name || username}</span>
 								<span>{subjectText}</span>
 							</div>
 							{!!message?.create_time_seconds && (

--- a/libs/core/src/lib/chat/contexts/ChatContext.tsx
+++ b/libs/core/src/lib/chat/contexts/ChatContext.tsx
@@ -2472,7 +2472,7 @@ const ChatContextProvider: React.FC<ChatContextProviderProps> = ({ children, isM
 			topicsActions.createTopicMeta({
 				lsnt: `${sdTopicEvent.last_sent_message?.timestamp_seconds || Date.now() / 1000}`,
 				message_id: sdTopicEvent?.message_id as string,
-				rpl: 1,
+				rpl: 0,
 				tp_id: sdTopicEvent.id
 			})
 		);


### PR DESCRIPTION
BUG: 
-https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-32
-https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-45
<img width="1581" height="165" alt="image" src="https://github.com/user-attachments/assets/bfbcc8c1-07c6-4176-8f97-ef03cdbe34fe" />
<img width="473" height="415" alt="image" src="https://github.com/user-attachments/assets/e4f6e135-a118-4230-893b-b463e03f43f0" />
 Expect :
<img width="1528" height="208" alt="image" src="https://github.com/user-attachments/assets/7fb27cdb-6a40-49a2-8f76-0dbdbad1f4ff" />
<img width="1028" height="842" alt="image" src="https://github.com/user-attachments/assets/77a2c52e-6dbd-4c2b-a6c2-a991df13b0d3" />



Test Case 1: Prevent duplicate topic messages on creation (ChatContext.tsx)
Action: Open the application, navigate into a Clan/Channel, and create a new Topic from an existing message (or open the Topic Discussions view and send the first message into a newly created topic). Keep the Topic view open and observe the newly sent message.
Expectation: The newly sent message appears exactly once in the topic chat UI. The internal topic reply count increments correctly from 0 to 1. Reloading the page (F5) maintains exactly one instance of the message, 
Test Case 2: Display missing avatar and username in "For You" tab (AllNotificationItem.tsx)
Action: Use a separate account (Account A) to trigger a "For You" notification (e.g., a token transfer like sent you +500000đ) to the current user (Account B). Ensure Account A is not in Account B's Direct Messages (DM) list, but they share a Clan. Log in as Account B, open the Notification Inbox, and switch to the "For You" tab.
Expectation: The notification item successfully displays Account A's avatar (prioritizing the Clan avatar, then falling back to the general avatar). The notification text correctly prefixes the bolded sender name at the beginning (e.g., [Account A's Name] sent you +500000đ), instead of rendering an empty avatar and missing name.