### PR TITLE
260710-web/desktop-fix: activity tracking toggle persistence and backend sync

### DIFF
--- a/libs/components/src/lib/components/SettingActivity/index.tsx
+++ b/libs/components/src/lib/components/SettingActivity/index.tsx
@@ -13,6 +13,15 @@ const SettingActivity = ({ menuIsOpen }: SettingActivityProps) => {
 
 	const handleToggleActivity = (checked: boolean) => {
 		dispatch(acitvitiesActions.setActivityTrackingEnabled(checked));
+		if (!checked) {
+			dispatch(
+				acitvitiesActions.createActivity({
+					activity_name: '',
+					activity_type: 0,
+					status: 0
+				})
+			);
+		}
 	};
 
 	return (

--- a/libs/core/src/lib/chat/hooks/useActivities.ts
+++ b/libs/core/src/lib/chat/hooks/useActivities.ts
@@ -1,11 +1,14 @@
-import { acitvitiesActions, useAppDispatch } from '@mezon/store';
+import { acitvitiesActions, selectIsActivityTrackingEnabled, useAppDispatch, useAppSelector } from '@mezon/store';
 import type { ActivitiesInfo } from '@mezon/utils';
 import { useCallback, useMemo } from 'react';
 
 export function useActivities() {
 	const dispatch = useAppDispatch();
+	const isActivityTrackingEnabled = useAppSelector(selectIsActivityTrackingEnabled);
+
 	const setUserActivity = useCallback(
 		(info: ActivitiesInfo) => {
+			if (!isActivityTrackingEnabled) return;
 			const body = {
 				activity_description: info?.windowTitle,
 				activity_name: info?.appName,
@@ -16,10 +19,11 @@ export function useActivities() {
 			};
 			dispatch(acitvitiesActions.createActivity(body));
 		},
-		[dispatch]
+		[dispatch, isActivityTrackingEnabled]
 	);
 	const setUserAFK = useCallback(
 		(status: number) => {
+			if (!isActivityTrackingEnabled) return;
 			const body = {
 				activity_name: 'AFK',
 				activity_type: 4,
@@ -27,7 +31,7 @@ export function useActivities() {
 			};
 			dispatch(acitvitiesActions.createActivity(body));
 		},
-		[dispatch]
+		[dispatch, isActivityTrackingEnabled]
 	);
 	return useMemo(
 		() => ({


### PR DESCRIPTION
Test Case 1: Turning OFF Activity Tracking immediately clears current activity

Preconditions: User has "Activity Tracking" enabled and currently has an active status displaying (e.g., playing a game or using an app).
Steps:
Go to Settings -> Activity.
Toggle "Activity Tracking" to OFF.
Expected Result:
The user's active status should immediately disappear and be cleared for all other users.
Test Case 2: No new activities are sent while Activity Tracking is OFF

Preconditions: "Activity Tracking" is toggled OFF.
Steps:
Open a new application or switch windows (actions that usually trigger activity tracking).
Trigger AFK mode by being idle for the required duration.
Expected Result:
No activity tracking API requests (createActivity) should be sent to the server.
Other users should not see any activity or AFK status under your profile.
Test Case 3: Turning ON Activity Tracking resumes activity updates

Preconditions: "Activity Tracking" is toggled OFF.
Steps:
Go to Settings -> Activity.
Toggle "Activity Tracking" to ON.
Open a new application or switch windows.
Expected Result:
Activity tracking API requests are successfully sent to the server.
Other users can now see your current active status.
Test Case 4: Activity Tracking state persists across reloads

Preconditions: User is logged into the Mezon app.
Steps:
Go to Settings -> Activity and toggle "Activity Tracking" OFF.
Reload the page (F5) or restart the application.
Go back to Settings -> Activity and check the toggle.
Repeat steps 1-3, but toggle "Activity Tracking" ON.
Expected Result:
The toggle should accurately retain its state (either OFF or ON) after the reload.