### PR TITLE
fix(web): heal messages stuck on "Uploading..." and fail loudly on a bad upload

### DIFF
--- a/libs/components/src/lib/components/MessageWithUser/MessageAttachment.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/MessageAttachment.tsx
@@ -31,6 +31,7 @@ import { MessageAudio } from './MessageAudio/MessageAudio';
 import MessageLinkFile from './MessageLinkFile';
 import MessageVideo from './MessageVideo';
 import Photo from './Photo';
+import { usePresignRefresh } from './usePresignRefresh';
 
 type MessageAttachmentProps = {
 	message: IMessageWithUser;
@@ -234,6 +235,14 @@ const MessageAttachment = memo(
 			[message.attachments, message.content]
 		);
 		const nowSeconds = usePresignExpiryNow(hasPresignPending, messageCreateTimeSeconds);
+		usePresignRefresh({
+			hasPresignPending,
+			clanId: message.clan_id,
+			bucketId: (message.channel_id ?? channelId) as string,
+			parentChannelId: channelId,
+			messageId: message.id,
+			createTimeSeconds: messageCreateTimeSeconds
+		});
 
 		const validateAttachment = useMemo(() => {
 			const rawAttachments = (message.attachments || []).filter((attachment) => Object.keys(attachment).length !== 0);

--- a/libs/components/src/lib/components/MessageWithUser/TimelineAttachment.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/TimelineAttachment.tsx
@@ -1,4 +1,12 @@
-import { attachmentActions, getStore, selectCurrentChannel, selectCurrentClanId, selectCurrentDM, useAppDispatch } from '@mezon/store';
+import {
+	attachmentActions,
+	getStore,
+	selectCurrentChannel,
+	selectCurrentClanId,
+	selectCurrentDM,
+	useAppDispatch,
+	useAppSelector
+} from '@mezon/store';
 import type { IMessageWithUser } from '@mezon/utils';
 import {
 	EMimeTypes,
@@ -7,6 +15,7 @@ import {
 	filterExpiredPresignAttachments,
 	generateAttachmentId,
 	getMessageCreateTimeSeconds,
+	hasActivePresignPendingAttachments,
 	isAttachmentPresignPendingForMessage,
 	isMediaTypeNotSupported
 } from '@mezon/utils';
@@ -14,6 +23,7 @@ import {
 import type { ApiMessageAttachment, ChannelStreamMode } from 'mezon-js';
 import { memo, useCallback, useMemo } from 'react';
 import { MessageAudio } from './MessageAudio/MessageAudio';
+import { usePresignRefresh } from './usePresignRefresh';
 
 type TimelineAttachmentProps = {
 	message: IMessageWithUser;
@@ -67,6 +77,22 @@ const TimelineAttachment = memo(({ message, maxThumbnails = 3, mode }: TimelineA
 	}, [message.attachments, message.content, messageCreateTimeSeconds]);
 
 	const isPresignPendingForUrl = useCallback((url?: string) => isAttachmentPresignPendingForMessage(url, message), [message]);
+
+	// Topic rows are the ones users reported stuck: the presign update lands on the
+	// parent channel copy and the topic copy never hears about it.
+	const hasPresignPending = useMemo(
+		() => hasActivePresignPendingAttachments(message.attachments, message.content),
+		[message.attachments, message.content]
+	);
+	const parentChannelId = useAppSelector((state) => selectCurrentChannel(state)?.channel_id);
+	usePresignRefresh({
+		hasPresignPending,
+		clanId: message.clan_id,
+		bucketId: message.channel_id,
+		parentChannelId,
+		messageId: message.id,
+		createTimeSeconds: messageCreateTimeSeconds
+	});
 
 	const { images, videos, audio } = useMemo(() => classifyAttachments(validateAttachment), [validateAttachment]);
 

--- a/libs/components/src/lib/components/MessageWithUser/usePresignRefresh.ts
+++ b/libs/components/src/lib/components/MessageWithUser/usePresignRefresh.ts
@@ -1,0 +1,76 @@
+import { messagesActions, selectCurrentClanId, useAppDispatch, useAppSelector } from '@mezon/store';
+import { PRESIGN_PENDING_MAX_AGE_SEC } from '@mezon/utils';
+import { useEffect } from 'react';
+
+/** How long a pending attachment is given before we suspect the update was lost. */
+const FIRST_REFRESH_DELAY_MS = 15000;
+/** Cadence afterwards. Cheap: one message, only while a row is actually stuck. */
+const REFRESH_INTERVAL_MS = 15000;
+
+type PresignRefreshArgs = {
+	hasPresignPending: boolean;
+	clanId?: string;
+	/** Where the message entity lives in the store: a channel id, or a topic id. */
+	bucketId?: string;
+	/** The channel the request goes to; for a topic that is the PARENT channel. */
+	parentChannelId?: string;
+	messageId?: string;
+	createTimeSeconds?: number;
+};
+
+/**
+ * Heal a message whose attachments are stuck in the "uploading" state.
+ *
+ * The receiver leaves that state on a single realtime update carrying
+ * presign_finish. When that one event is lost the row stays stuck until the
+ * user reloads the page — which is exactly the bug users report. Re-read the
+ * message instead, on a slow cadence and only while it is still pending.
+ */
+export function usePresignRefresh({ hasPresignPending, clanId, bucketId, parentChannelId, messageId, createTimeSeconds }: PresignRefreshArgs) {
+	const dispatch = useAppDispatch();
+	// Topic and thread rows do not always carry clan_id on the entity.
+	const currentClanId = useAppSelector(selectCurrentClanId);
+
+	useEffect(() => {
+		const clan = clanId || currentClanId;
+		if (!hasPresignPending || !messageId || !bucketId || !clan) return;
+
+		// Topic messages are stored under the topic id but must be requested from
+		// the parent channel, with the topic passed separately.
+		const isTopic = Boolean(parentChannelId) && parentChannelId !== bucketId;
+		const channelId = isTopic ? (parentChannelId as string) : bucketId;
+		const topicId = isTopic ? bucketId : undefined;
+
+		let timer: ReturnType<typeof setTimeout> | undefined;
+		let cancelled = false;
+
+		const ageMs = () => (createTimeSeconds ? Date.now() - createTimeSeconds * 1000 : 0);
+
+		const run = () => {
+			if (cancelled) return;
+			// Past the expiry the attachment is dropped from the row entirely, so
+			// there is nothing left to heal.
+			if (ageMs() > PRESIGN_PENDING_MAX_AGE_SEC * 1000) return;
+			dispatch(messagesActions.refreshPresignMessage({ clanId: clan, channelId, messageId, topicId }));
+			timer = setTimeout(run, REFRESH_INTERVAL_MS);
+		};
+
+		// A message that is already older than the grace period — reopened channel,
+		// restored tab — is checked straight away.
+		timer = setTimeout(run, Math.max(0, FIRST_REFRESH_DELAY_MS - ageMs()));
+
+		// A dropped socket is the most likely way to miss the update in the first
+		// place, so do not wait out the cadence after one reconnects.
+		const onReconnect = () => {
+			if (timer) clearTimeout(timer);
+			run();
+		};
+		window.addEventListener('mezon:socket-reconnect', onReconnect);
+
+		return () => {
+			cancelled = true;
+			if (timer) clearTimeout(timer);
+			window.removeEventListener('mezon:socket-reconnect', onReconnect);
+		};
+	}, [hasPresignPending, clanId, currentClanId, bucketId, parentChannelId, messageId, createTimeSeconds, dispatch]);
+}

--- a/libs/store/src/lib/messages/messages.slice.ts
+++ b/libs/store/src/lib/messages/messages.slice.ts
@@ -15,6 +15,7 @@ import {
 	EOgpType,
 	LIMIT_MESSAGE,
 	MessageCrypt,
+	PRESIGN_PENDING_MAX_AGE_SEC,
 	TypeMessage,
 	getMessageCreateTimeSeconds,
 	getPublicKeys,
@@ -60,6 +61,9 @@ export const MESSAGES_FEATURE_KEY = 'messages';
 /*
  * Update these interfaces according to your requirements.
  */
+
+/** Retry schedule for the presign_finish patch; the last entry means "no more waiting". */
+const PRESIGN_PATCH_BACKOFF_MS = [1000, 3000, 0];
 
 export const mapMessageChannelToEntity = (channelMess: ChannelMessage, lastSeenId?: string): IMessageWithUser => {
 	const isAnonymous = channelMess?.sender_id === NX_CHAT_APP_ANNONYMOUS_USER_ID;
@@ -125,6 +129,8 @@ export interface MessagesState {
 		navigate?: boolean;
 	} | null;
 	channelDraftMessage: Record<string, ChannelDraftMessages>;
+	/** messageId -> ms of the last presign refetch, so N rendered copies cost one request. */
+	presignRefreshAt: Record<string, number>;
 	isJumpingToPresent: Record<string, boolean>;
 	channelMessages: Record<
 		string,
@@ -1513,20 +1519,40 @@ export const sendMessage = createAsyncThunk('messages/sendMessage', async (paylo
 						})
 					);
 					await new Promise((resolve) => setTimeout(resolve, 1000));
-					thunkAPI.dispatch(
-						editMessageViaApi({
-							content: {
-								...content,
-								presign_finish
-							},
-							channelId,
-							clanId,
-							isPublic,
-							messageId: messageResult?.message_id,
-							mode,
-							hideEditted: true
-						})
-					);
+					// This patch is what stops every receiver showing "uploading". It used
+					// to be dispatched once and never checked: one failed request and the
+					// row stayed stuck for everyone until a reload.
+					// Capture the id — the closure below outlives the guard above.
+					const presignMessageId = messageResult.message_id as string;
+					const patch = () =>
+						thunkAPI
+							.dispatch(
+								editMessageViaApi({
+									content: {
+										...content,
+										presign_finish
+									},
+									channelId,
+									clanId,
+									isPublic,
+									messageId: presignMessageId,
+									mode,
+									hideEditted: true
+								})
+							)
+							.unwrap();
+					void (async () => {
+						for (let attempt = 0; attempt < PRESIGN_PATCH_BACKOFF_MS.length; attempt++) {
+							try {
+								await patch();
+								return;
+							} catch (e) {
+								console.error(`presign_finish patch failed (attempt ${attempt + 1}/${PRESIGN_PATCH_BACKOFF_MS.length})`, e);
+								const wait = PRESIGN_PATCH_BACKOFF_MS[attempt];
+								if (wait) await new Promise((resolve) => setTimeout(resolve, wait));
+							}
+						}
+					})();
 				} catch (error) {
 					console.error('error: ', error);
 				}
@@ -1842,6 +1868,7 @@ export const initialMessagesState: MessagesState = {
 	dataReactionGetFromLoadMessage: [],
 	channelMessages: {},
 	channelDraftMessage: {},
+	presignRefreshAt: {},
 	isFocused: false,
 	isViewingOlderMessagesByChannelId: {},
 	isJumpingToPresent: {},
@@ -2077,6 +2104,30 @@ export const messagesSlice = createSlice({
 				id: messageId,
 				changes: { attachments }
 			});
+		},
+		applyPresignRefresh: (
+			state,
+			action: PayloadAction<{ channelId: string; messageId: string; content: unknown; attachments: ApiMessageAttachment[] }>
+		) => {
+			const { channelId, messageId, content, attachments } = action.payload;
+			const channelEntity = state.channelMessages[channelId];
+			if (!channelEntity?.entities[messageId]) {
+				return;
+			}
+			channelMessagesAdapter.updateOne(channelEntity, {
+				id: messageId,
+				changes: { content, attachments } as Partial<MessagesEntity>
+			});
+		},
+		markPresignRefresh: (state, action: PayloadAction<{ messageId: string; at: number }>) => {
+			const { messageId, at } = action.payload;
+			const ids = Object.keys(state.presignRefreshAt);
+			if (ids.length > 200) {
+				ids.forEach((id) => {
+					if (at - state.presignRefreshAt[id] > PRESIGN_PENDING_MAX_AGE_SEC * 1000) delete state.presignRefreshAt[id];
+				});
+			}
+			state.presignRefreshAt[messageId] = at;
 		},
 		markAsError: (
 			state,
@@ -2422,6 +2473,55 @@ import { channel } from 'process';
  * See: https://react-redux.js.org/next/api/hooks#usedispatch
  */
 
+/** Smallest gap between two refetches of the same message. */
+const PRESIGN_REFRESH_MIN_GAP_MS = 10000;
+/** Second line of defence next to the store-state gate below. */
+const presignRefreshLocal = new Map<string, number>();
+
+/**
+ * Re-read one message from the server.
+ *
+ * A message with attachments is posted before its uploads finish, and the
+ * receiver only stops showing "uploading" when the follow-up presign_finish
+ * update arrives over the socket. If that single event is lost — a socket blip,
+ * a failed patch on the sender — the row stays stuck until a manual reload.
+ * Ask for the message again so it can heal itself.
+ */
+export const refreshPresignMessage = createAsyncThunk(
+	'messages/refreshPresignMessage',
+	async ({ clanId, channelId, messageId, topicId }: { clanId: string; channelId: string; messageId: string; topicId?: string }, thunkAPI) => {
+		const now = Date.now();
+		const localLast = presignRefreshLocal.get(messageId);
+		if (localLast && now - localLast < PRESIGN_REFRESH_MIN_GAP_MS) {
+			return;
+		}
+		// The gate lives in store state on purpose: a module-scope Map is not shared
+		// when the slice module gets instantiated more than once, and every rendered
+		// copy of the row would then fire its own request.
+		const last = getMessagesState(thunkAPI.getState() as RootState).presignRefreshAt?.[messageId];
+		if (last && now - last < PRESIGN_REFRESH_MIN_GAP_MS) {
+			return;
+		}
+		presignRefreshLocal.set(messageId, now);
+		thunkAPI.dispatch(messagesActions.markPresignRefresh({ messageId, at: now }));
+
+		const mezon = await ensureSession(getMezonCtx(thunkAPI));
+		const response = await mezon.client.listChannelMessages(mezon.session, clanId, channelId, messageId, 1, 1, topicId);
+		const fresh = response?.messages?.find((message) => (message.id || message.message_id) === messageId);
+		if (!fresh) {
+			return;
+		}
+		thunkAPI.dispatch(
+			messagesActions.applyPresignRefresh({
+				channelId: topicId || channelId,
+				messageId,
+				content: fresh.content,
+				attachments: fresh.attachments ?? []
+			})
+		);
+	}
+);
+
 export const messagesActions = {
 	...messagesSlice.actions,
 	addNewMessage,
@@ -2438,7 +2538,8 @@ export const messagesActions = {
 	loadMoreMessage,
 	jumpToMessage,
 	clickButtonMessage,
-	mapMessageChannelToEntityAction
+	mapMessageChannelToEntityAction,
+	refreshPresignMessage
 };
 
 export const getMessagesState = (rootState: { [MESSAGES_FEATURE_KEY]: MessagesState }): MessagesState => rootState[MESSAGES_FEATURE_KEY];

--- a/libs/store/src/lib/messages/messages.slice.ts
+++ b/libs/store/src/lib/messages/messages.slice.ts
@@ -33,6 +33,7 @@ import { createAsyncThunk, createEntityAdapter, createSelector, createSelectorCr
 import { Snowflake } from '@theinternetfolks/snowflake';
 import { t } from 'i18next';
 import type { ApiChannelMessageHeader, ApiMessageAttachment, ApiMessageMention, ApiMessageRef, ChannelMessage, MessageButtonClicked } from 'mezon-js';
+import { safeJSONParse } from 'mezon-js';
 import { toast } from 'react-toastify';
 import { accountActions, selectAllAccount } from '../account/account.slice';
 import { getUserAvatarOverride, getUserClanAvatarOverride } from '../avatarOverride/avatarOverride';
@@ -2105,22 +2106,34 @@ export const messagesSlice = createSlice({
 				changes: { attachments }
 			});
 		},
-		applyPresignRefresh: (
-			state,
-			action: PayloadAction<{ channelId: string; messageId: string; content: unknown; attachments: ApiMessageAttachment[] }>
-		) => {
-			const { channelId, messageId, content, attachments } = action.payload;
+		applyPresignRefresh: (state, action: PayloadAction<{ channelId: string; messageId: string; presignFinish: string[] }>) => {
+			const { channelId, messageId, presignFinish } = action.payload;
 			const channelEntity = state.channelMessages[channelId];
-			if (!channelEntity?.entities[messageId]) {
+			const existing = channelEntity?.entities[messageId];
+			if (!existing) {
 				return;
 			}
+			// Merge ONLY the keys. What the row holds is not always what the server
+			// holds: in an E2EE channel the stored content carries the DECRYPTED
+			// text, and the attachments can point at local preview urls, so writing
+			// the server copy over either would undo work this client already did —
+			// for the sake of a field the client only needs to read.
+			// Keep whatever shape the row already stores (object here, but a string
+			// elsewhere would otherwise be replaced by an object holding nothing but
+			// the keys — i.e. the message text would vanish).
+			const stored = existing.content;
+			const base = typeof stored === 'string' ? safeJSONParse(stored) : stored;
+			const merged = { ...(base && typeof base === 'object' ? base : {}), presign_finish: presignFinish };
 			channelMessagesAdapter.updateOne(channelEntity, {
 				id: messageId,
-				changes: { content, attachments } as Partial<MessagesEntity>
+				changes: { content: typeof stored === 'string' ? JSON.stringify(merged) : merged } as Partial<MessagesEntity>
 			});
 		},
 		markPresignRefresh: (state, action: PayloadAction<{ messageId: string; at: number }>) => {
 			const { messageId, at } = action.payload;
+			if (!state.presignRefreshAt) {
+				state.presignRefreshAt = {};
+			}
 			const ids = Object.keys(state.presignRefreshAt);
 			if (ids.length > 200) {
 				ids.forEach((id) => {
@@ -2511,12 +2524,18 @@ export const refreshPresignMessage = createAsyncThunk(
 		if (!fresh) {
 			return;
 		}
+		// Take the keys verbatim rather than the parsed/normalised form: they end up
+		// back in `content`, which a later edit re-sends to the server.
+		const freshContent = typeof fresh.content === 'string' ? safeJSONParse(fresh.content) : fresh.content;
+		const presignFinish = (freshContent as { presign_finish?: unknown } | null)?.presign_finish;
+		if (!Array.isArray(presignFinish)) {
+			return;
+		}
 		thunkAPI.dispatch(
 			messagesActions.applyPresignRefresh({
 				channelId: topicId || channelId,
 				messageId,
-				content: fresh.content,
-				attachments: fresh.attachments ?? []
+				presignFinish: presignFinish.filter((key): key is string => typeof key === 'string')
 			})
 		);
 	}

--- a/libs/transport/src/lib/minio/index.ts
+++ b/libs/transport/src/lib/minio/index.ts
@@ -321,6 +321,15 @@ export function createUploadFilePath(filename: string, index?: number): { filePa
 export async function uploadFileToPath(uploadPath: string, file: Blob, size: number) {
 	try {
 		const res = await uploadImageToMinIO(uploadPath, file, size);
+		// fetch only rejects on a network-level failure — an expired presign (403)
+		// or a bucket 5xx resolves like a success. The caller publishes the object
+		// key on the strength of this return value, so a non-2xx has to read as a
+		// failure; otherwise presign_finish names a key that was never written and
+		// every viewer gets "Source is unreachable" from imgproxy, forever.
+		// `handleUploadFile` in this same file already guards this way.
+		if (!res.ok) {
+			throw new Error(`Upload failed with status ${res.status}`);
+		}
 		return res;
 	} catch (error) {
 		console.error('error: ', error);

--- a/libs/utils/src/lib/utils/calculateAlbumLayout.ts
+++ b/libs/utils/src/lib/utils/calculateAlbumLayout.ts
@@ -60,7 +60,14 @@ function getRatios(allMedia: any[], isSingleMessage?: boolean, isMobile?: boolea
 			isMobile
 		}) as ApiDimensions;
 
-		return dimensions.width / dimensions.height;
+		const ratio = dimensions.width / dimensions.height;
+
+		// An attachment whose sender could not measure it arrives as 0x0, and
+		// 0/0 is NaN. The average ratio is a plain sum, so a single NaN poisons
+		// it and EVERY tile in the album comes out NaN-sized — the whole message
+		// renders as zero-width boxes, not just the offending picture. Treat an
+		// unmeasurable item as square and let the rest lay out normally.
+		return Number.isFinite(ratio) && ratio > 0 ? ratio : 1;
 	});
 }
 

--- a/libs/utils/src/lib/utils/index.ts
+++ b/libs/utils/src/lib/utils/index.ts
@@ -821,6 +821,15 @@ export async function getWebUploadedAttachments(payload: {
 			}
 
 			const result = await uploadFileToPath(createdFile.uploadPath, createdFile, createdFile.size);
+
+			// The id returned here becomes a presign_finish key, i.e. a promise to
+			// every client that the object is on the CDN. Returning it after a
+			// failed PUT is what turns a transient upload error into a message
+			// permanently pointing at a 404. Fail the send instead.
+			if (!result) {
+				throw new Error(`Upload failed for ${createdFile.name}`);
+			}
+
 			if (result && createdFile.thumbnailBlob && attachment?.thumbnailUpload && createdFile.thumbnail && createdFile.type.startsWith('video')) {
 				await uploadFileToPath(attachment.thumbnailUpload, createdFile.thumbnailBlob, createdFile.thumbnailBlob?.size);
 			}

--- a/libs/utils/src/lib/utils/presignFinish.ts
+++ b/libs/utils/src/lib/utils/presignFinish.ts
@@ -134,7 +134,11 @@ export function hasActivePresignPendingAttachments(attachments: ApiMessageAttach
 	const presignFinishKeys = parsePresignFinishKeys(content);
 	if (presignFinishKeys === null || !attachments?.length) return false;
 
-	return attachments.some((attachment) => isPresignAttachmentPending(attachment.url, presignFinishKeys));
+	// Pass the attachments so the count short-circuit applies: a message whose keys
+	// all arrived is finished even when a key does not match its url by name. Without
+	// this the answer disagrees with what the row actually renders, and anything
+	// driven off it (the expiry tick, the refetch) never stops.
+	return attachments.some((attachment) => isPresignAttachmentPending(attachment.url, presignFinishKeys, attachments));
 }
 
 export function getPresignExpiryDelayMs(messageCreateTimeSeconds?: number, nowMs = Date.now()): number | null {


### PR DESCRIPTION
## Problem

A message with attachments is posted before its files finish uploading; the files are patched in afterwards through `presign_finish`. Readers leave the pending ("Uploading…") state on **one** realtime update. Lose that event — socket blip, or a failed patch on the sender — and the row spins until the reader reloads the page. That is the report we got from users, including for images posted into a topic.

## What changes

**Stop losing the patch**
- The `presign_finish` patch is retried (1s, 3s, once more) instead of being dispatched once and never checked.

**Heal the row when it is lost anyway**
- A row still pending after 15s re-reads its own message from the server, repeating every 15s until the 10 minute presign expiry, plus once on socket reconnect.
- Topic rows are covered: the copy lives under the topic id but has to be fetched from the parent channel.
- Requests are deduplicated per message in store state. A module-scope map is not enough — the slice module can be instantiated more than once, and each rendered copy of a row would then fire its own request.

**Make the "pending" answer agree with what is rendered**
- `hasActivePresignPendingAttachments` now passes the attachments through so the key-count short-circuit applies. Without it, the helper reports "pending" forever on a row that renders fine, and anything driven off it (the expiry tick, the refetch above) never stops.

**Upload failures stop being silent**
- `uploadFileToPath` treats a non-2xx as a failure. `fetch` only rejects on a network error, so an expired presign (403) resolved like a success and `presign_finish` then named an object that was never written.
- `getWebUploadedAttachments` throws instead of returning a key for a PUT that failed.
- One unmeasurable image (0×0) no longer poisons the album layout: the average ratio is a plain sum, so a single NaN made **every** tile in that message zero-sized.

## Testing

Against prod, two accounts in one channel, web ⇄ desktop both directions.

- Formats: png/jpg/webp/heic/gif, mp4/mov/webm/mkv/avi, mp3/wav/ogg, pdf/zip/txt, multi-file and 25MB multipart — all delivered, no row left pending.
- Failure cases, forced with temporary fault injection (removed before this commit):
  - patch fails twice then succeeds → retry logs `attempt 1/3`, `2/3`, third lands, receiver renders normally;
  - patch fails permanently → the desktop client heals its row from the CDN; the web reader stays pending, see below;
  - lost realtime update → the refetch clears the row on the next tick;
  - slow upload → the refetch keeps trying and the row resolves when the object lands.
- Healthy path spends no extra requests: the refetch only arms while a row is actually pending, and stops as soon as it resolves.

## Known gap

If the patch fails *permanently*, the server never stores `presign_finish`, so the refetch returns the same unfinished content and a web reader stays pending until the 10 minute expiry. The desktop client recovers because it can ask the CDN directly whether the object exists; the web cannot, since the media CDN sends no `Access-Control-Allow-Origin`. Two ways to close it, happy to follow up with either: let an `<img>` probe the URL (an image load needs no CORS), or have infra allow the origin so the web can do the same HEAD the desktop does.