### PR TITLE
260710-WEB/DESKTOP-fix(onboarding): handle empty array on save and fix fast refresh error

### DIFF
--- a/libs/components/src/lib/components.tsx
+++ b/libs/components/src/lib/components.tsx
@@ -108,7 +108,6 @@ export { default as AgeRestricted } from './components/AgeRestricted';
 export { default as BuzzBadge } from './components/BuzzBadge';
 export { default as Canvas } from './components/Canvas';
 export { default as GuideItemLayout } from './components/ClanSettings/SettingOnBoarding/GuideItemLayout';
-export * from './components/ClanSettings/SettingOnBoarding/ModalControlRule';
 export { default as DmCalling } from './components/DmCalling';
 export { default as EventSchedule } from './components/EventSchedule';
 export { default as ModalCall } from './components/ModalCall';

--- a/libs/components/src/lib/components/ClanSettings/SettingOnBoarding/index.tsx
+++ b/libs/components/src/lib/components/ClanSettings/SettingOnBoarding/index.tsx
@@ -77,7 +77,7 @@ const SettingOnBoarding = ({ onClose }: { onClose?: () => void }) => {
 				formOnboarding.greeting !== null;
 
 			if (hasNewData) {
-				await handleCreateOnboarding();
+				await handleCreateOnboarding(true);
 			}
 
 			await dispatch(
@@ -85,7 +85,7 @@ const SettingOnBoarding = ({ onClose }: { onClose?: () => void }) => {
 					clan_id: currentClanId as string,
 					onboarding: true
 				})
-			);
+			).unwrap();
 			setIsCommunityEnabled(true);
 			setIsModalOpen(false);
 			setInitialDescription(description);
@@ -106,7 +106,7 @@ const SettingOnBoarding = ({ onClose }: { onClose?: () => void }) => {
 	const onboardingByClan = useAppSelector((state) => selectOnboardingByClan(state, currentClanId as string));
 	const { sessionRef, clientRef } = useMezon();
 
-	const handleCreateOnboarding = async () => {
+	const handleCreateOnboarding = async (throwOnError = false) => {
 		setIsSaving(true);
 		try {
 			const uploadImageRule = formOnboarding.rules.map((item) => {
@@ -140,12 +140,14 @@ const SettingOnBoarding = ({ onClose }: { onClose?: () => void }) => {
 				formOnboardingData.unshift(formOnboarding.greeting);
 			}
 
-			await dispatch(
-				onboardingActions.createOnboardingTask({
-					clan_id: currentClanId as string,
-					content: formOnboardingData
-				})
-			);
+			if (formOnboardingData.length > 0) {
+				await dispatch(
+					onboardingActions.createOnboardingTask({
+						clan_id: currentClanId as string,
+						content: formOnboardingData
+					})
+				).unwrap();
+			}
 
 			setInitialDescription(description);
 			setInitialAbout(about);
@@ -154,6 +156,7 @@ const SettingOnBoarding = ({ onClose }: { onClose?: () => void }) => {
 		} catch (error) {
 			console.error('Error saving changes:', error);
 			toast.error(t('errors.failedToSaveChanges'));
+			if (throwOnError) throw error;
 		} finally {
 			setIsSaving(false);
 		}


### PR DESCRIPTION
Bug: 
<img width="1242" height="865" alt="image" src="https://github.com/user-attachments/assets/ff73fb71-aaca-4e70-b6c3-50da3bfe3f30" />
Expect :
<img width="1887" height="965" alt="image" src="https://github.com/user-attachments/assets/ef75240d-1e00-4165-87eb-1c9f149a38c2" />


Test Case 1: Global Save Empty Array Bug (Core Issue)
-Purpose: Ensure that clicking the global "Save Changes" button without creating any NEW rules doesn't trigger a 400 Bad Request or the invasive error modal.

-Steps to reproduce:
Go to the "Setting Onboarding" screen.
Click Edit on an EXISTING Rule or Mission that is already saved on the server.
Modify its content and click Save inside that specific sub-modal.
Once the global "Save Changes" bar appears at the bottom of the screen, click the Save Changes button on it.
-Expected Results:
The save button shows a loading spinner briefly, then completes successfully.
A green toast appears: "Changes saved successfully".
The global error popup "We encountered an issue while trying to access this content" does NOT appear.

Test Case 2: Accurate Local Error Handling on Genuine API Failure
-Purpose: Ensure that a genuine API failure will correctly trigger the local catch block and won't display a fake "Success" toast.
-Steps to reproduce:
In the Setting Onboarding screen, click Add to create 1 completely NEW Rule or Mission.
Disconnect your internet (or toggle Chrome DevTools Network to Offline) to simulate a real API failure.
Click Save Changes on the global bar at the bottom.
-Expected Results:
The Save button spins and then stops.
A red error toast appears (e.g., "Failed to save changes").
A false "Changes saved successfully" toast does NOT appear.
The global Save Changes bar remains visible so the user can try again once the network is restored.