### PR TITLE
260812 - WEB - Fix hidden channel typing on mobile devices

### DIFF
--- a/apps/chat/src/app/pages/channel/ChannelTyping.tsx
+++ b/apps/chat/src/app/pages/channel/ChannelTyping.tsx
@@ -13,7 +13,7 @@ type ChannelTypingProps = {
 export function ChannelTyping({ channelId }: ChannelTypingProps) {
 	const { t } = useTranslation('common');
 	const typingUsers = useTypingUsersByChannel(channelId);
-	const boxWidthClass = 'w-full min-[480px]:max-w-wrappBoxChatView';
+	const boxWidthClass = 'w-full sbm:max-w-wrappBoxChatView';
 
 	const typingLabel = useMemo(() => {
 		if (typingUsers.length === 1) {

--- a/apps/chat/src/app/pages/channel/ChannelTyping.tsx
+++ b/apps/chat/src/app/pages/channel/ChannelTyping.tsx
@@ -1,4 +1,4 @@
-import { selectCloseMenu, selectStatusMenu, useAppSelector, useTypingUsersByChannel } from '@mezon/store';
+import { useTypingUsersByChannel } from '@mezon/store';
 import { Icons } from '@mezon/ui';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -10,19 +10,17 @@ type ChannelTypingProps = {
 	isDM?: boolean;
 };
 
-export function ChannelTyping({ channelId, mode, isPublic, isDM }: ChannelTypingProps) {
+export function ChannelTyping({ channelId }: ChannelTypingProps) {
 	const { t } = useTranslation('common');
 	const typingUsers = useTypingUsersByChannel(channelId);
-	const boxWidthClass = 'w-full max-w-wrappBoxChatView';
+	const boxWidthClass = 'w-full min-[480px]:max-w-wrappBoxChatView';
 
 	const typingLabel = useMemo(() => {
 		if (typingUsers.length === 1) {
 			return (
 				<>
 					<Icons.IconLoadingTyping className="shrink-0" width={20} height={10} aria-hidden />
-					<span className="min-w-0 text-theme-primary-active font-semibold mr-[2px] truncate">
-						{typingUsers[0].typingName}
-					</span>
+					<span className="min-w-0 text-theme-primary-active font-semibold mr-[2px] truncate">{typingUsers[0].typingName}</span>
 					<span className="shrink-0 text-theme-primary">{t('isTyping')}</span>
 				</>
 			);


### PR DESCRIPTION
## Cause
There is a macro `max-w-wrappBoxChatView` to calculate the width of chatbox by `viewport width - sidebar width`, but below 480px the sidebar no longer appears.

## Solution
Add `min-[480px]:` before `max-w-wrappBoxChatView` to get full viewport in mobile web.

## Tests

### Channel/Thread scope case
<img width="1920" height="882" alt="image" src="https://github.com/user-attachments/assets/7c4307d9-deea-4cab-ae9a-40508b6a1f8e" />

### DM scope case
<img width="1915" height="888" alt="image" src="https://github.com/user-attachments/assets/cd626dab-5527-4c5f-a4c8-c4f400ae8a69" />
