### PR TITLE
20260813 - WEB - Fix anonymous attachment send losing images

### DIFF
--- a/libs/store/src/lib/messages/messages.slice.ts
+++ b/libs/store/src/lib/messages/messages.slice.ts
@@ -1341,7 +1341,11 @@ export const sendMessage = createAsyncThunk('messages/sendMessage', async (paylo
 			};
 		}
 		const needUpload = attachments?.some((attachment) => attachment?.uploadPath);
-		if (needUpload) {
+		// The presign_finish patch rides on updateChannelMessage, which carries no
+		// anonymity flag, so the server rejects it for a message owned by the
+		// anonymous account. Anonymous sends upload first and post once instead.
+		const usePresignFirst = Boolean(needUpload) && !anonymous;
+		if (usePresignFirst) {
 			content = {
 				...content,
 				presign_finish: []
@@ -1389,6 +1393,18 @@ export const sendMessage = createAsyncThunk('messages/sendMessage', async (paylo
 
 		try {
 			thunkAPI.dispatch(messagesActions.markAsSent({ id, mess: fakeMess }));
+
+			if (needUpload && !usePresignFirst && attachments) {
+				await thunkAPI.dispatch(handleUploadFileToMinIO(attachments)).unwrap();
+				thunkAPI.dispatch(
+					messagesActions.updateSendingMessageAttachments({
+						channelId: channelId as string,
+						messageId: id,
+						attachments: toPublicMessageAttachments(attachments)
+					})
+				);
+			}
+
 			const SEND_TIMEOUT_MS = 30_000;
 			let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
@@ -1436,7 +1452,7 @@ export const sendMessage = createAsyncThunk('messages/sendMessage', async (paylo
 				);
 			}
 
-			if (attachments && attachments.length > 0 && messageResult?.message_id && needUpload) {
+			if (attachments && attachments.length > 0 && messageResult?.message_id && usePresignFirst) {
 				try {
 					const presign_finish = await thunkAPI.dispatch(handleUploadFileToMinIO(attachments)).unwrap();
 


### PR DESCRIPTION
Sending an attachment while anonymous mode is on leaves the image stuck on a
loading placeholder for everyone: the file uploads fine, but the message never
learns about it.

## Cause

`sendMessage` posts the message first with an empty `presign_finish`, uploads the
files, then patches the keys in through `editMessageViaApi` →
`updateChannelMessage`. That request carries no anonymity flag, so the server
sees the signed-in user editing a message owned by the anonymous account and
rejects it. The keys are never recorded, and recipients keep the placeholder
until the 10-minute presign expiry hides it.

## Fix

Anonymous sends skip presign-first: upload every file, then post the message once
with no `presign_finish` at all — so no `updateChannelMessage` is issued. This is
what the Android client already does for small batches.

- `usePresignFirst = needUpload && !anonymous` gates both the empty
  `presign_finish` on the outgoing content and the post-send patch.
- When anonymous, `handleUploadFileToMinIO` runs before the send, and
  `updateSendingMessageAttachments` still swaps the local previews for the real
  URLs.

Non-anonymous sends are untouched — same order, same patch, same batching.

## Trade-off

Anonymous messages now appear after the upload finishes instead of immediately.
That is the cost of not being able to patch the message afterwards; the
alternative is the image never showing at all.

## Related

Same defect and same fix on the desktop client: mezonai/mezon-desktop#320, where
it was reproduced end to end (server answered `code=13` on every anonymous
attachment send, and the fix was verified against the real backend).
