### PR TITLE
260814 - WEB - Fix pagination not working problem in clan channel setting

### DIFF
--- a/libs/store/src/lib/clans/clanSettingChannel.slice.ts
+++ b/libs/store/src/lib/clans/clanSettingChannel.slice.ts
@@ -13,6 +13,13 @@ import type { RootState } from '../store';
 
 export const SETTING_CLAN_CHANNEL = 'settingClanChannel';
 
+interface CachedChannelSettingData {
+	channel_setting_list: ApiChannelSettingItem[];
+	channel_count: number;
+	thread_count: number;
+	metadata?: CacheMetadata;
+}
+
 export interface SettingClanChannelState extends EntityState<ApiChannelSettingItem, string> {
 	loadingStatus: LoadingStatus;
 	error?: string | null;
@@ -21,7 +28,7 @@ export interface SettingClanChannelState extends EntityState<ApiChannelSettingIt
 	threadsByChannel: Record<string, ApiChannelSettingItem[]>;
 	listSearchChannel: ApiChannelSettingItem[];
 	listArchivedChannel: ApiChannelDescription[];
-	cache?: CacheMetadata;
+	cache: Record<string, CachedChannelSettingData>;
 }
 
 export const channelSettingAdapter = createEntityAdapter({
@@ -38,7 +45,8 @@ export const initialSettingClanChannelState: SettingClanChannelState = channelSe
 	threadCount: 0,
 	threadsByChannel: {},
 	listSearchChannel: [],
-	listArchivedChannel: []
+	listArchivedChannel: [],
+	cache: {}
 });
 
 const resetSettingClanChannelState = (state: SettingClanChannelState) => {
@@ -50,7 +58,7 @@ const resetSettingClanChannelState = (state: SettingClanChannelState) => {
 	state.threadsByChannel = {};
 	state.listSearchChannel = [];
 	state.listArchivedChannel = [];
-	state.cache = undefined;
+	state.cache = {};
 };
 
 export enum ETypeFetchChannelSetting {
@@ -74,20 +82,21 @@ export const fetchChannelSettingInClanCached = async (
 	const channelSettingState = currentState[SETTING_CLAN_CHANNEL];
 	const apiKey = createApiKey('fetchChannelSettingInClan', clanId, parentId, page, limit, channel_label);
 
-	const shouldForceCall = shouldForceApiCall(apiKey, channelSettingState.cache, noCache);
+	if (channelSettingState.cache?.[apiKey]) {
+		const cacheForKey = channelSettingState.cache?.[apiKey].metadata;
+		const shouldForceCall = shouldForceApiCall(apiKey, cacheForKey, noCache);
 
-	if (!shouldForceCall) {
-		const cachedList =
-			parentId && parentId !== '0' ? channelSettingState.threadsByChannel[parentId] : Object.values(channelSettingState.entities);
+		if (!shouldForceCall) {
+			const cachedData = channelSettingState.cache?.[apiKey];
 
-		if (cachedList) {
-			return {
-				channel_setting_list: cachedList,
-				channel_count: channelSettingState.channelCount,
-				thread_count: channelSettingState.threadCount,
-				fromCache: true,
-				time: channelSettingState.cache?.lastFetched || Date.now()
-			};
+			if (cachedData) {
+				return {
+					...cachedData,
+					fromCache: true,
+					apiKey,
+					time: cacheForKey?.lastFetched || Date.now()
+				};
+			}
 		}
 	}
 	const response = await mezon.client.getChannelSettingInClan(
@@ -109,6 +118,7 @@ export const fetchChannelSettingInClanCached = async (
 	return {
 		...response,
 		fromCache: false,
+		apiKey,
 		time: Date.now()
 	};
 };
@@ -137,20 +147,21 @@ export const fetchActiveChannelSettingInClanCached = async (
 	const channelSettingState = currentState[SETTING_CLAN_CHANNEL];
 	const apiKey = createApiKey('fetchActiveChannelSettingInClan', clanId, parentId, page, limit, channel_label);
 
-	const shouldForceCall = shouldForceApiCall(apiKey, channelSettingState.cache, noCache);
+	if (channelSettingState.cache?.[apiKey]) {
+		const cacheForKey = channelSettingState.cache?.[apiKey].metadata;
+		const shouldForceCall = shouldForceApiCall(apiKey, cacheForKey, noCache);
 
-	if (!shouldForceCall) {
-		const cachedList =
-			parentId && parentId !== '0' ? channelSettingState.threadsByChannel[parentId] : Object.values(channelSettingState.entities);
+		if (!shouldForceCall) {
+			const cachedData = channelSettingState.cache?.[apiKey];
 
-		if (cachedList) {
-			return {
-				channel_setting_list: cachedList,
-				channel_count: channelSettingState.channelCount,
-				thread_count: channelSettingState.threadCount,
-				fromCache: true,
-				time: channelSettingState.cache?.lastFetched || Date.now()
-			};
+			if (cachedData) {
+				return {
+					...cachedData,
+					fromCache: true,
+					apiKey,
+					time: cacheForKey?.lastFetched || Date.now()
+				};
+			}
 		}
 	}
 	const response = await mezon.client.getChannelSettingInClan(
@@ -172,6 +183,7 @@ export const fetchActiveChannelSettingInClanCached = async (
 	return {
 		...response,
 		fromCache: false,
+		apiKey,
 		time: Date.now()
 	};
 };
@@ -197,18 +209,12 @@ export const fetchActiveChannelSettingInClan = createAsyncThunk(
 				return thunkAPI.rejectWithValue('Invalid fetchActiveChannelSettingInClan');
 			}
 
-			if (response.fromCache) {
-				return {
-					fromCache: true,
-					parentId,
-					typeFetch
-				};
-			}
-
 			return {
 				parentId,
 				response,
-				typeFetch
+				typeFetch,
+				apiKey: response.apiKey,
+				fromCache: Boolean(response.fromCache)
 			};
 		} catch (error) {
 			captureSentryError(error, 'channelSetting/fetchActiveChannelSettingInClan');
@@ -238,18 +244,12 @@ export const fetchChannelSettingInClan = createAsyncThunk(
 				return thunkAPI.rejectWithValue('Invalid fetchChannelSettingInClan');
 			}
 
-			if (response.fromCache) {
-				return {
-					fromCache: true,
-					parentId,
-					typeFetch
-				};
-			}
-
 			return {
 				parentId,
 				response,
-				typeFetch
+				typeFetch,
+				apiKey: response.apiKey,
+				fromCache: Boolean(response.fromCache)
 			};
 		} catch (error) {
 			captureSentryError(error, 'channelSetting/fetchClanChannelSetting');
@@ -273,6 +273,59 @@ export const fetchArchivedChannelsInClan = createAsyncThunk('channelSetting/fetc
 		return thunkAPI.rejectWithValue(error);
 	}
 });
+
+const applyChannelSettingFulfilled = (
+	state: SettingClanChannelState,
+	payload: {
+		response?: {
+			fromCache: boolean;
+			apiKey: string;
+			time: number;
+			channel_count?: number;
+			channel_setting_list?: Array<ApiChannelSettingItem>;
+			clan_id?: string;
+			thread_count?: number;
+		};
+		typeFetch: ETypeFetchChannelSetting;
+		parentId: string;
+		apiKey?: string;
+		fromCache?: boolean;
+	}
+) => {
+	const { response, typeFetch, parentId, apiKey, fromCache } = payload;
+	if (!response) return;
+
+	state.loadingStatus = 'loaded';
+	const cleanedList = (response.channel_setting_list || []).map(cleanUndefinedFields);
+
+	switch (typeFetch) {
+		case ETypeFetchChannelSetting.FETCH_CHANNEL:
+			channelSettingAdapter.setAll(state, cleanedList);
+			break;
+		case ETypeFetchChannelSetting.MORE_CHANNEL:
+			channelSettingAdapter.upsertMany(state, cleanedList);
+			break;
+		case ETypeFetchChannelSetting.FETCH_THREAD:
+			state.threadsByChannel[parentId] = response.channel_setting_list || [];
+			break;
+		case ETypeFetchChannelSetting.SEARCH_CHANNEL:
+			state.listSearchChannel = response.channel_setting_list || [];
+			break;
+		default:
+			channelSettingAdapter.setAll(state, response.channel_setting_list || []);
+	}
+	state.channelCount = response.channel_count || 0;
+	state.threadCount = response.thread_count || 0;
+
+	if (!fromCache && apiKey) {
+		state.cache[apiKey] = {
+			channel_setting_list: cleanedList,
+			channel_count: response.channel_count || 0,
+			thread_count: response.thread_count || 0
+		};
+		state.cache[apiKey].metadata = createCacheMetadata();
+	}
+};
 
 export const settingClanChannelSlice = createSlice({
 	name: SETTING_CLAN_CHANNEL,
@@ -360,32 +413,7 @@ export const settingClanChannelSlice = createSlice({
 	extraReducers(builder) {
 		builder
 			.addCase(fetchChannelSettingInClan.fulfilled, (state: SettingClanChannelState, actions) => {
-				const { fromCache, response, typeFetch } = actions.payload;
-
-				if (!fromCache && response) {
-					state.loadingStatus = 'loaded';
-					const cleanedList = (response.channel_setting_list || []).map(cleanUndefinedFields);
-					switch (typeFetch) {
-						case ETypeFetchChannelSetting.FETCH_CHANNEL:
-							channelSettingAdapter.setAll(state, cleanedList);
-							break;
-						case ETypeFetchChannelSetting.MORE_CHANNEL:
-							channelSettingAdapter.upsertMany(state, cleanedList);
-							break;
-						case ETypeFetchChannelSetting.FETCH_THREAD:
-							state.threadsByChannel[actions.payload.parentId] = response.channel_setting_list || [];
-							break;
-						case ETypeFetchChannelSetting.SEARCH_CHANNEL:
-							state.listSearchChannel = response.channel_setting_list || [];
-							break;
-						default:
-							channelSettingAdapter.setAll(state, response.channel_setting_list || []);
-					}
-					state.channelCount = response.channel_count || 0;
-					state.threadCount = response.thread_count || 0;
-					state.cache = createCacheMetadata();
-				}
-
+				applyChannelSettingFulfilled(state, actions.payload);
 				state.loadingStatus = 'loaded';
 			})
 			.addCase(fetchChannelSettingInClan.pending, (state: SettingClanChannelState) => {
@@ -411,32 +439,7 @@ export const settingClanChannelSlice = createSlice({
 				state.error = action.error.message;
 			})
 			.addCase(fetchActiveChannelSettingInClan.fulfilled, (state: SettingClanChannelState, actions) => {
-				const { fromCache, response, typeFetch } = actions.payload;
-
-				if (!fromCache && response) {
-					state.loadingStatus = 'loaded';
-					const cleanedList = (response.channel_setting_list || []).map(cleanUndefinedFields);
-					switch (typeFetch) {
-						case ETypeFetchChannelSetting.FETCH_CHANNEL:
-							channelSettingAdapter.setAll(state, cleanedList);
-							break;
-						case ETypeFetchChannelSetting.MORE_CHANNEL:
-							channelSettingAdapter.upsertMany(state, cleanedList);
-							break;
-						case ETypeFetchChannelSetting.FETCH_THREAD:
-							state.threadsByChannel[actions.payload.parentId] = response.channel_setting_list || [];
-							break;
-						case ETypeFetchChannelSetting.SEARCH_CHANNEL:
-							state.listSearchChannel = response.channel_setting_list || [];
-							break;
-						default:
-							channelSettingAdapter.setAll(state, response.channel_setting_list || []);
-					}
-					state.channelCount = response.channel_count || 0;
-					state.threadCount = response.thread_count || 0;
-					state.cache = createCacheMetadata();
-				}
-
+				applyChannelSettingFulfilled(state, actions.payload);
 				state.loadingStatus = 'loaded';
 			})
 			.addCase(fetchActiveChannelSettingInClan.pending, (state: SettingClanChannelState) => {


### PR DESCRIPTION
## Cause
It's caching by key-value logic but only store the last data fetched in state, so cache hits but it serves to client the last data, not the cached data.

## Solution
Using key-value for caching so every queries (page change, limit change, clan change) can be handled.

## Changes
Refactored from storing last data in state to key-value cache using map.

## Future Improvements
It's now using key-value-based cache with `clanId`, `page` and `limit` to simply fix the bug and do not impact anything else. But we can also reduce the number of fetch calls with record-based cache. 

**E.g.:** Fetch 1 page 30 members, then reduce limit to 10 and page 2, just do like sliding window on cached data with flexible range.

## Tests
Doing the same reproduction of the bug as reported. The first video is the bug, the latter is the fixed one.

### Before

https://github.com/user-attachments/assets/739d5db5-8c0e-4a4c-9383-d5370c6ae375

### After

https://github.com/user-attachments/assets/d0890401-ce6e-4021-ac15-3597862b5115

