### PR TITLE
fix(web): show the loading skeleton while a channel is fetching

### DIFF
--- a/apps/chat/src/app/pages/channel/ChannelMessages.tsx
+++ b/apps/chat/src/app/pages/channel/ChannelMessages.tsx
@@ -1310,6 +1310,15 @@ export default MemoizedChannelMessages;
 
 (MemoizedChannelMessages as any).displayName = 'MemoizedChannelMessages';
 
+/**
+ * Long enough that a channel whose history is already cached never flashes a
+ * skeleton it does not need, short enough that a channel being fetched shows one
+ * instead of an empty page. The old second-long wait outlasted most fetches, so
+ * opening a channel just went blank and then filled in — the skeleton was there
+ * but almost never on screen.
+ */
+const LOAD_SKELETON_DELAY_MS = 120;
+
 const StickyLoadingIndicator = memo(({ messageCount }: { messageCount: number }) => {
 	const isLoading = useAppSelector(selectMessageIsLoading);
 	const [showLoading, setShowLoading] = useState(false);
@@ -1319,7 +1328,7 @@ const StickyLoadingIndicator = memo(({ messageCount }: { messageCount: number })
 		if (isLoading && !messageCount) {
 			timeoutId = setTimeout(() => {
 				setShowLoading(true);
-			}, 1000);
+			}, LOAD_SKELETON_DELAY_MS);
 		} else {
 			setShowLoading(false);
 		}


### PR DESCRIPTION
## What

Opening a channel showed a blank page for a moment and then the messages, with no skeleton in between.

The skeleton is already there — `StickyLoadingIndicator` renders `MessageSkeleton` while the store is loading and the channel holds no rows — but it was gated behind a `setTimeout(..., 1000)`. Most fetches finish inside that second, so the timer was cancelled before it ever fired and the loading state was drawn as an empty page.

## Change

One constant: the delay drops from 1000 ms to 120 ms, with a comment saying what the delay is for. Long enough that a channel whose history is already cached does not flash a skeleton it does not need; short enough that a channel actually being fetched shows one.

## Testing

- `prettier --check` on the changed file: clean.
- Behaviour verified by reading the gate: `isLoading && !messageCount` is unchanged, so a cached channel (messageCount > 0) still renders nothing, and the indicator still clears the moment rows arrive.