### PR TITLE
revert(chat): restore pre-#13490 reconnect flow for verification

### DIFF
--- a/apps/chat/src/app/layouts/MainLayout.tsx
+++ b/apps/chat/src/app/layouts/MainLayout.tsx
@@ -23,14 +23,11 @@ import { selectTotalUnreadDM, useAppSelector } from '@mezon/store';
 import { MezonSuspense } from '@mezon/transport';
 import { SubPanelName } from '@mezon/utils';
 
-import { memo, useCallback, useContext, useEffect, useMemo, useRef } from 'react';
+import { memo, useContext, useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Outlet } from 'react-router-dom';
 import ChannelVoice from '../pages/channel/ChannelVoice';
 import { getMainLayoutClassName } from './desktopWindowChrome';
-
-const RECONNECT_SETTLE_MS = 750;
-const RECONNECT_FULL_REFRESH_DELAY_MS = 3000;
 
 const GlobalEventListener = () => {
 	const { handleReconnect } = useContext(ChatContext);
@@ -52,34 +49,12 @@ const GlobalEventListener = () => {
 		debouncedScheduleMs: 3000
 	});
 
-	const reconnectTimersRef = useRef<{ settle?: number; full?: number }>({});
-
-	const clearReconnectTimers = useCallback(() => {
-		const timers = reconnectTimersRef.current;
-		if (timers.settle !== undefined) {
-			window.clearTimeout(timers.settle);
-			timers.settle = undefined;
-		}
-		if (timers.full !== undefined) {
-			window.clearTimeout(timers.full);
-			timers.full = undefined;
-		}
-	}, []);
-
 	const handleReconnectSuccess = useMemo(
 		() =>
 			throttle(() => {
-				clearReconnectTimers();
-				reconnectTimersRef.current.settle = window.setTimeout(() => {
-					reconnectTimersRef.current.settle = undefined;
-					dispatch(appActions.reconnectSync());
-					reconnectTimersRef.current.full = window.setTimeout(() => {
-						reconnectTimersRef.current.full = undefined;
-						dispatch(appActions.refreshApp({ skipReconnectWarmup: true }));
-					}, RECONNECT_FULL_REFRESH_DELAY_MS);
-				}, RECONNECT_SETTLE_MS);
+				dispatch(appActions.refreshApp());
 			}, 2000),
-		[dispatch, clearReconnectTimers]
+		[dispatch]
 	);
 
 	useEffect(() => {
@@ -99,9 +74,8 @@ const GlobalEventListener = () => {
 		window.addEventListener('mezon:socket-reconnect', handleReconnectSuccess);
 		return () => {
 			window.removeEventListener('mezon:socket-reconnect', handleReconnectSuccess);
-			clearReconnectTimers();
 		};
-	}, [handleReconnectSuccess, clearReconnectTimers]);
+	}, [handleReconnectSuccess]);
 
 	useEffect(() => {
 		let notificationCountAllClan = 0;

--- a/libs/store/src/lib/app/app.slice.ts
+++ b/libs/store/src/lib/app/app.slice.ts
@@ -1,16 +1,16 @@
 import { captureSentryError } from '@mezon/logger';
+import { isElectron } from '@mezon/utils';
 import type { LoadingStatus } from '@mezon/utils';
-import { checkIsThread, isElectron } from '@mezon/utils';
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createAsyncThunk, createSelector, createSlice } from '@reduxjs/toolkit';
 import { ChannelType } from 'mezon-js';
 import { badgeService } from '../badge/badgeService';
 import { clearApiCallTracker } from '../cache-metadata';
 import { listChannelsByUserActions } from '../channels/channelUser.slice';
-import { channelsActions, selectChannelById, type ChannelsEntity } from '../channels/channels.slice';
+import { channelsActions } from '../channels/channels.slice';
 import { usersClanActions } from '../clanMembers/clan.members';
 import { clansActions } from '../clans/clans.slice';
-import { directActions, selectDirectById } from '../direct/direct.slice';
+import { directActions } from '../direct/direct.slice';
 import { createCachedSelector, messagesActions } from '../messages/messages.slice';
 import type { RootState } from '../store';
 import { voiceActions } from '../voice/voice.slice';
@@ -55,114 +55,6 @@ const canRefreshApp = (): { allowed: boolean; reason?: string } => {
 const trackRefreshAttempt = () => {
 	refreshAttempts.push(Date.now());
 };
-
-const RECONNECT_JOIN_STAGGER_MS = 400;
-
-export type RefreshAppPayload = {
-	skipReconnectWarmup?: boolean;
-};
-
-const delay = (ms: number): Promise<void> =>
-	new Promise((resolve) => {
-		if (typeof window === 'undefined') {
-			resolve();
-			return;
-		}
-		window.setTimeout(resolve, ms);
-	});
-
-type ActiveChannelContext = {
-	clanId: string;
-	channelId: string;
-};
-
-type ReconnectSyncThunkApi = {
-	dispatch: (action: unknown) => unknown;
-	getState: () => unknown;
-};
-
-function resolveActiveChannelContext(state: RootState): ActiveChannelContext | null {
-	const path = isElectron() ? window.location.hash : window.location.pathname;
-	const currentClanId = state.clans?.currentClanId;
-	const currentChannelId = state.channels?.byClans[currentClanId as string]?.currentChannelId;
-	const currentDirectId = state.direct?.currentDirectMessageId;
-
-	if (currentChannelId && path.includes(`/${currentChannelId}`)) {
-		return { clanId: currentClanId || '0', channelId: currentChannelId };
-	}
-	if (currentDirectId && path.includes(`/${currentDirectId}`)) {
-		return { clanId: '0', channelId: currentDirectId };
-	}
-	return null;
-}
-
-function dispatchJoinChatForChannel(thunkAPI: ReconnectSyncThunkApi, clanId: string, channelId: string): void {
-	const state = thunkAPI.getState() as RootState;
-	const channel = selectChannelById(state, channelId) || (selectDirectById(state, channelId) as ChannelsEntity | null | undefined);
-	if (!channel) {
-		return;
-	}
-
-	const resolvedClanId = channel.clan_id ?? clanId;
-	const resolvedChannelId = channel.channel_id ?? channelId;
-	const channelType = channel.type ?? ChannelType.CHANNEL_TYPE_CHANNEL;
-	const isDirect = channelType === ChannelType.CHANNEL_TYPE_DM || channelType === ChannelType.CHANNEL_TYPE_GROUP;
-	const isPublic = !isDirect && !checkIsThread(channel as ChannelsEntity) && !channel.channel_private;
-
-	thunkAPI.dispatch(
-		channelsActions.joinChat({
-			clanId: resolvedClanId,
-			channelId: resolvedChannelId,
-			channelType,
-			isPublic
-		})
-	);
-}
-
-async function syncActiveChannelAfterReconnect(thunkAPI: ReconnectSyncThunkApi, state: RootState): Promise<void> {
-	const activeChannel = resolveActiveChannelContext(state);
-	if (!activeChannel) {
-		return;
-	}
-
-	const { clanId, channelId } = activeChannel;
-
-	await thunkAPI.dispatch(
-		messagesActions.fetchMessages({
-			clanId,
-			channelId,
-			isFetchingLatestMessages: true,
-			isClearMessage: true,
-			noCache: true
-		})
-	);
-
-	dispatchJoinChatForChannel(thunkAPI, clanId, channelId);
-}
-
-async function dispatchStaggeredJoinClans(thunkAPI: ReconnectSyncThunkApi, currentClanId: string | null | undefined): Promise<void> {
-	await delay(RECONNECT_JOIN_STAGGER_MS);
-	thunkAPI.dispatch(clansActions.joinClan({ clanId: '0' }));
-
-	if (currentClanId && currentClanId !== '0') {
-		await delay(RECONNECT_JOIN_STAGGER_MS);
-		thunkAPI.dispatch(clansActions.joinClan({ clanId: currentClanId }));
-	}
-}
-
-async function syncMinimalAfterReconnect(thunkAPI: ReconnectSyncThunkApi, state: RootState): Promise<void> {
-	clearApiCallTracker();
-	thunkAPI.dispatch(clansActions.clearJoinList());
-	await syncActiveChannelAfterReconnect(thunkAPI, state);
-
-	const currentClanId = state.clans?.currentClanId;
-	await dispatchStaggeredJoinClans(thunkAPI, currentClanId);
-
-	badgeService.onReconnect();
-	if (currentClanId && currentClanId !== '0') {
-		badgeService.syncClanBadge(currentClanId);
-	}
-}
 
 export interface showSettingFooterProps {
 	status: boolean;
@@ -262,58 +154,54 @@ export const initialAppState: AppState = {
 	autoHidden: false
 };
 
-export const reconnectSync = createAsyncThunk('app/reconnectSync', async (_, thunkAPI) => {
-	const state = thunkAPI.getState() as RootState;
-
-	if (!state) {
-		throw Error('reconnect sync error: state does not init');
-	}
-
-	try {
-		await syncMinimalAfterReconnect(thunkAPI, state);
-	} catch (error) {
-		captureSentryError(error, 'app/reconnectSync');
-		return thunkAPI.rejectWithValue(error);
-	}
-});
-
-export const refreshApp = createAsyncThunk('app/refreshApp', async (payload: RefreshAppPayload | undefined, thunkAPI) => {
-	const state = thunkAPI.getState() as RootState;
-
-	if (!state) {
-		throw Error('refresh app error: state does not init');
-	}
-
-	const skipReconnectWarmup = payload?.skipReconnectWarmup ?? false;
-
+export const refreshApp = createAsyncThunk('app/refreshApp', async (_, thunkAPI) => {
 	const { allowed, reason } = canRefreshApp();
 
 	if (!allowed) {
 		console.warn('[refreshApp] Rate limited:', reason);
-		if (!skipReconnectWarmup) {
-			try {
-				await syncMinimalAfterReconnect(thunkAPI, state);
-			} catch (error) {
-				captureSentryError(error, 'app/refreshApp/minimal');
-			}
-		}
 		return thunkAPI.rejectWithValue({ rateLimited: true, reason });
 	}
 
 	trackRefreshAttempt();
 
 	try {
+		const state = thunkAPI.getState() as RootState;
+
+		if (!state) {
+			throw Error('refresh app error: state does not init');
+		}
+
 		clearApiCallTracker();
 
 		const isClanView = state?.clans?.currentClanId && state.clans.currentClanId !== '0';
+		const currentChannelId = state.channels?.byClans[state.clans?.currentClanId as string]?.currentChannelId;
+		const currentDirectId = state.direct?.currentDirectMessageId;
 		const currentClanId = state.clans?.currentClanId;
+		const path = isElectron() ? window.location.hash : window.location.pathname;
 
-		if (!skipReconnectWarmup) {
-			thunkAPI.dispatch(clansActions.clearJoinList());
-			await syncActiveChannelAfterReconnect(thunkAPI, state);
-			await dispatchStaggeredJoinClans(thunkAPI, currentClanId);
+		let channelId = null;
+		let clanId = null;
+		if (currentChannelId && path.includes('/' + currentChannelId)) {
+			clanId = currentClanId;
+			channelId = currentChannelId;
+		} else if (currentDirectId && path.includes('/' + currentDirectId)) {
+			clanId = '0';
+			channelId = currentDirectId;
 		}
+		thunkAPI.dispatch(clansActions.clearJoinList());
 
+		channelId &&
+			thunkAPI.dispatch(
+				messagesActions.fetchMessages({
+					clanId: clanId || '',
+					channelId,
+					isFetchingLatestMessages: true,
+					isClearMessage: true,
+					noCache: true
+				})
+			);
+
+		thunkAPI.dispatch(clansActions.joinClan({ clanId: '0' }));
 		const fetchClansPromise = thunkAPI.dispatch(clansActions.fetchClans({}));
 		thunkAPI.dispatch(listChannelsByUserActions.fetchListChannelsByUser({}));
 
@@ -321,6 +209,7 @@ export const refreshApp = createAsyncThunk('app/refreshApp', async (payload: Ref
 		if (isClanView && currentClanId) {
 			thunkAPI.dispatch(usersClanActions.fetchUsersClan({ clanId: currentClanId }));
 			fetchChannelsPromise = thunkAPI.dispatch(channelsActions.fetchChannels({ clanId: currentClanId, noCache: true }));
+			thunkAPI.dispatch(clansActions.joinClan({ clanId: currentClanId }));
 			thunkAPI.dispatch(
 				voiceActions.fetchVoiceChannelMembers({
 					clanId: currentClanId ?? '',
@@ -335,11 +224,9 @@ export const refreshApp = createAsyncThunk('app/refreshApp', async (payload: Ref
 		const settledPromises = [fetchClansPromise, fetchChannelsPromise].filter(Boolean);
 		await Promise.allSettled(settledPromises);
 
-		if (!skipReconnectWarmup) {
-			badgeService.onReconnect();
-			if (currentClanId && currentClanId !== '0') {
-				badgeService.syncClanBadge(currentClanId);
-			}
+		badgeService.onReconnect();
+		if (currentClanId && currentClanId !== '0') {
+			badgeService.syncClanBadge(currentClanId);
 		}
 	} catch (error) {
 		captureSentryError(error, 'app/refreshApp');
@@ -567,7 +454,7 @@ export const appSlice = createSlice({
  */
 export const appReducer = appSlice.reducer;
 
-export const appActions = { ...appSlice.actions, reconnectSync, refreshApp };
+export const appActions = { ...appSlice.actions, refreshApp };
 
 export const getAppState = (rootState: { [APP_FEATURE_KEY]: AppState }): AppState => rootState[APP_FEATURE_KEY];
 


### PR DESCRIPTION
## Summary
Temporary revert of #13490 reconnect changes to verify root cause of missing/stuck realtime messages after reconnect.

Reverts:
- deferred `reconnectSync` (+750ms) / deferred `refreshApp` (+3750ms)
- staggered `joinClan` WS commands
- `skipReconnectWarmup` split refresh path

Restores:
- immediate `refreshApp()` on socket reconnect
- fire-and-forget `fetchMessages` inside `refreshApp` for active channel

## Context
Investigation suggests missing UI messages may come from existing `addNewMessage` viewport guards, while #13490 mainly changes reconnect timing and makes the issue easier to reproduce. This PR is for A/B verification only.

## Test plan
- [ ] Reconnect while viewing active channel → messages refetch immediately
- [ ] WS message while on another channel → return to channel → message visible?
- [ ] Compare with #13490 behavior for disconnect loop regression
- [ ] Document whether message bug persists without #13490 timing changes

## Follow-up
If bug persists after revert → fix `addNewMessage` / viewport heal (not reconnect timing).
If bug disappears → follow-up PR to keep #13490 stagger/delay and add message/viewport fixes.

Made with [Cursor](https://cursor.com)