### PR TITLE
260710-WEB/DESKTOP-fix: resolve role member sync bugs and channel permission UI issues

### DIFF
--- a/libs/components/src/lib/components/ChannelSetting/Component/Modal/listRoles.tsx
+++ b/libs/components/src/lib/components/ChannelSetting/Component/Modal/listRoles.tsx
@@ -1,6 +1,6 @@
 import type { RolesClanEntity } from '@mezon/store';
 import { Icons } from '@mezon/ui';
-import { generateE2eId } from '@mezon/utils';
+import { generateE2eId, DEFAULT_ROLE_COLOR } from '@mezon/utils';
 
 type ListRoleProps = {
 	listItem: RolesClanEntity[];
@@ -29,7 +29,7 @@ const ListRole = (props: ListRoleProps) => {
 					/>
 					<Icons.Check className="absolute invisible peer-checked:visible forced-colors:hidden w-4 h-4" />
 				</div>
-				{role.role_icon ? <img src={role.role_icon} alt="" className={'size-5'} /> : <Icons.RoleIcon className="w-5 h-5 min-w-5" />}
+				{role.role_icon ? <img src={role.role_icon} alt="" className={'size-5'} /> : <Icons.RoleIcon className="w-5 h-5 min-w-5" defaultFill1={role.color || DEFAULT_ROLE_COLOR} />}
 				<p
 					className="text-sm one-line"
 					data-e2e={generateE2eId('channel_setting_page.permissions.section.member_role_management.modal.role_list.role_item.title')}

--- a/libs/components/src/lib/components/ChannelSetting/Component/PermissionsChannel/PermissionManage/ListRoleMember.tsx
+++ b/libs/components/src/lib/components/ChannelSetting/Component/PermissionsChannel/PermissionManage/ListRoleMember.tsx
@@ -101,7 +101,7 @@ const HeaderAddRoleMember = memo((props: HeaderAddRoleMemberProps) => {
 			return listManageNotInChannel;
 		}
 		return listManageNotInChannel.filter((role) => searchNormalizeText(role.title, search));
-	}, [search]);
+	}, [search, listManageNotInChannel]);
 
 	const listMemberCanAdd = useMemo(() => {
 		if (!search) {
@@ -113,41 +113,43 @@ const HeaderAddRoleMember = memo((props: HeaderAddRoleMemberProps) => {
 				searchNormalizeText(user.user?.display_name || '', search) ||
 				searchNormalizeText(user.user?.username || '', search)
 		);
-	}, [search]);
+	}, [search, usersClan]);
 
 	return (
-		<div ref={panelRef} className="flex justify-between items-center relative" onClick={() => setShowPopup(!showPopup)}>
+		<div ref={panelRef} className="flex justify-between items-center relative cursor-pointer" onClick={() => setShowPopup(!showPopup)}>
 			<h4 className="uppercase font-bold text-xs text-theme-primary-active">{t('channelPermission.bottomSheet.rolesMembers')}</h4>
 			{channel?.channel_private === 1 && <Icons.PlusIcon className="size-4  cursor-pointer" />}
 			{showPopup && (
-				<div
-					className="absolute bottom-5 w-64 rounded-lg overflow-hidden bg-theme-setting-primary border-theme-primary"
-					onClick={(e) => e.stopPropagation()}
-				>
-					<div className=" flex gap-x-1 p-4 text-sm bg-theme-setting-nav">
-						<p className="font-bold text-theme-primary-active">{t('channelPermission.bottomSheet.add')}:</p>
-						<input
-							type="text"
-							className="bg-transparent outline-none font-medium"
-							placeholder={t('channelPermission.bottomSheet.roleMemberPlaceholder')}
-							value={search}
-							onChange={(e) => setSearch(e.target.value)}
-						/>
-					</div>
+				<>
+					<div className="fixed inset-0 z-40 cursor-default" onClick={(e) => { e.stopPropagation(); setShowPopup(false); }} />
 					<div
-						className=" p-2 h-64 overflow-y-scroll hide-scrollbar text-theme-primary text-theme-primary-hover"
-						onClick={() => setShowPopup(!showPopup)}
+						className="absolute bottom-5 w-64 rounded-lg overflow-hidden bg-theme-setting-primary border-theme-primary z-50 cursor-default"
+						onClick={(e) => e.stopPropagation()}
 					>
-						{Boolean(listRoleCanAdd.length) && (
-							<div>
-								<p className="px-3 py-2 uppercase text-[11px] font-bold">{t('channelPermission.bottomSheet.roles')}</p>
-								{listRoleCanAdd.map((item) => (
-									<div key={item.id} className="rounded px-3 py-2 font-semibold bg-item-hover" onClick={() => addRole(item.id)}>
-										{item.title}
-									</div>
-								))}
-							</div>
-						)}
+						<div className=" flex gap-x-1 p-4 text-sm bg-theme-setting-nav">
+							<p className="font-bold text-theme-primary-active">{t('channelPermission.bottomSheet.add')}:</p>
+							<input
+								type="text"
+								className="bg-transparent outline-none font-medium"
+								placeholder={t('channelPermission.bottomSheet.roleMemberPlaceholder')}
+								value={search}
+								onChange={(e) => setSearch(e.target.value)}
+							/>
+						</div>
+						<div
+							className=" p-2 h-64 overflow-y-scroll hide-scrollbar text-theme-primary"
+							onClick={() => setShowPopup(!showPopup)}
+						>
+							{Boolean(listRoleCanAdd.length) && (
+								<div>
+									<p className="px-3 py-2 uppercase text-[11px] font-bold">{t('channelPermission.bottomSheet.roles')}</p>
+									{listRoleCanAdd.map((item) => (
+										<div key={item.id} className="rounded px-3 py-2 font-semibold bg-item-hover text-theme-primary-hover cursor-pointer" onClick={() => addRole(item.id)}>
+											{item.title}
+										</div>
+									))}
+								</div>
+							)}
 						{Boolean(listMemberCanAdd.length) && (
 							<div>
 								<p className="px-3 py-2 uppercase text-[11px] font-bold">{t('channelPermission.bottomSheet.members')}</p>
@@ -166,6 +168,7 @@ const HeaderAddRoleMember = memo((props: HeaderAddRoleMemberProps) => {
 						)}
 					</div>
 				</div>
+				</>
 			)}
 		</div>
 	);

--- a/libs/components/src/lib/components/ChannelSetting/Component/PermissionsChannel/listRolePermission.tsx
+++ b/libs/components/src/lib/components/ChannelSetting/Component/PermissionsChannel/listRolePermission.tsx
@@ -1,7 +1,7 @@
 import { channelUsersActions, selectAllRolesClan, selectCurrentClanId, selectRolesByChannelId, useAppDispatch } from '@mezon/store';
 import { Icons } from '@mezon/ui';
 import type { IChannel } from '@mezon/utils';
-import { generateE2eId } from '@mezon/utils';
+import { generateE2eId, DEFAULT_ROLE_COLOR } from '@mezon/utils';
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
@@ -61,7 +61,7 @@ const ListRolePermission = (props: ListRolePermissionProps) => {
 					{role.role_icon ? (
 						<img src={role.role_icon} alt="role icon" className="w-5 h-5 min-w-5 rounded" />
 					) : (
-						<Icons.RoleIcon className="w-5 h-5 min-w-5" />
+						<Icons.RoleIcon className="w-5 h-5 min-w-5" defaultFill1={role.color || DEFAULT_ROLE_COLOR} />
 					)}
 					<p className="text-sm">{role.title}</p>
 				</div>

--- a/libs/components/src/lib/components/ClanSettings/SettingRoleManagement/SettingManageMembers/index.tsx
+++ b/libs/components/src/lib/components/ClanSettings/SettingRoleManagement/SettingManageMembers/index.tsx
@@ -1,6 +1,6 @@
 import { useRoles } from '@mezon/core';
 import type { RolesClanEntity } from '@mezon/store';
-import { getNewAddMembers, getSelectedRoleId, selectAllUserClans, selectCurrentClanId, selectCurrentRoleIcon, setAddMemberRoles } from '@mezon/store';
+import { getNewAddMembers, getSelectedRoleId, selectAllUserClans, selectCurrentClanId, selectCurrentRoleIcon, setAddMemberRoles, usersClanActions } from '@mezon/store';
 import { Icons, InputField } from '@mezon/ui';
 import type { UsersClanEntity } from '@mezon/utils';
 import { createImgproxyUrl, getAvatarForPrioritize, getNameForPrioritize } from '@mezon/utils';
@@ -60,6 +60,18 @@ const SettingManageMembers = ({ RolesClan, hasPermissionEdit }: { RolesClan: Rol
 		}
 		const userIDArray = userID?.split(',');
 		await updateRole(currentClanId ?? '', clickRole, activeRole?.title ?? '', activeRole?.color ?? '', [], [], userIDArray, [], currentRoleIcon);
+		
+		userIDArray?.forEach((id) => {
+			if (id) {
+				dispatchRole(
+					usersClanActions.removeRoleIdUser({
+						clanId: currentClanId as string,
+						id: clickRole,
+						userId: id
+					})
+				);
+			}
+		});
 	};
 	return (
 		<div>

--- a/libs/components/src/lib/components/ClanSettings/SettingRoleManagement/index.tsx
+++ b/libs/components/src/lib/components/ClanSettings/SettingRoleManagement/index.tsx
@@ -17,7 +17,8 @@ import {
 	setCurrentRoleIcon,
 	setNameRoleNew,
 	setSelectedPermissions,
-	setSelectedRoleId
+	setSelectedRoleId,
+	usersClanActions
 } from '@mezon/store';
 import { generateE2eId } from '@mezon/utils';
 import { useTranslation } from 'react-i18next';
@@ -87,6 +88,14 @@ const ServerSettingRoleManagement = (props: EditNewRole) => {
 		if (isCreateNewRole) {
 			const respond = await createRole(currentClanId || '', nameRole, colorRole, addUsers, addPermissions);
 			if (!hasChangeRole) dispatch(setSelectedRoleId(respond?.id || ''));
+			if (addUsers.length > 0 && respond?.id) {
+				dispatch(
+					usersClanActions.updateManyRoleIds({
+						clanId: currentClanId as string,
+						updates: addUsers.map((id) => ({ userId: id, roleId: respond.id, clanId: currentClanId }))
+					})
+				);
+			}
 		} else {
 			const roleIcon = newRoleIcon || currentRoleIcon || '';
 			await updateRole(currentClanId ?? '', clickRole, nameRole, colorRole, [], addPermissions, [], removePermissions, roleIcon);

--- a/libs/core/src/lib/chat/contexts/ChatContext.tsx
+++ b/libs/core/src/lib/chat/contexts/ChatContext.tsx
@@ -2311,7 +2311,10 @@ const ChatContextProvider: React.FC<ChatContextProviderProps> = ({ children, isM
 					}
 				}
 
-				dispatch(rolesClanActions.update({ role, clanId: role.clan_id as string }));
+				const roleToUpdate = { ...role };
+				delete roleToUpdate.role_user_list;
+				
+				dispatch(rolesClanActions.update({ role: roleToUpdate, clanId: role.clan_id as string }));
 				return;
 			}
 

--- a/libs/store/src/lib/clans/clans.slice.ts
+++ b/libs/store/src/lib/clans/clans.slice.ts
@@ -380,6 +380,9 @@ export const removeClanUsers = createAsyncThunk('clans/removeClanUsers', async (
 			return thunkAPI.rejectWithValue([]);
 		}
 		thunkAPI.dispatch(usersClanActions.removeUsersAndClearCache({ clanId, userIds }));
+		userIds.forEach(userId => {
+			thunkAPI.dispatch(rolesClanActions.updateRemoveUserRole({ userId, clanId }));
+		});
 		return response;
 	} catch (error) {
 		captureSentryError(error, 'clans/removeClanUsers');


### PR DESCRIPTION
BUG: 
<img width="1064" height="602" alt="image" src="https://github.com/user-attachments/assets/67cd01d4-00d9-43ca-8edd-3b5a30efbb6a" />
[Screencast from 2026-07-06 17-25-28.webm](https://github.com/user-attachments/assets/6ad3285d-0193-4b22-9fbc-bb7d04509988)
<img width="429" height="586" alt="image" src="https://github.com/user-attachments/assets/777880a9-7fdf-4764-b46e-7f8f3022d401" />
Expect : 
https://drive.google.com/file/d/173HkyP2L0H2xge01GKzgeFWeNV-oa--y/view?usp=sharing
Test Case : 

Group 1: Role & Clan Member Management (Redux State Sync)
Test Case 1.1: Remove Member from Clan (Clean up Ghost Roles)
Objective: Ensure that when a user is kicked from a Clan, they are immediately removed from all assigned roles in the local cache.
Steps:
Invite User A to the Clan.
Assign a role (e.g., Moderator) to User A.
In another tab or device, keep the member list of the Moderator role open.
Kick (Remove) User A from the Clan.
Expected Result:
User A disappears from the Clan's member list.
User A is immediately removed from the Moderator role's member list (UI updates automatically without needing to refresh/F5).
Test Case 1.2: Remove Member from a Specific Role (Optimistic UI)
Steps:
Go to Clan Settings -> Role Management -> Select a Role (e.g., Member).
In the user list for this role, click to remove one or more users.
Expected Result: The user instantly disappears from the role's member list without any network delay (thanks to the optimistic removeRoleIdUser dispatch).
Test Case 1.3: Create a New Role and Assign Members Instantly
Steps:
Go to Clan Settings -> Role Management -> Create a new Role.
During the "Add Members" step, select a few users and complete the role creation.
Expected Result: When checking the profiles or role lists of the assigned users, the new role is displayed immediately.

Group 2: Realtime Data Sync (ChatContext)
Test Case 2.1: WebSocket Event Doesn't Wipe Role Member List
Objective: Ensure incoming role update events do not overwrite or clear the cached role member list.
Steps:
Using User 1: Open the Channel Setting -> Permissions tab to view the list of roles and members with permissions.
Using User 2 (Admin): Edit the name or color of a role that is currently displayed in that channel.
Observe User 1's screen.
Expected Result: The role's name/color updates automatically (via WebSocket) BUT the list of members assigned to that role does not flash, blank out, or disappear.

Group 3: Channel Settings & Permissions UI
Test Case 3.1: Add Role/Member Popup (Click Outside & Filter)
Steps:
Go to Channel Setting -> Permissions.
Click the + icon to open the Add Role/Member bottom sheet/popup.
Type a user/role name into the search bar.
Click anywhere outside the popup area on the dark backdrop.
Expected Result:
The search bar correctly filters users/roles in real-time (verifying the useMemo dependency fix).
Clicking outside the popup instantly and smoothly closes it.
Test Case 3.2: Verify Role Icon Colors
Steps:
Ensure the Clan has multiple roles with different configured colors (e.g., red, blue) and some without a specific color.
Go to Channel Setting -> Permissions.
Open the Add Role list and view the roles currently in the permissions list.
Expected Result:
Instead of a default gray/uncolored icon, the role icons correctly display their configured colors.
Roles without a customized color fall back properly to the DEFAULT_ROLE_COLO