### PR TITLE
260813 - WEB - Fix responsive problem on mobile web

### DIFF
--- a/libs/components/src/lib/components/ChannelTopbar/index.tsx
+++ b/libs/components/src/lib/components/ChannelTopbar/index.tsx
@@ -114,7 +114,7 @@ const ChannelTopbar = memo(() => {
 	return (
 		<div
 			onMouseDown={onMouseDownTopbar}
-			className={`max-sbm:z-20 flex h-heightTopBar min-w-0 w-full items-center justify-between  flex-shrink   ${closeMenu && 'fixed top-0 w-screen'} ${closeMenu && statusMenu ? 'left-[100vw]' : 'left-0'}`}
+			className={`max-sbm:z-20 flex h-heightTopBar min-w-0 w-full items-center justify-between flex-shrink ${closeMenu && 'fixed top-0 w-screen'} ${closeMenu && statusMenu ? 'left-[100vw]' : 'left-0'}`}
 		>
 			<TopBarChannelText />
 		</div>
@@ -210,6 +210,12 @@ const TopBarChannelText = memo(() => {
 	const userStatus = useMemberStatus(currentDmGroup?.user_ids?.[0] || '');
 	const checkInvoice = useSelector((state) => selectStatusInVoice(state, currentDmGroup?.user_ids?.[0] || ''));
 
+	const handleOpenMenu = () => {
+		openMenu();
+		dispatch(appActions.setIsShowMemberList(false));
+		dispatch(appActions.setIsUseProfileDM(false));
+	};
+
 	const handleJoinVoice = () => {
 		if (!checkInvoice || currentDmGroup?.type === ChannelType.CHANNEL_TYPE_GROUP) {
 			return;
@@ -217,45 +223,44 @@ const TopBarChannelText = memo(() => {
 		const link = toChannelPage(checkInvoice.channelId, checkInvoice.clanId);
 		navigate(link);
 	};
+
 	return (
 		<>
-			<div className="flex relative flex-1 min-w-0 items-center gap-2  text-theme-primary mr-5">
-				<div className="flex sbm:hidden pl-3 px-2 text-[var(--bg-icon-theme)]" onClick={openMenu} role="button">
+			<div className="flex relative flex-1 min-w-0 items-center gap-2 text-theme-primary mr-5">
+				<div className="flex w-10 sbm:hidden pl-3 px-2 text-[var(--bg-icon-theme)]" onClick={handleOpenMenu} role="button">
 					<Icons.OpenMenu />
 				</div>
 
 				{pagePathTitle ? (
 					<p className="text-base font-semibold truncate max-sbm:max-w-[180px]">{pagePathTitle}</p>
 				) : (
-					<>
-						{!!channelType && (
-							<>
-								{channelParent && (
-									<div className="flex gap-1 items-center truncate max-sbm:hidden cursor-pointer" onClick={handleNavigateToParent}>
-										<ChannelTopbarLabel
-											isPrivate={!!channelParent?.channel_private}
-											isAgeRestricted={channelParent?.age_restricted === 1}
-											label={channelParent?.channel_label || ''}
-											type={channelParent?.type || ChannelType.CHANNEL_TYPE_CHANNEL}
-										/>
-										<Icons.ArrowRight />
-									</div>
-								)}
-								<ChannelTopbarLabel
-									isPrivate={!!channelPrivate}
-									isAgeRestricted={channelAgeRestricted === 1}
-									label={channelLabel || ''}
-									type={channelType || ChannelType.CHANNEL_TYPE_CHANNEL}
-									onClick={handleCloseCanvas}
-								/>
-							</>
-						)}
-					</>
+					!!channelType && (
+						<>
+							{channelParent && (
+								<div className="flex gap-1 items-center truncate max-sbm:hidden cursor-pointer" onClick={handleNavigateToParent}>
+									<ChannelTopbarLabel
+										isPrivate={!!channelParent?.channel_private}
+										isAgeRestricted={channelParent?.age_restricted === 1}
+										label={channelParent?.channel_label || ''}
+										type={channelParent?.type || ChannelType.CHANNEL_TYPE_CHANNEL}
+									/>
+									<Icons.ArrowRight />
+								</div>
+							)}
+							<ChannelTopbarLabel
+								isPrivate={!!channelPrivate}
+								isAgeRestricted={channelAgeRestricted === 1}
+								label={channelLabel || ''}
+								type={channelType || ChannelType.CHANNEL_TYPE_CHANNEL}
+								onClick={handleCloseCanvas}
+							/>
+						</>
+					)
 				)}
 
 				{currentClanId === '0' && (
 					<div
-						className=" h-9 flex items-center gap-3 flex-1 overflow-hidden relative"
+						className="h-9 flex items-center gap-3 flex-1 overflow-hidden relative"
 						data-e2e={generateE2eId(`chat.direct_message.header.left_container`)}
 					>
 						<DmTopbarAvatar
@@ -320,21 +325,18 @@ const TopBarChannelText = memo(() => {
 				)}
 			</div>
 			<div className="flex items-center gap-2 sm:gap-4 flex-shrink-0">
-				{!pagePathTitle && (
-					<>
-						{channelType ? (
-							<ChannelTopbarTools
-								isPagePath={!!isMemberPath || !!isChannelPath}
-								isStream={channelType === ChannelType.CHANNEL_TYPE_STREAMING}
-								isVoice={channelType === ChannelType.CHANNEL_TYPE_MEZON_VOICE}
-								isApp={channelType === ChannelType.CHANNEL_TYPE_APP}
-								isThread={!!(channelParentId !== '0' && channelParentId)}
-							/>
-						) : (
-							<DmTopbarTools />
-						)}
-					</>
-				)}
+				{!pagePathTitle &&
+					(channelType ? (
+						<ChannelTopbarTools
+							isPagePath={!!isMemberPath || !!isChannelPath}
+							isStream={channelType === ChannelType.CHANNEL_TYPE_STREAMING}
+							isVoice={channelType === ChannelType.CHANNEL_TYPE_MEZON_VOICE}
+							isApp={channelType === ChannelType.CHANNEL_TYPE_APP}
+							isThread={!!(channelParentId !== '0' && channelParentId)}
+						/>
+					) : (
+						<DmTopbarTools />
+					))}
 
 				{!isMemberPath && !isChannelPath && channelType !== ChannelType.CHANNEL_TYPE_STREAMING && (
 					<SearchMessageChannel mode={channelType ? ChannelStreamMode.STREAM_MODE_CHANNEL : ChannelStreamMode.STREAM_MODE_DM} />

--- a/libs/components/src/lib/components/ChannelTopbar/index.tsx
+++ b/libs/components/src/lib/components/ChannelTopbar/index.tsx
@@ -138,18 +138,24 @@ const TopBarChannelText = memo(() => {
 		isGuidePath: guidePath
 	});
 	const channelParent = useAppSelector((state) => selectChannelById(state, (channelParentId ? (channelParentId as string) : '') ?? '')) || null;
+
+	const navigate = useCustomNavigate();
+	const dispatch = useAppDispatch();
+
 	const { setStatusMenu } = useMenu();
+
 	const openMenu = useCallback(() => {
 		setStatusMenu(true);
-	}, [setStatusMenu]);
+		dispatch(appActions.setIsShowMemberList(false));
+		dispatch(appActions.setIsUseProfileDM(false));
+	}, [setStatusMenu, dispatch]);
+
 	const closeMenu = useCallback(() => {
 		const isMobile = window.innerWidth < 640;
 		if (isMobile) {
 			setStatusMenu(false);
 		}
 	}, [setStatusMenu]);
-	const navigate = useCustomNavigate();
-	const dispatch = useAppDispatch();
 
 	const handleNavigateToParent = () => {
 		if (!channelParent?.id || !channelParent?.clan_id) {
@@ -210,12 +216,6 @@ const TopBarChannelText = memo(() => {
 	const userStatus = useMemberStatus(currentDmGroup?.user_ids?.[0] || '');
 	const checkInvoice = useSelector((state) => selectStatusInVoice(state, currentDmGroup?.user_ids?.[0] || ''));
 
-	const handleOpenMenu = () => {
-		openMenu();
-		dispatch(appActions.setIsShowMemberList(false));
-		dispatch(appActions.setIsUseProfileDM(false));
-	};
-
 	const handleJoinVoice = () => {
 		if (!checkInvoice || currentDmGroup?.type === ChannelType.CHANNEL_TYPE_GROUP) {
 			return;
@@ -227,7 +227,7 @@ const TopBarChannelText = memo(() => {
 	return (
 		<>
 			<div className="flex relative flex-1 min-w-0 items-center gap-2 text-theme-primary mr-5">
-				<div className="flex w-10 sbm:hidden pl-3 px-2 text-[var(--bg-icon-theme)]" onClick={handleOpenMenu} role="button">
+				<div className="flex w-10 sbm:hidden pl-3 px-2 text-[var(--bg-icon-theme)]" onClick={openMenu} role="button">
 					<Icons.OpenMenu />
 				</div>
 

--- a/libs/components/src/lib/components/ChatWelcome/OnBoardWelcome.tsx
+++ b/libs/components/src/lib/components/ChatWelcome/OnBoardWelcome.tsx
@@ -102,7 +102,7 @@ const Onboarditem = memo(({ icon, title, tick, onClick }: { icon: ReactNode; tit
 	};
 	return (
 		<div
-			className="w-[400px] gap-4 h-[72px] items-center flex p-4 text-sm font-semibold text-theme-primary-active text-theme-primary-hover bg-item-hover bg-item-theme rounded-lg hover:cursor-pointer"
+			className="w-full sbm:w-[400px] gap-4 h-[72px] items-center flex p-4 text-sm font-semibold text-theme-primary-active text-theme-primary-hover bg-item-hover bg-item-theme rounded-lg hover:cursor-pointer"
 			onClick={handleOnClickItem}
 			data-e2e={generateE2eId('onboarding.chat.guide_sections')}
 		>


### PR DESCRIPTION
## What's happening
-There's no back to menu button on mobile web's chat UI.
-States of opening profile and list member is not reset to false on opening a channel/thread/DM that leads to immediate jump to profile or list member tab.
-Channel welcome/onboarding block on mobile app is overflowing due to hardcoded w-[400px].

## Fixes
Fixed the problems listed above.

## Tests
This video contains tests for all above bugs.

https://github.com/user-attachments/assets/35932a63-631c-4c13-8908-05f37e8aa533

