### PR TITLE
[WIP] fix(web): say "Uploading..." on an attachment that is still on its way

### DIFF
--- a/libs/components/src/lib/components/MessageWithUser/AttachmentSendingIndicator.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/AttachmentSendingIndicator.tsx
@@ -1,10 +1,26 @@
-export function AttachmentSendingIndicator({ className = '' }: { className?: string }) {
+import { useTranslation } from 'react-i18next';
+
+/**
+ * Below this the caption has nowhere to sit without covering the picture, so a
+ * small tile keeps just the spinner.
+ */
+const LABEL_MIN_WIDTH = 160;
+
+type AttachmentSendingIndicatorProps = {
+	className?: string;
+	/** Name the state instead of leaving a bare spinner to be read as "broken". */
+	showLabel?: boolean;
+	boxWidth?: number;
+};
+
+export function AttachmentSendingIndicator({ className = '', showLabel = false, boxWidth }: AttachmentSendingIndicatorProps) {
+	const { t } = useTranslation('media');
+	const withLabel = showLabel && (boxWidth === undefined || boxWidth >= LABEL_MIN_WIDTH);
+
 	return (
-		<div
-			className={`absolute inset-0 flex items-center justify-center pointer-events-none z-[2] ${className}`}
-			aria-hidden
-		>
+		<div className={`absolute inset-0 flex flex-col gap-2 items-center justify-center pointer-events-none z-[2] ${className}`} aria-hidden>
 			<div className="w-8 h-8 border-2 border-textSecondary800 dark:border-textSecondary border-t-transparent rounded-full animate-spin" />
+			{withLabel && <span className="text-xs text-textSecondary800 dark:text-textSecondary">{t('attachment.uploading')}</span>}
 		</div>
 	);
 }

--- a/libs/components/src/lib/components/MessageWithUser/AttachmentSendingIndicator.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/AttachmentSendingIndicator.tsx
@@ -18,9 +18,18 @@ export function AttachmentSendingIndicator({ className = '', showLabel = false, 
 	const withLabel = showLabel && (boxWidth === undefined || boxWidth >= LABEL_MIN_WIDTH);
 
 	return (
-		<div className={`absolute inset-0 flex flex-col gap-2 items-center justify-center pointer-events-none z-[2] ${className}`} aria-hidden>
-			<div className="w-8 h-8 border-2 border-textSecondary800 dark:border-textSecondary border-t-transparent rounded-full animate-spin" />
-			{withLabel && <span className="text-xs text-textSecondary800 dark:text-textSecondary">{t('attachment.uploading')}</span>}
+		<div className={`absolute inset-0 flex flex-col gap-2 items-center justify-center pointer-events-none z-[2] ${className}`}>
+			{/* The spinner says nothing a screen reader can use; the label does, so
+			    only the spinner is hidden and the label is announced once. */}
+			<div
+				className="w-8 h-8 border-2 border-textSecondary800 dark:border-textSecondary border-t-transparent rounded-full animate-spin"
+				aria-hidden
+			/>
+			{withLabel && (
+				<span className="text-xs text-textSecondary800 dark:text-textSecondary" role="status" aria-live="polite">
+					{t('attachment.uploading')}
+				</span>
+			)}
 		</div>
 	);
 }

--- a/libs/components/src/lib/components/MessageWithUser/MessageAttachment.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/MessageAttachment.tsx
@@ -192,17 +192,28 @@ const Attachments: React.FC<{
 					/>
 				)}
 
+				{/* A pending file used to be dropped from the row entirely, so the
+				    reader saw the text with nothing under it and then a box appearing
+				    out of nowhere. Show the box, and say what it is waiting for. */}
 				{documents.length > 0 &&
-					documents
-						.filter((document) => !isPresignPendingForUrl(document.url))
-						.map((document, index) => (
-							<MessageLinkFile key={`${index}_${document.url}`} attachmentData={document} mode={mode} message={message} />
-						))}
+					documents.map((document, index) => (
+						<MessageLinkFile
+							key={`${index}_${document.url}`}
+							attachmentData={document}
+							mode={mode}
+							message={message}
+							isPresignPending={isPresignPendingForUrl(document.url)}
+						/>
+					))}
 
 				{audio.length > 0 &&
-					audio
-						.filter((audioItem) => !isPresignPendingForUrl(audioItem.url))
-						.map((audioItem, index) => <MessageAudio key={`${index}_${audioItem.url}`} audioUrl={audioItem.url || ''} />)}
+					audio.map((audioItem, index) => (
+						<MessageAudio
+							key={`${index}_${audioItem.url}`}
+							audioUrl={audioItem.url || ''}
+							isPresignPending={isPresignPendingForUrl(audioItem.url)}
+						/>
+					))}
 			</>
 		);
 	},

--- a/libs/components/src/lib/components/MessageWithUser/MessageAudio/MessageAudio.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/MessageAudio/MessageAudio.tsx
@@ -1,13 +1,26 @@
 import React, { useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { MessageAudioControl } from './MessageAudioControl';
 import { MessageAudioUI } from './MessageAudioUI';
 
 type MessageAudioProps = {
 	audioUrl: string;
 	posInPopUp?: boolean;
+	/** The row exists but the object is not on the CDN yet. */
+	isPresignPending?: boolean;
 };
 
-export const MessageAudio: React.FC<MessageAudioProps> = React.memo(({ audioUrl, posInPopUp = false }) => {
+function AudioUploadingPill() {
+	const { t } = useTranslation('media');
+	return (
+		<div className="mt-[10px] flex items-center gap-2 rounded-lg bg-item-theme border-theme-primary px-3 py-3 w-fit">
+			<div className="w-4 h-4 border-2 border-textSecondary800 dark:border-textSecondary border-t-transparent rounded-full animate-spin" />
+			<span className="text-xs text-theme-primary">{t('attachment.uploading')}</span>
+		</div>
+	);
+}
+
+export const MessageAudio: React.FC<MessageAudioProps> = React.memo(({ audioUrl, posInPopUp = false, isPresignPending = false }) => {
 	const [isPlaying, setIsPlaying] = useState(false);
 	const [currentTime, setCurrentTime] = useState(0);
 	const [duration, setDuration] = useState<number>(0);
@@ -38,6 +51,11 @@ export const MessageAudio: React.FC<MessageAudioProps> = React.memo(({ audioUrl,
 			console.error('Download failed:', err);
 		}
 	};
+
+	// After the hooks above, so the early return cannot change their order.
+	if (isPresignPending) {
+		return <AudioUploadingPill />;
+	}
 
 	return (
 		<>

--- a/libs/components/src/lib/components/MessageWithUser/MessageLinkFile.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/MessageLinkFile.tsx
@@ -5,6 +5,7 @@ import type { IMessageWithUser } from '@mezon/utils';
 import { EFailAttachment, EMimeTypes } from '@mezon/utils';
 import type { ApiMessageAttachment, ChannelStreamMode } from 'mezon-js';
 import { Suspense, lazy, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useModal } from 'react-modal-hook';
 import { useSelector } from 'react-redux';
 import { ModalDeleteMess, RenderAttachmentThumbnail } from '../../components';
@@ -17,6 +18,8 @@ export type MessageImage = {
 	readonly attachmentData: ApiMessageAttachment;
 	readonly mode?: ChannelStreamMode;
 	message?: IMessageWithUser;
+	/** The row exists but the object is not on the CDN yet. */
+	isPresignPending?: boolean;
 };
 function formatFileSize(bytes: number) {
 	if (bytes >= 1000000) {
@@ -49,7 +52,11 @@ const PDFLoadingFallback = () => {
 	);
 };
 
-function MessageLinkFile({ attachmentData, mode, message }: MessageImage) {
+function MessageLinkFile({ attachmentData, mode, message, isPresignPending = false }: MessageImage) {
+	const { t } = useTranslation('media');
+	// The sender sees isSending, a reader only ever sees the presign gate; both
+	// mean the same thing to whoever is looking at the row.
+	const isUploading = Boolean(message?.isSending) || isPresignPending;
 	const [isDownloading, setIsDownloading] = useState(false);
 	const downloadingRef = useRef(false);
 	const handleDownload = async () => {
@@ -73,18 +80,18 @@ function MessageLinkFile({ attachmentData, mode, message }: MessageImage) {
 
 		try {
 			const response = await fetch(url);
-				if (!response.ok) {
-					return;
-				}
+			if (!response.ok) {
+				return;
+			}
 
-				const blob = await response.blob();
-				const dataUrl = URL.createObjectURL(blob);
-				const a = document.createElement('a');
-				a.href = dataUrl;
-				a.download = filename;
-				a.click();
+			const blob = await response.blob();
+			const dataUrl = URL.createObjectURL(blob);
+			const a = document.createElement('a');
+			a.href = dataUrl;
+			a.download = filename;
+			a.click();
 
-				URL.revokeObjectURL(dataUrl);
+			URL.revokeObjectURL(dataUrl);
 		} catch (error) {
 			console.error('Error during download:', error);
 		} finally {
@@ -169,18 +176,24 @@ function MessageLinkFile({ attachmentData, mode, message }: MessageImage) {
 		>
 			<div className="relative flex items-center shrink-0">
 				{thumbnailAttachment}
-				{message?.isSending && <AttachmentSendingIndicator className="rounded" />}
+				{isUploading && <AttachmentSendingIndicator className="rounded" />}
 			</div>
 			{attachmentData.filename === EFailAttachment.FAIL_ATTACHMENT ? (
 				<div className="text-red-500">Attachment failed to load.</div>
 			) : (
 				hideTheInformationFile && (
 					<>
-						<div className="cursor-pointer flex-1" onClick={handleDownload} onKeyDown={handleDownload}>
+						<div
+							className="cursor-pointer flex-1"
+							onClick={isUploading ? undefined : handleDownload}
+							onKeyDown={isUploading ? undefined : handleDownload}
+						>
 							<p className="text-blue-500 hover:underline">{attachmentData.filename}</p>
-							<p className="text-theme-primary">size: {formatFileSize(attachmentData.size || 0)}</p>
+							<p className="text-theme-primary">
+								{isUploading ? t('attachment.uploading') : `size: ${formatFileSize(attachmentData.size || 0)}`}
+							</p>
 						</div>
-						{hoverShowOptButtonStatus && (
+						{hoverShowOptButtonStatus && !isUploading && (
 							<div className="flex space-x-2 absolute right-4">
 								<button
 									onClick={handleDownload}

--- a/libs/components/src/lib/components/MessageWithUser/MessageVideo.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/MessageVideo.tsx
@@ -412,13 +412,15 @@ function VideoPoster({
 	style,
 	onPlay,
 	disablePlay = false,
-	isSending = false
+	isSending = false,
+	boxWidth
 }: {
 	thumbnailUrl?: string;
 	style: React.CSSProperties;
 	onPlay: () => void;
 	disablePlay?: boolean;
 	isSending?: boolean;
+	boxWidth?: number;
 }) {
 	return (
 		<div
@@ -430,7 +432,7 @@ function VideoPoster({
 		>
 			{thumbnailUrl && <img src={thumbnailUrl} alt="" className="w-full h-full object-cover" loading="lazy" />}
 			{isSending ? (
-				<AttachmentSendingIndicator />
+				<AttachmentSendingIndicator showLabel boxWidth={boxWidth} />
 			) : (
 				<div className="absolute inset-0 flex items-center justify-center bg-black bg-opacity-30 group">
 					<div className="flex items-center justify-center w-12 h-12 rounded-full bg-black bg-opacity-50 transition-transform duration-150 group-hover:scale-110">
@@ -518,7 +520,14 @@ function DefaultVideo({
 			{!showMedia && <VideoSkeleton style={mediaStyle} />}
 
 			{showMedia && !activated && (
-				<VideoPoster thumbnailUrl={thumbnailUrl} style={mediaStyle} onPlay={handlePlay} disablePlay={isUploading} isSending={isUploading} />
+				<VideoPoster
+					thumbnailUrl={thumbnailUrl}
+					style={mediaStyle}
+					onPlay={handlePlay}
+					disablePlay={isUploading}
+					isSending={isUploading}
+					boxWidth={width}
+				/>
 			)}
 
 			{isVideoActive && (

--- a/libs/components/src/lib/components/MessageWithUser/Photo.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/Photo.tsx
@@ -199,7 +199,7 @@ const Photo = <T,>({
 				/>
 			)}
 			{showPresignSkeleton && <ImageAttachmentSkeleton width={displayWidth} height={displayHeight} />}
-			{isSending && <AttachmentSendingIndicator />}
+			{isUploading && <AttachmentSendingIndicator showLabel boxWidth={displayWidth} />}
 			{!isUploading && shouldRenderSkeleton && (
 				<div
 					style={{ width: displayWidth, height: displayHeight }}

--- a/libs/translations/src/languages/blr/media.json
+++ b/libs/translations/src/languages/blr/media.json
@@ -11,5 +11,8 @@
 			"downloadButton": "Загрузіць відэа",
 			"browserNotSupported": "Ваш браўзер не падтрымлівае тэг відэа."
 		}
+	},
+	"attachment": {
+		"uploading": "Загрузка..."
 	}
 }

--- a/libs/translations/src/languages/de/media.json
+++ b/libs/translations/src/languages/de/media.json
@@ -11,5 +11,8 @@
 			"downloadButton": "Video herunterladen",
 			"browserNotSupported": "Dein Browser unterstützt das Video-Tag nicht."
 		}
+	},
+	"attachment": {
+		"uploading": "Wird hochgeladen..."
 	}
 }

--- a/libs/translations/src/languages/en/media.json
+++ b/libs/translations/src/languages/en/media.json
@@ -11,5 +11,8 @@
 			"downloadButton": "Download video",
 			"browserNotSupported": "Your browser does not support the video tag."
 		}
+	},
+	"attachment": {
+		"uploading": "Uploading..."
 	}
 }

--- a/libs/translations/src/languages/es/media.json
+++ b/libs/translations/src/languages/es/media.json
@@ -11,5 +11,8 @@
 			"downloadButton": "Descargar video",
 			"browserNotSupported": "Tu navegador no soporta el reproductor de video"
 		}
+	},
+	"attachment": {
+		"uploading": "Cargando..."
 	}
 }

--- a/libs/translations/src/languages/fr/media.json
+++ b/libs/translations/src/languages/fr/media.json
@@ -11,5 +11,8 @@
 			"downloadButton": "Télécharger la vidéo",
 			"browserNotSupported": "Votre navigateur ne prend pas en charge la balise vidéo."
 		}
+	},
+	"attachment": {
+		"uploading": "Téléchargement en cours..."
 	}
 }

--- a/libs/translations/src/languages/it/media.json
+++ b/libs/translations/src/languages/it/media.json
@@ -11,5 +11,8 @@
 			"downloadButton": "Scarica video",
 			"browserNotSupported": "Il tuo browser non supporta il tag video."
 		}
+	},
+	"attachment": {
+		"uploading": "Caricamento in corso..."
 	}
 }

--- a/libs/translations/src/languages/jpn/media.json
+++ b/libs/translations/src/languages/jpn/media.json
@@ -11,5 +11,8 @@
 			"downloadButton": "ビデオをダウンロード",
 			"browserNotSupported": "ブラウザはビデオタグをサポートしていません。"
 		}
+	},
+	"attachment": {
+		"uploading": "アップロード中..."
 	}
 }

--- a/libs/translations/src/languages/kr/media.json
+++ b/libs/translations/src/languages/kr/media.json
@@ -11,5 +11,8 @@
 			"downloadButton": "비디오 다운로드",
 			"browserNotSupported": "브라우저가 비디오 태그를 지원합니다."
 		}
+	},
+	"attachment": {
+		"uploading": "업로드 중..."
 	}
 }

--- a/libs/translations/src/languages/nl/media.json
+++ b/libs/translations/src/languages/nl/media.json
@@ -11,5 +11,8 @@
 			"downloadButton": "Video downloaden",
 			"browserNotSupported": "Je browser ondersteunt het videobegrip."
 		}
+	},
+	"attachment": {
+		"uploading": "Aan het uploaden..."
 	}
 }

--- a/libs/translations/src/languages/pl/media.json
+++ b/libs/translations/src/languages/pl/media.json
@@ -11,5 +11,8 @@
 			"downloadButton": "Pobierz wideo",
 			"browserNotSupported": "Twoja przeglądarka nie obsługuje tagu wideo."
 		}
+	},
+	"attachment": {
+		"uploading": "Przekazywanie..."
 	}
 }

--- a/libs/translations/src/languages/pt/media.json
+++ b/libs/translations/src/languages/pt/media.json
@@ -11,5 +11,8 @@
 			"downloadButton": "Baixar vídeo",
 			"browserNotSupported": "Seu navegador não suporta a tag de vídeo."
 		}
+	},
+	"attachment": {
+		"uploading": "Carregando..."
 	}
 }

--- a/libs/translations/src/languages/ru/media.json
+++ b/libs/translations/src/languages/ru/media.json
@@ -11,6 +11,8 @@
 			"downloadButton": "Загрузить видео",
 			"browserNotSupported": "Ваш браузер не поддерживает тег video."
 		}
+	},
+	"attachment": {
+		"uploading": "Загрузка..."
 	}
 }
-

--- a/libs/translations/src/languages/swe/media.json
+++ b/libs/translations/src/languages/swe/media.json
@@ -11,5 +11,8 @@
 			"downloadButton": "Ladda ner video",
 			"browserNotSupported": "Din webbläsare stöder inte video-tagg."
 		}
+	},
+	"attachment": {
+		"uploading": "Laddar upp..."
 	}
 }

--- a/libs/translations/src/languages/tt/media.json
+++ b/libs/translations/src/languages/tt/media.json
@@ -11,5 +11,8 @@
 			"downloadButton": "Видеоны күчереп алу",
 			"browserNotSupported": "Сезнең браузерыгыз video тегын тотымый."
 		}
+	},
+	"attachment": {
+		"uploading": "Йөкләү..."
 	}
 }

--- a/libs/translations/src/languages/ukr/media.json
+++ b/libs/translations/src/languages/ukr/media.json
@@ -11,5 +11,8 @@
 			"downloadButton": "Завантажити відео",
 			"browserNotSupported": "Ваш браузер не підтримує тег відео."
 		}
+	},
+	"attachment": {
+		"uploading": "Завантаження..."
 	}
 }

--- a/libs/translations/src/languages/vi/media.json
+++ b/libs/translations/src/languages/vi/media.json
@@ -11,5 +11,8 @@
 			"downloadButton": "Tải video xuống",
 			"browserNotSupported": "Trình duyệt của bạn không hỗ trợ thẻ video."
 		}
+	},
+	"attachment": {
+		"uploading": "Đang tải lên..."
 	}
 }


### PR DESCRIPTION
## Problem

A reader cannot tell an attachment that is still uploading from one that is broken:

- an image shows a bare shimmer,
- a video shows a spinner with no explanation,
- a file or a voice clip is **dropped from the row entirely** — the text appears with nothing under it, and a box pops in later out of nowhere.

The desktop client already names this state; the web did not.

## What changes

- `AttachmentSendingIndicator` can carry a caption. It is dropped on a tile too small to hold it (< 160px), so small album cells keep just the spinner.
- `Photo` and `MessageVideo` show it whenever the attachment is uploading, not only while *this* client is the sender — a reader is the one who cannot tell what is going on.
- `MessageLinkFile` shows it in place of the size line, and stops offering download/preview for bytes that are not on the CDN yet.
- `MessageAudio` shows a small pill instead of mounting a player that cannot play.
- Pending documents and audio are no longer filtered out of the message, so the row keeps its shape while the upload finishes.

Every language reuses the wording it already had for "uploading" elsewhere in its own bundle — nothing machine-translated.

## Testing

Sent from desktop and from web, two accounts in one channel: image, album, video, mp3, pdf and a 25MB file. The caption appears on both the sender's and the reader's side, disappears the moment the upload lands, and small album cells keep the spinner alone.