### PR TITLE
fix(web): stop a stuck picture, a mislabelled file and a needless download

### DIFF
--- a/libs/components/src/lib/components/MessageWithUser/MessageAttachment.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/MessageAttachment.tsx
@@ -94,7 +94,7 @@ const classifyAttachments = (attachments: ApiMessageAttachment[], message: IMess
 	const messageCreateTimeSeconds = getMessageCreateTimeSeconds(message);
 
 	attachments.forEach((attachment) => {
-		if (isMediaTypeNotSupported(attachment.filetype)) {
+		if (isMediaTypeNotSupported(attachment.filetype, attachment.url)) {
 			documents.push(attachment);
 			return;
 		}
@@ -241,7 +241,9 @@ const MessageAttachment = memo(
 			bucketId: (message.channel_id ?? channelId) as string,
 			parentChannelId: channelId,
 			messageId: message.id,
-			createTimeSeconds: messageCreateTimeSeconds
+			createTimeSeconds: messageCreateTimeSeconds,
+			attachments: message.attachments,
+			content: message.content
 		});
 
 		const validateAttachment = useMemo(() => {

--- a/libs/components/src/lib/components/MessageWithUser/MessageAudio/MessageAudioControl.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/MessageAudio/MessageAudioControl.tsx
@@ -1,4 +1,3 @@
-import { getBlobDuration } from '@mezon/utils';
 import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
 
 type AudioControlProps = {
@@ -63,31 +62,56 @@ export const MessageAudioControl = forwardRef((props: AudioControlProps, ref) =>
 		};
 	}, []);
 
-	const getAudioDuration = async () => {
-		const abortController = new AbortController();
-
-		try {
-			const response = await fetch(audioUrl, { signal: abortController.signal });
-			const blob = await response.blob();
-			const duration = await getBlobDuration(blob);
-			setDuration(Math.floor(duration));
-		} catch (error) {
-			if (error instanceof DOMException && error.name === 'AbortError') return;
-			console.error('Error fetching audio:', error, audioUrl);
-		}
-
-		return () => {
-			abortController.abort();
-		};
-	};
-
+	// The element below already has the file open, and its metadata carries the
+	// duration. Reading it there costs nothing extra and, unlike fetch(), needs no
+	// CORS header from the media host — a host that does not send one made every
+	// clip read "0:00 / 0:00". Downloading the whole clip for its length also meant
+	// a channel full of voice messages fetched all of them on render.
 	useEffect(() => {
-		const cleanup = getAudioDuration();
+		const audio = audioRef.current;
+		if (!audio) return;
 
-		return () => {
-			cleanup.then((cleanupFn) => cleanupFn?.());
+		const readDuration = () => {
+			if (Number.isFinite(audio.duration) && audio.duration > 0) {
+				setDuration(Math.floor(audio.duration));
+				return true;
+			}
+			return false;
 		};
-	}, [audioUrl]);
 
-	return <audio ref={audioRef} src={audioUrl} onEnded={() => setIsPlaying(false)} className="hidden" onTimeUpdate={handleTimeUpdate} />;
+		if (readDuration()) return;
+
+		// A stream written without a duration in its header (webm/opus from a
+		// browser recorder) reports Infinity until it is seeked to the end.
+		const handleLoadedMetadata = () => {
+			if (readDuration()) return;
+			const onSeeked = () => {
+				readDuration();
+				audio.currentTime = 0;
+				audio.removeEventListener('seeked', onSeeked);
+			};
+			audio.addEventListener('seeked', onSeeked);
+			try {
+				audio.currentTime = Number.MAX_SAFE_INTEGER;
+			} catch {
+				audio.removeEventListener('seeked', onSeeked);
+			}
+		};
+
+		audio.addEventListener('loadedmetadata', handleLoadedMetadata);
+		return () => {
+			audio.removeEventListener('loadedmetadata', handleLoadedMetadata);
+		};
+	}, [audioUrl, setDuration]);
+
+	return (
+		<audio
+			ref={audioRef}
+			src={audioUrl}
+			preload="metadata"
+			onEnded={() => setIsPlaying(false)}
+			className="hidden"
+			onTimeUpdate={handleTimeUpdate}
+		/>
+	);
 });

--- a/libs/components/src/lib/components/MessageWithUser/TimelineAttachment.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/TimelineAttachment.tsx
@@ -38,7 +38,7 @@ const classifyAttachments = (attachments: ApiMessageAttachment[]) => {
 	const others: ApiMessageAttachment[] = [];
 
 	attachments.forEach((attachment) => {
-		if (isMediaTypeNotSupported(attachment.filetype)) {
+		if (isMediaTypeNotSupported(attachment.filetype, attachment.url)) {
 			others.push(attachment);
 			return;
 		}
@@ -91,7 +91,9 @@ const TimelineAttachment = memo(({ message, maxThumbnails = 3, mode }: TimelineA
 		bucketId: message.channel_id,
 		parentChannelId,
 		messageId: message.id,
-		createTimeSeconds: messageCreateTimeSeconds
+		createTimeSeconds: messageCreateTimeSeconds,
+		attachments: message.attachments,
+		content: message.content
 	});
 
 	const { images, videos, audio } = useMemo(() => classifyAttachments(validateAttachment), [validateAttachment]);

--- a/libs/components/src/lib/components/MessageWithUser/usePresignRefresh.ts
+++ b/libs/components/src/lib/components/MessageWithUser/usePresignRefresh.ts
@@ -1,11 +1,16 @@
 import { messagesActions, selectCurrentClanId, useAppDispatch, useAppSelector } from '@mezon/store';
-import { PRESIGN_PENDING_MAX_AGE_SEC } from '@mezon/utils';
+import { ETypeLinkMedia, PRESIGN_PENDING_MAX_AGE_SEC, getPresignKeyFromAttachmentUrl, isAttachmentPresignPendingForMessage } from '@mezon/utils';
+import type { ApiMessageAttachment } from 'mezon-js';
 import { useEffect } from 'react';
 
 /** How long a pending attachment is given before we suspect the update was lost. */
 const FIRST_REFRESH_DELAY_MS = 15000;
 /** Cadence afterwards. Cheap: one message, only while a row is actually stuck. */
 const REFRESH_INTERVAL_MS = 15000;
+/** Refetches to give the server before falling back to asking the object itself. */
+const REFETCHES_BEFORE_IMAGE_PROBE = 2;
+/** Only probe pictures small enough that fetching one is not a cost of its own. */
+const IMAGE_PROBE_MAX_BYTES = 5 * 1024 * 1024;
 
 type PresignRefreshArgs = {
 	hasPresignPending: boolean;
@@ -16,6 +21,9 @@ type PresignRefreshArgs = {
 	parentChannelId?: string;
 	messageId?: string;
 	createTimeSeconds?: number;
+	/** Needed for the image fallback below; the refetch alone does not use them. */
+	attachments?: ApiMessageAttachment[];
+	content?: unknown;
 };
 
 /**
@@ -26,7 +34,16 @@ type PresignRefreshArgs = {
  * user reloads the page — which is exactly the bug users report. Re-read the
  * message instead, on a slow cadence and only while it is still pending.
  */
-export function usePresignRefresh({ hasPresignPending, clanId, bucketId, parentChannelId, messageId, createTimeSeconds }: PresignRefreshArgs) {
+export function usePresignRefresh({
+	hasPresignPending,
+	clanId,
+	bucketId,
+	parentChannelId,
+	messageId,
+	createTimeSeconds,
+	attachments,
+	content
+}: PresignRefreshArgs) {
 	const dispatch = useAppDispatch();
 	// Topic and thread rows do not always carry clan_id on the entity.
 	const currentClanId = useAppSelector(selectCurrentClanId);
@@ -46,12 +63,43 @@ export function usePresignRefresh({ hasPresignPending, clanId, bucketId, parentC
 
 		const ageMs = () => (createTimeSeconds ? Date.now() - createTimeSeconds * 1000 : 0);
 
+		// Last resort. If the sender's patch never landed, the server has no
+		// presign_finish to hand back and the refetch above can only return the same
+		// unfinished message forever — while the object itself may be sitting on the
+		// CDN. The desktop client asks the CDN with a HEAD; the web cannot, because
+		// the media host sends no CORS header. An <img> load needs none, so let the
+		// picture answer for itself, and record the key it just proved readable.
+		const probeImages = () => {
+			(attachments ?? []).forEach((attachment) => {
+				const url = attachment.url;
+				const key = getPresignKeyFromAttachmentUrl(url);
+				if (!url || !key) return;
+				if (!attachment.filetype?.startsWith(ETypeLinkMedia.IMAGE_PREFIX)) return;
+				if ((attachment.size ?? 0) > IMAGE_PROBE_MAX_BYTES) return;
+				if (!isAttachmentPresignPendingForMessage(url, { content })) return;
+
+				const probe = new Image();
+				probe.onload = () => {
+					if (cancelled) return;
+					dispatch(messagesActions.applyPresignRefresh({ channelId: bucketId, messageId, presignFinish: [key] }));
+				};
+				// Straight at the object: going through imgproxy would let it cache a
+				// not-found for the url the row renders with.
+				probe.src = url;
+			});
+		};
+
+		let refetches = 0;
 		const run = () => {
 			if (cancelled) return;
 			// Past the expiry the attachment is dropped from the row entirely, so
 			// there is nothing left to heal.
 			if (ageMs() > PRESIGN_PENDING_MAX_AGE_SEC * 1000) return;
 			dispatch(messagesActions.refreshPresignMessage({ clanId: clan, channelId, messageId, topicId }));
+			refetches += 1;
+			if (refetches >= REFETCHES_BEFORE_IMAGE_PROBE) {
+				probeImages();
+			}
 			timer = setTimeout(run, REFRESH_INTERVAL_MS);
 		};
 
@@ -72,5 +120,5 @@ export function usePresignRefresh({ hasPresignPending, clanId, bucketId, parentC
 			if (timer) clearTimeout(timer);
 			window.removeEventListener('mezon:socket-reconnect', onReconnect);
 		};
-	}, [hasPresignPending, clanId, currentClanId, bucketId, parentChannelId, messageId, createTimeSeconds, dispatch]);
+	}, [hasPresignPending, clanId, currentClanId, bucketId, parentChannelId, messageId, createTimeSeconds, attachments, content, dispatch]);
 }

--- a/libs/store/src/lib/messages/messages.slice.ts
+++ b/libs/store/src/lib/messages/messages.slice.ts
@@ -2123,7 +2123,16 @@ export const messagesSlice = createSlice({
 			// the keys — i.e. the message text would vanish).
 			const stored = existing.content;
 			const base = typeof stored === 'string' ? safeJSONParse(stored) : stored;
-			const merged = { ...(base && typeof base === 'object' ? base : {}), presign_finish: presignFinish };
+			// Union, not replace: the list only ever grows, and the caller may be
+			// contributing a single key it just proved readable rather than the whole
+			// server-side list.
+			const storedKeys = Array.isArray((base as { presign_finish?: unknown })?.presign_finish)
+				? ((base as { presign_finish: unknown[] }).presign_finish.filter((key): key is string => typeof key === 'string') as string[])
+				: [];
+			const merged = {
+				...(base && typeof base === 'object' ? base : {}),
+				presign_finish: [...new Set([...storedKeys, ...presignFinish])]
+			};
 			channelMessagesAdapter.updateOne(channelEntity, {
 				id: messageId,
 				changes: { content: typeof stored === 'string' ? JSON.stringify(merged) : merged } as Partial<MessagesEntity>

--- a/libs/utils/src/lib/utils/file.ts
+++ b/libs/utils/src/lib/utils/file.ts
@@ -166,32 +166,39 @@ export async function processFilesForAttachment(files: File[]): Promise<ApiMessa
 		await Promise.all(Array.from({ length: Math.min(concurrency, indexes.length) }, () => worker()));
 	};
 
-	await Promise.all([
-		runPool(lightweightIndexes, FILE_PROCESS_CONCURRENCY),
-		runPool(videoIndexes, VIDEO_PROCESS_CONCURRENCY)
-	]);
+	await Promise.all([runPool(lightweightIndexes, FILE_PROCESS_CONCURRENCY), runPool(videoIndexes, VIDEO_PROCESS_CONCURRENCY)]);
 	return results;
 }
 
-export function isMediaTypeNotSupported(mediaType?: string) {
-	if (!mediaType) return false;
+const UNSUPPORTED_MEDIA_TYPES = new Set([
+	'video/x-ms-wmv',
+	'video/wmv',
+	'video/avi',
+	'video/flv',
+	'video/mkv',
+	'video/rmvb',
+	'audio/wma',
+	'audio/ra',
+	'audio/atrac',
+	'image/tiff',
+	'image/bmp',
+	'image/psd'
+]);
 
-	const unsupportedMediaTypes = new Set([
-		'video/x-ms-wmv',
-		'video/wmv',
-		'video/avi',
-		'video/flv',
-		'video/mkv',
-		'video/rmvb',
-		'audio/wma',
-		'audio/ra',
-		'audio/atrac',
-		'image/tiff',
-		'image/bmp',
-		'image/psd'
-	]);
+/** Extensions of the types above, for senders that give us no usable MIME. */
+const UNSUPPORTED_MEDIA_EXTENSIONS = new Set(['wmv', 'avi', 'flv', 'mkv', 'rmvb', 'wma', 'ra', 'tiff', 'tif', 'bmp', 'psd']);
 
-	return unsupportedMediaTypes.has(mediaType);
+export function isMediaTypeNotSupported(mediaType?: string, url?: string) {
+	if (mediaType && UNSUPPORTED_MEDIA_TYPES.has(mediaType)) {
+		return true;
+	}
+
+	// The desktop client sends a category ("image", "video") rather than a MIME,
+	// so the check above never matched anything it uploaded: a .bmp took the image
+	// path, imgproxy could not read it, and the reader was left with a broken
+	// thumbnail. The extension is the only thing left to go on.
+	const extension = url?.split('?')[0].split('#')[0].split('.').pop()?.toLowerCase();
+	return Boolean(extension && UNSUPPORTED_MEDIA_EXTENSIONS.has(extension));
 }
 
 export function isImageFile(file: File): boolean {


### PR DESCRIPTION
Three attachment problems found while testing the presign self-heal (#13628). Independent of each other; all small.

## 1. A row can stay pending forever

If the sender's `presign_finish` patch never lands, the server has nothing to hand back: the refetch added in #13628 can only return the same unfinished message, again and again, while the object itself may be sitting on the CDN the whole time.

The desktop client resolves this by asking the CDN with a HEAD. The web cannot — the media host sends no `Access-Control-Allow-Origin`. An `<img>` load needs none, so after two fruitless refetches the picture is asked to answer for itself, and the key it just proved readable is recorded.

- Straight at the object, never through imgproxy, so a not-found can never be cached against the url the row actually renders with.
- Images only, and only below 5MB — a probe should not become a download of its own.
- `applyPresignRefresh` now merges the key list as a union, since this path contributes a single key rather than the server's whole list.

## 2. A .bmp from desktop showed a broken thumbnail

`isMediaTypeNotSupported` only knew MIME types, but the desktop client sends a category (`"image"`, `"video"`) rather than `image/bmp`. The check never matched anything it uploaded, so the file took the image path, imgproxy could not read it, and the reader got a broken tile. The object on the CDN is fine — only the classification was wrong. Now falls back to the file extension.

## 3. Every voice message downloaded itself to show its length

`getAudioDuration` fetched the whole clip just to read its duration, so a channel full of voice messages fetched all of them on render — and on a host without a CORS header the fetch failed outright, which is why clips read `0:00 / 0:00`. The `<audio>` element already has the file open and its metadata carries the duration; a stream that reports `Infinity` (webm/opus from a browser recorder) is seeked once to settle it.

## Testing

Desktop ⇄ web, two accounts in one channel: image/album/video/mp3/pdf/25MB. Duration now shows for mp3, wav and ogg where it previously read 0:00; a .bmp sent from desktop renders as a file box instead of a broken tile; a row whose patch was killed on purpose recovers from the image probe instead of waiting out the 10 minute expiry.

Touches the same two components as #13629, in different places — merge order does not matter, git resolves both.