### PR TITLE
fix(web): show the picture being sent instead of an empty row

### DIFF
--- a/libs/components/src/lib/components/MessageWithUser/Album.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/Album.tsx
@@ -1,4 +1,4 @@
-import type { ApiPhoto, IAlbum, IAlbumLayout, ObserveFn } from '@mezon/utils';
+import type { ApiPhoto, IAlbum, IAlbumLayout, ObserveFn, PreSendMediaAttachment } from '@mezon/utils';
 import { AlbumRectPart, generateAttachmentId } from '@mezon/utils';
 import type { ApiMessageAttachment } from 'mezon-js';
 import type { FC } from 'react';
@@ -78,6 +78,7 @@ const Album: FC<OwnProps> = ({
 					onContextMenu={onContextMenu}
 					isSending={isSending}
 					isPresignPending={isPresignPending}
+					localSource={(attachment as PreSendMediaAttachment)?.local_source}
 					loadWhenUnpending={!isPresignPending}
 					isInSearchMessage={isInSearchMessage}
 				/>

--- a/libs/components/src/lib/components/MessageWithUser/AttachmentSendingIndicator.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/AttachmentSendingIndicator.tsx
@@ -35,11 +35,12 @@ export function AttachmentSendingIndicator({ className = '', showLabel = false, 
 				className="w-8 h-8 border-2 border-textSecondary800 dark:border-textSecondary border-t-transparent rounded-full animate-spin"
 				aria-hidden
 			/>
-			{withLabel && (
-				<span className="text-xs text-textSecondary800 dark:text-textSecondary" role="status" aria-live="polite">
-					{t('attachment.uploading')}
-				</span>
-			)}
+			{/* Whether the caption fits is a layout question. Whether the state is
+			    announced is not, so on a tile too small to show it the same text
+			    is still there for a screen reader. */}
+			<span className={withLabel ? 'text-xs text-textSecondary800 dark:text-textSecondary' : 'sr-only'} role="status" aria-live="polite">
+				{t('attachment.uploading')}
+			</span>
 		</div>
 	);
 }

--- a/libs/components/src/lib/components/MessageWithUser/AttachmentSendingIndicator.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/AttachmentSendingIndicator.tsx
@@ -6,19 +6,29 @@ import { useTranslation } from 'react-i18next';
  */
 const LABEL_MIN_WIDTH = 160;
 
+/**
+ * The spinner is 32px and the caption another ~16 on top of the gap. In a box
+ * shorter than this the stack does not fit and pushes out of the tile, which is
+ * what makes a wide, short picture look broken rather than busy.
+ */
+const LABEL_MIN_HEIGHT = 92;
+
 type AttachmentSendingIndicatorProps = {
 	className?: string;
 	/** Name the state instead of leaving a bare spinner to be read as "broken". */
 	showLabel?: boolean;
 	boxWidth?: number;
+	boxHeight?: number;
 };
 
-export function AttachmentSendingIndicator({ className = '', showLabel = false, boxWidth }: AttachmentSendingIndicatorProps) {
+export function AttachmentSendingIndicator({ className = '', showLabel = false, boxWidth, boxHeight }: AttachmentSendingIndicatorProps) {
 	const { t } = useTranslation('media');
-	const withLabel = showLabel && (boxWidth === undefined || boxWidth >= LABEL_MIN_WIDTH);
+	const fitsWidth = boxWidth === undefined || boxWidth >= LABEL_MIN_WIDTH;
+	const fitsHeight = boxHeight === undefined || boxHeight >= LABEL_MIN_HEIGHT;
+	const withLabel = showLabel && fitsWidth && fitsHeight;
 
 	return (
-		<div className={`absolute inset-0 flex flex-col gap-2 items-center justify-center pointer-events-none z-[2] ${className}`}>
+		<div className={`absolute inset-0 flex flex-col gap-2 items-center justify-center overflow-hidden pointer-events-none z-[2] ${className}`}>
 			{/* The spinner says nothing a screen reader can use; the label does, so
 			    only the spinner is hidden and the label is announced once. */}
 			<div

--- a/libs/components/src/lib/components/MessageWithUser/MessageAttachment.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/MessageAttachment.tsx
@@ -8,7 +8,7 @@ import {
 	useAppDispatch,
 	useAppSelector
 } from '@mezon/store';
-import type { ApiPhoto, IMessageWithUser, ObserveFn } from '@mezon/utils';
+import type { ApiPhoto, IMessageWithUser, ObserveFn, PreSendMediaAttachment } from '@mezon/utils';
 import {
 	EMimeTypes,
 	ETypeLinkMedia,
@@ -435,6 +435,7 @@ const ImageAlbum = memo(
 						isInSearchMessage={isInSearchMessage}
 						isSending={message.isSending}
 						isPresignPending={isPresignPending}
+						localSource={(firstImage as PreSendMediaAttachment)?.local_source}
 						loadWhenUnpending={!isPresignPending}
 						isMobile={isMobile}
 					/>

--- a/libs/components/src/lib/components/MessageWithUser/MessageVideo.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/MessageVideo.tsx
@@ -413,7 +413,8 @@ function VideoPoster({
 	onPlay,
 	disablePlay = false,
 	isSending = false,
-	boxWidth
+	boxWidth,
+	boxHeight
 }: {
 	thumbnailUrl?: string;
 	style: React.CSSProperties;
@@ -421,6 +422,7 @@ function VideoPoster({
 	disablePlay?: boolean;
 	isSending?: boolean;
 	boxWidth?: number;
+	boxHeight?: number;
 }) {
 	return (
 		<div
@@ -432,7 +434,7 @@ function VideoPoster({
 		>
 			{thumbnailUrl && <img src={thumbnailUrl} alt="" className="w-full h-full object-cover" loading="lazy" />}
 			{isSending ? (
-				<AttachmentSendingIndicator showLabel boxWidth={boxWidth} />
+				<AttachmentSendingIndicator showLabel boxWidth={boxWidth} boxHeight={boxHeight} />
 			) : (
 				<div className="absolute inset-0 flex items-center justify-center bg-black bg-opacity-30 group">
 					<div className="flex items-center justify-center w-12 h-12 rounded-full bg-black bg-opacity-50 transition-transform duration-150 group-hover:scale-110">
@@ -527,6 +529,7 @@ function DefaultVideo({
 					disablePlay={isUploading}
 					isSending={isUploading}
 					boxWidth={width}
+					boxHeight={height}
 				/>
 			)}
 

--- a/libs/components/src/lib/components/MessageWithUser/Photo.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/Photo.tsx
@@ -8,7 +8,7 @@ import {
 	createImgproxyUrl,
 	useIsIntersecting
 } from '@mezon/utils';
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useMessageContextMenu } from '../ContextMenu';
 import { AttachmentSendingIndicator } from './AttachmentSendingIndicator';
 
@@ -145,7 +145,6 @@ const Photo = <T,>({
 		return 'fill';
 	})();
 
-	const shouldRenderSkeleton = !shouldLoad && !isUploading;
 	const isNonInteractive = nonInteractive || isPresignPending;
 
 	const componentClassName = buildClassName(
@@ -179,8 +178,19 @@ const Photo = <T,>({
 
 	const thumbnailDataUri = photo.thumbnail?.dataUri;
 	const hasThumbnail = !!thumbnailDataUri;
-	const showPresignSkeleton = isPresignPending && !hasThumbnail && !showLocalPreview;
 	const canOpenViewer = !isPresignPending;
+
+	// The proxied copy is absolutely positioned, so between "start loading" and
+	// "decoded" there is nothing in the layout at all and the row goes blank for
+	// the length of a network round trip. Hold the placeholder until something is
+	// genuinely on screen — the local copy, the thumbnail, or the image itself.
+	const [imagePainted, setImagePainted] = useState(false);
+	const onImageSettled = useCallback(() => setImagePainted(true), []);
+	useEffect(() => {
+		setImagePainted(false);
+	}, [photo?.url]);
+
+	const somethingIsPainted = showLocalPreview || (isPresignPending && hasThumbnail) || (shouldLoad && imagePainted);
 
 	return (
 		<div
@@ -205,6 +215,7 @@ const Photo = <T,>({
 					isProtected={isProtected}
 					onContextMenu={onContextMenu}
 					isInSearchMessage={isInSearchMessage}
+					onSettled={onImageSettled}
 				/>
 			)}
 			{/* The sender's own copy, straight off disk: the CDN object is not there
@@ -227,14 +238,8 @@ const Photo = <T,>({
 					style={{ width: displayWidth, height: displayHeight }}
 				/>
 			)}
-			{showPresignSkeleton && <ImageAttachmentSkeleton width={displayWidth} height={displayHeight} />}
-			{isUploading && <AttachmentSendingIndicator showLabel boxWidth={displayWidth} />}
-			{!isUploading && shouldRenderSkeleton && (
-				<div
-					style={{ width: displayWidth, height: displayHeight }}
-					className="max-w-full max-h-full absolute bottom-0 left-0 rounded-md bg-[#0000001c] animate-pulse"
-				/>
-			)}
+			{!somethingIsPainted && <ImageAttachmentSkeleton width={displayWidth} height={displayHeight} />}
+			{isUploading && <AttachmentSendingIndicator showLabel boxWidth={displayWidth} boxHeight={displayHeight} />}
 			{isProtected && <span className="protector" />}
 		</div>
 	);
@@ -250,10 +255,12 @@ type PhotoImageProps = {
 	isProtected?: boolean;
 	onContextMenu?: (event: React.MouseEvent<HTMLImageElement>) => void;
 	isInSearchMessage?: boolean;
+	/** Fires once the CDN copy is painted, or has failed for good. */
+	onSettled?: () => void;
 };
 
 const PhotoImage = React.memo(
-	({ url, width, height, resizeType, displayWidth, isGif, isProtected, onContextMenu, isInSearchMessage }: PhotoImageProps) => {
+	({ url, width, height, resizeType, displayWidth, isGif, isProtected, onContextMenu, isInSearchMessage, onSettled }: PhotoImageProps) => {
 		const { setImageURL, setPositionShow } = useMessageContextMenu();
 		const [hasError, setHasError] = useState(false);
 
@@ -272,7 +279,12 @@ const PhotoImage = React.memo(
 
 		const handleError = useCallback(() => {
 			setHasError(true);
-		}, []);
+			onSettled?.();
+		}, [onSettled]);
+
+		const handleLoad = useCallback(() => {
+			onSettled?.();
+		}, [onSettled]);
 
 		if (hasError) {
 			return (
@@ -301,6 +313,7 @@ const PhotoImage = React.memo(
 				style={{ width: displayWidth }}
 				draggable={!isProtected}
 				onError={handleError}
+				onLoad={handleLoad}
 			/>
 		);
 	}

--- a/libs/components/src/lib/components/MessageWithUser/Photo.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/Photo.tsx
@@ -8,7 +8,7 @@ import {
 	createImgproxyUrl,
 	useIsIntersecting
 } from '@mezon/utils';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { useMessageContextMenu } from '../ContextMenu';
 import { AttachmentSendingIndicator } from './AttachmentSendingIndicator';
 
@@ -94,7 +94,20 @@ const Photo = <T,>({
 
 	const isRecentlySent = !!(photo?.url && photo.url === lastSentUrl);
 	const isUploading = isSending || isPresignPending;
-	const shouldLoad = canAutoLoad && !isPresignPending && (isSending || isIntersecting || isRecentlySent || loadWhenUnpending);
+	// The sender already holds the bytes, so their row never asks the proxy for a
+	// rendition of them. That request is the one thing that can go wrong at the
+	// worst moment: it lands seconds after the object is written, and a proxy
+	// timeout there is cached as a failure for a week — for everyone, triggered by
+	// the one person who did not need the request at all.
+	//
+	// The cost is that this row holds the file in memory until the message leaves
+	// the store, and that a broken object stays invisible to its sender until they
+	// reload. A reload has no blob and takes the ordinary path.
+	const [localFailed, setLocalFailed] = useState(false);
+	const showLocalPreview = !!localSource && !localFailed;
+	const onLocalPreviewError = useCallback(() => setLocalFailed(true), []);
+
+	const shouldLoad = canAutoLoad && !isPresignPending && !showLocalPreview && (isSending || isIntersecting || isRecentlySent || loadWhenUnpending);
 
 	if (isSending && photo?.url) {
 		lastSentUrl = photo.url;
@@ -166,20 +179,6 @@ const Photo = <T,>({
 
 	const thumbnailDataUri = photo.thumbnail?.dataUri;
 	const hasThumbnail = !!thumbnailDataUri;
-	// Hold the local copy until the CDN one is actually painted, not merely
-	// requested: dropping it the moment the upload lands leaves a gap the width of
-	// a network round trip, which reads as a flicker on the sender's own row.
-	const [cdnSettled, setCdnSettled] = useState(false);
-	const onCdnSettled = useCallback(() => setCdnSettled(true), []);
-	const showLocalPreview = !!localSource && !cdnSettled;
-
-	// The object url pins the whole file in memory and the store keeps the
-	// attachment long after the upload lands, so it cannot be held for the row's
-	// lifetime — the CDN copy taking over is what makes it safe to let go.
-	useEffect(() => {
-		if (!cdnSettled || !localSource) return;
-		URL.revokeObjectURL(localSource);
-	}, [cdnSettled, localSource]);
 	const showPresignSkeleton = isPresignPending && !hasThumbnail && !showLocalPreview;
 	const canOpenViewer = !isPresignPending;
 
@@ -206,7 +205,6 @@ const Photo = <T,>({
 					isProtected={isProtected}
 					onContextMenu={onContextMenu}
 					isInSearchMessage={isInSearchMessage}
-					onSettled={onCdnSettled}
 				/>
 			)}
 			{/* The sender's own copy, straight off disk: the CDN object is not there
@@ -218,6 +216,7 @@ const Photo = <T,>({
 					alt=""
 					className="block max-w-full rounded object-cover"
 					style={{ maxHeight: displayHeight, width: width || undefined }}
+					onError={onLocalPreviewError}
 				/>
 			)}
 			{isPresignPending && hasThumbnail && (
@@ -251,12 +250,10 @@ type PhotoImageProps = {
 	isProtected?: boolean;
 	onContextMenu?: (event: React.MouseEvent<HTMLImageElement>) => void;
 	isInSearchMessage?: boolean;
-	/** Called once the CDN copy is on screen — decoded, or failed for good. */
-	onSettled?: () => void;
 };
 
 const PhotoImage = React.memo(
-	({ url, width, height, resizeType, displayWidth, isGif, isProtected, onContextMenu, isInSearchMessage, onSettled }: PhotoImageProps) => {
+	({ url, width, height, resizeType, displayWidth, isGif, isProtected, onContextMenu, isInSearchMessage }: PhotoImageProps) => {
 		const { setImageURL, setPositionShow } = useMessageContextMenu();
 		const [hasError, setHasError] = useState(false);
 
@@ -275,14 +272,7 @@ const PhotoImage = React.memo(
 
 		const handleError = useCallback(() => {
 			setHasError(true);
-			// A dead object must not hide behind the sender's local copy: whatever
-			// everyone else sees, the sender sees too.
-			onSettled?.();
-		}, [onSettled]);
-
-		const handleLoad = useCallback(() => {
-			onSettled?.();
-		}, [onSettled]);
+		}, []);
 
 		if (hasError) {
 			return (
@@ -311,7 +301,6 @@ const PhotoImage = React.memo(
 				style={{ width: displayWidth }}
 				draggable={!isProtected}
 				onError={handleError}
-				onLoad={handleLoad}
 			/>
 		);
 	}

--- a/libs/components/src/lib/components/MessageWithUser/Photo.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/Photo.tsx
@@ -8,19 +8,20 @@ import {
 	createImgproxyUrl,
 	useIsIntersecting
 } from '@mezon/utils';
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useMessageContextMenu } from '../ContextMenu';
 import { AttachmentSendingIndicator } from './AttachmentSendingIndicator';
 
 let lastSentUrl: string | null = null;
 
+/**
+ * In the layout flow on purpose. A locally picked file usually has no measured
+ * width, and the wrapper is `width: auto` — so with every child positioned
+ * absolutely the box collapses to zero and the row renders as nothing at all.
+ * This one is what gives it a size while there is no image to show.
+ */
 function ImageAttachmentSkeleton({ width, height }: { width: number; height: number }) {
-	return (
-		<div
-			style={{ width, height }}
-			className="max-w-full max-h-full absolute bottom-0 left-0 z-[1] rounded-md bg-bgLightSecondary dark:bg-bgSecondary"
-		/>
-	);
+	return <div style={{ width, height }} className="max-w-full rounded-md bg-bgLightSecondary dark:bg-bgSecondary" />;
 }
 
 export type OwnProps<T> = {
@@ -51,6 +52,8 @@ export type OwnProps<T> = {
 	isInSearchMessage?: boolean;
 	isSending?: boolean;
 	isPresignPending?: boolean;
+	/** Object url for the file being uploaded; shown until the CDN copy exists. */
+	localSource?: string;
 	loadWhenUnpending?: boolean;
 	isMobile?: boolean;
 };
@@ -81,6 +84,7 @@ const Photo = <T,>({
 	isInSearchMessage,
 	isSending,
 	isPresignPending = false,
+	localSource,
 	loadWhenUnpending = false,
 	isMobile
 }: OwnProps<T>) => {
@@ -162,7 +166,16 @@ const Photo = <T,>({
 
 	const thumbnailDataUri = photo.thumbnail?.dataUri;
 	const hasThumbnail = !!thumbnailDataUri;
-	const showPresignSkeleton = isPresignPending && !hasThumbnail;
+	const showLocalPreview = isUploading && !!localSource;
+
+	// The object url pins the whole file in memory, and the store keeps the
+	// attachment long after the upload lands. Once the row is no longer uploading
+	// the CDN copy is what renders, so nothing reads this again — let it go.
+	useEffect(() => {
+		if (isUploading || !localSource) return;
+		URL.revokeObjectURL(localSource);
+	}, [isUploading, localSource]);
+	const showPresignSkeleton = isPresignPending && !hasThumbnail && !showLocalPreview;
 	const canOpenViewer = !isPresignPending;
 
 	return (
@@ -188,6 +201,17 @@ const Photo = <T,>({
 					isProtected={isProtected}
 					onContextMenu={onContextMenu}
 					isInSearchMessage={isInSearchMessage}
+				/>
+			)}
+			{/* The sender's own copy, straight off disk: the CDN object is not there
+			    yet, and requesting it early is what pins a 404 in the image proxy's
+			    cache. In the layout flow, so it is also what gives the row a size. */}
+			{showLocalPreview && (
+				<img
+					src={localSource}
+					alt=""
+					className="block max-w-full rounded object-cover"
+					style={{ maxHeight: displayHeight, width: width || undefined }}
 				/>
 			)}
 			{isPresignPending && hasThumbnail && (

--- a/libs/components/src/lib/components/MessageWithUser/Photo.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/Photo.tsx
@@ -166,15 +166,20 @@ const Photo = <T,>({
 
 	const thumbnailDataUri = photo.thumbnail?.dataUri;
 	const hasThumbnail = !!thumbnailDataUri;
-	const showLocalPreview = isUploading && !!localSource;
+	// Hold the local copy until the CDN one is actually painted, not merely
+	// requested: dropping it the moment the upload lands leaves a gap the width of
+	// a network round trip, which reads as a flicker on the sender's own row.
+	const [cdnSettled, setCdnSettled] = useState(false);
+	const onCdnSettled = useCallback(() => setCdnSettled(true), []);
+	const showLocalPreview = !!localSource && !cdnSettled;
 
-	// The object url pins the whole file in memory, and the store keeps the
-	// attachment long after the upload lands. Once the row is no longer uploading
-	// the CDN copy is what renders, so nothing reads this again — let it go.
+	// The object url pins the whole file in memory and the store keeps the
+	// attachment long after the upload lands, so it cannot be held for the row's
+	// lifetime — the CDN copy taking over is what makes it safe to let go.
 	useEffect(() => {
-		if (isUploading || !localSource) return;
+		if (!cdnSettled || !localSource) return;
 		URL.revokeObjectURL(localSource);
-	}, [isUploading, localSource]);
+	}, [cdnSettled, localSource]);
 	const showPresignSkeleton = isPresignPending && !hasThumbnail && !showLocalPreview;
 	const canOpenViewer = !isPresignPending;
 
@@ -201,6 +206,7 @@ const Photo = <T,>({
 					isProtected={isProtected}
 					onContextMenu={onContextMenu}
 					isInSearchMessage={isInSearchMessage}
+					onSettled={onCdnSettled}
 				/>
 			)}
 			{/* The sender's own copy, straight off disk: the CDN object is not there
@@ -245,10 +251,12 @@ type PhotoImageProps = {
 	isProtected?: boolean;
 	onContextMenu?: (event: React.MouseEvent<HTMLImageElement>) => void;
 	isInSearchMessage?: boolean;
+	/** Called once the CDN copy is on screen — decoded, or failed for good. */
+	onSettled?: () => void;
 };
 
 const PhotoImage = React.memo(
-	({ url, width, height, resizeType, displayWidth, isGif, isProtected, onContextMenu, isInSearchMessage }: PhotoImageProps) => {
+	({ url, width, height, resizeType, displayWidth, isGif, isProtected, onContextMenu, isInSearchMessage, onSettled }: PhotoImageProps) => {
 		const { setImageURL, setPositionShow } = useMessageContextMenu();
 		const [hasError, setHasError] = useState(false);
 
@@ -267,7 +275,14 @@ const PhotoImage = React.memo(
 
 		const handleError = useCallback(() => {
 			setHasError(true);
-		}, []);
+			// A dead object must not hide behind the sender's local copy: whatever
+			// everyone else sees, the sender sees too.
+			onSettled?.();
+		}, [onSettled]);
+
+		const handleLoad = useCallback(() => {
+			onSettled?.();
+		}, [onSettled]);
 
 		if (hasError) {
 			return (
@@ -296,6 +311,7 @@ const PhotoImage = React.memo(
 				style={{ width: displayWidth }}
 				draggable={!isProtected}
 				onError={handleError}
+				onLoad={handleLoad}
 			/>
 		);
 	}

--- a/libs/store/src/lib/messages/messages.slice.ts
+++ b/libs/store/src/lib/messages/messages.slice.ts
@@ -17,6 +17,7 @@ import {
 	MessageCrypt,
 	PRESIGN_PENDING_MAX_AGE_SEC,
 	TypeMessage,
+	createLocalPreviewUrl,
 	getMessageCreateTimeSeconds,
 	getPublicKeys,
 	getWebUploadedAttachments,
@@ -24,7 +25,6 @@ import {
 	isTikTokLink,
 	isYouTubeLink,
 	mergePresignFinishContent,
-	createLocalPreviewUrl,
 	revokePreSendAttachmentUrls,
 	toPublicMessageAttachments,
 	withCreateTimeSecondsInUpdateContent
@@ -2114,10 +2114,30 @@ export const messagesSlice = createSlice({
 			if (!existingMessage) {
 				return;
 			}
-			existingMessage.attachments?.forEach(revokePreSendAttachmentUrls);
+
+			// This runs on the upload-first path (anonymous sends), where the
+			// public metadata that lands here has a CDN url and no local copy.
+			// Handing the row that alone sends the sender to the image proxy for
+			// an object uploaded seconds ago — the request that pins a failure in
+			// the proxy's cache, and the one thing this whole path exists to
+			// avoid. The picture stays; only the wire payload is public.
+			const previous = existingMessage.attachments ?? [];
+			const spare = [...previous];
+			const carried = new Set<string>();
+			const withLocalSource = attachments.map((attachment) => {
+				const at = spare.findIndex((p) => p.local_source && p.filename === attachment.filename);
+				if (at === -1) {
+					return attachment;
+				}
+				const [match] = spare.splice(at, 1);
+				carried.add(match.local_source as string);
+				return { ...attachment, local_source: match.local_source };
+			});
+
+			previous.forEach((attachment) => revokePreSendAttachmentUrls(attachment, carried));
 			channelMessagesAdapter.updateOne(channelEntity, {
 				id: messageId,
-				changes: { attachments }
+				changes: { attachments: withLocalSource }
 			});
 		},
 		applyPresignRefresh: (state, action: PayloadAction<{ channelId: string; messageId: string; presignFinish: string[] }>) => {

--- a/libs/store/src/lib/messages/messages.slice.ts
+++ b/libs/store/src/lib/messages/messages.slice.ts
@@ -24,6 +24,7 @@ import {
 	isTikTokLink,
 	isYouTubeLink,
 	mergePresignFinishContent,
+	createLocalPreviewUrl,
 	revokePreSendAttachmentUrls,
 	toPublicMessageAttachments,
 	withCreateTimeSecondsInUpdateContent
@@ -1239,6 +1240,19 @@ export const sendMessage = createAsyncThunk('messages/sendMessage', async (paylo
 			width: attach.width
 		})) ?? [];
 
+	// The row this client renders while the bytes are still going up. Presign has
+	// already rewritten `url` to the CDN object, which does not exist yet, so
+	// without a local source the sender's own message has nothing to show — and
+	// asking for the CDN object early is what pins a 404 in the image proxy cache
+	// for a week. Kept off `attachmentsMessage` so the wire payload (and the size
+	// guard below) never carries a blob url.
+	const sendingAttachmentsMessage: ApiMessageAttachment[] = attachments?.length
+		? attachmentsMessage.map((attachment, index) => {
+				const local_source = createLocalPreviewUrl(attachments[index]);
+				return local_source ? { ...attachment, local_source } : attachment;
+			})
+		: attachmentsMessage;
+
 	const payloadSizeInBytes = Buffer.byteLength(
 		JSON.stringify({
 			...payload,
@@ -1415,7 +1429,7 @@ export const sendMessage = createAsyncThunk('messages/sendMessage', async (paylo
 			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 			// @ts-expect-error
 			content,
-			attachments: attachmentsMessage,
+			attachments: sendingAttachmentsMessage,
 			create_time_seconds: clientSendTime / 1000,
 			create_time: new Date(clientSendTime).toISOString(),
 			client_send_time: clientSendTime,

--- a/libs/utils/src/lib/types/index.ts
+++ b/libs/utils/src/lib/types/index.ts
@@ -1118,8 +1118,13 @@ export enum ENotificationTypes {
 export type PreSendMediaAttachmentFields = {
 	_sourceFile?: File;
 	_thumbnailBlob?: Blob;
-	/** Display-sized copy of the picked image, made once at pick time. */
-	_previewUrl?: string;
+	/**
+	 * Display-sized copy of the picked image, made once at pick time. A blob and
+	 * not a url on purpose: an object url can be revoked out from under the row
+	 * that still holds the string (a resend, or the live-preview cap evicting an
+	 * older one), and a string cannot be re-opened. From the blob it can.
+	 */
+	_previewBlob?: Blob;
 	/**
 	 * Object url for the file this client is uploading right now, so the sender
 	 * sees the picture they just sent instead of a placeholder. Never leaves the

--- a/libs/utils/src/lib/types/index.ts
+++ b/libs/utils/src/lib/types/index.ts
@@ -1118,6 +1118,8 @@ export enum ENotificationTypes {
 export type PreSendMediaAttachmentFields = {
 	_sourceFile?: File;
 	_thumbnailBlob?: Blob;
+	/** Display-sized copy of the picked image, made once at pick time. */
+	_previewUrl?: string;
 	/**
 	 * Object url for the file this client is uploading right now, so the sender
 	 * sees the picture they just sent instead of a placeholder. Never leaves the

--- a/libs/utils/src/lib/types/index.ts
+++ b/libs/utils/src/lib/types/index.ts
@@ -1118,6 +1118,14 @@ export enum ENotificationTypes {
 export type PreSendMediaAttachmentFields = {
 	_sourceFile?: File;
 	_thumbnailBlob?: Blob;
+	/**
+	 * Object url for the file this client is uploading right now, so the sender
+	 * sees the picture they just sent instead of a placeholder. Never leaves the
+	 * browser: presign rewrites `url` to the CDN object before the message is
+	 * sent, and that object does not exist yet — asking for it early is what
+	 * pins a 404 in the image proxy's cache.
+	 */
+	local_source?: string;
 };
 
 export type PreSendMediaAttachment = ApiMessageAttachment & PreSendMediaAttachmentFields;

--- a/libs/utils/src/lib/utils/file.ts
+++ b/libs/utils/src/lib/utils/file.ts
@@ -32,6 +32,31 @@ export function getPreSendThumbnailBlob(attachment: ApiMessageAttachment): Blob 
 }
 
 /**
+ * How many local previews stay alive at once. Leaving a channel does not drop
+ * its messages — only a jump-to-present refetch or a reload does — so without a
+ * cap these accumulate for the whole session. A row whose preview has been
+ * revoked falls back to the network copy on its own, so the oldest can go.
+ */
+const LIVE_LOCAL_PREVIEWS = 12;
+
+const livePreviews: string[] = [];
+
+function rememberPreview(url: string): string {
+	livePreviews.push(url);
+	while (livePreviews.length > LIVE_LOCAL_PREVIEWS) {
+		const oldest = livePreviews.shift();
+		if (oldest) URL.revokeObjectURL(oldest);
+	}
+	return url;
+}
+
+/** Called when a preview is revoked elsewhere, so the cap does not count it twice. */
+export function forgetLocalPreview(url: string): void {
+	const at = livePreviews.indexOf(url);
+	if (at !== -1) livePreviews.splice(at, 1);
+}
+
+/**
  * An object url for the file being uploaded, so the row can show it while the
  * CDN object does not exist yet. Images only: a document already renders as a
  * named box, and the video player has its own poster path — handing either one
@@ -53,10 +78,10 @@ export function createLocalPreviewUrl(attachment: ApiMessageAttachment): string 
 	// original keeps a row that has none from going blank, at the price of holding
 	// the full file until the message leaves the store.
 	const preview = (attachment as PreSendMediaAttachment)._previewUrl;
-	if (preview) return preview;
+	if (preview) return rememberPreview(preview);
 
 	try {
-		return URL.createObjectURL(sourceFile);
+		return rememberPreview(URL.createObjectURL(sourceFile));
 	} catch {
 		return undefined;
 	}
@@ -71,6 +96,7 @@ export function revokePreSendAttachmentUrls(attachment: ApiMessageAttachment): v
 		URL.revokeObjectURL(att.thumbnail);
 	}
 	if (att.local_source?.startsWith('blob:')) {
+		forgetLocalPreview(att.local_source);
 		URL.revokeObjectURL(att.local_source);
 	}
 	if (att._previewUrl?.startsWith('blob:') && att._previewUrl !== att.local_source) {

--- a/libs/utils/src/lib/utils/file.ts
+++ b/libs/utils/src/lib/utils/file.ts
@@ -49,6 +49,12 @@ export function createLocalPreviewUrl(attachment: ApiMessageAttachment): string 
 	const mime = sourceFile.type || attachment.filetype || '';
 	if (!mime.startsWith('image/') && attachment.filetype !== 'image') return undefined;
 
+	// The display-sized copy made when the file was picked. Falling back to the
+	// original keeps a row that has none from going blank, at the price of holding
+	// the full file until the message leaves the store.
+	const preview = (attachment as PreSendMediaAttachment)._previewUrl;
+	if (preview) return preview;
+
 	try {
 		return URL.createObjectURL(sourceFile);
 	} catch {
@@ -67,12 +73,15 @@ export function revokePreSendAttachmentUrls(attachment: ApiMessageAttachment): v
 	if (att.local_source?.startsWith('blob:')) {
 		URL.revokeObjectURL(att.local_source);
 	}
+	if (att._previewUrl?.startsWith('blob:') && att._previewUrl !== att.local_source) {
+		URL.revokeObjectURL(att._previewUrl);
+	}
 }
 
 /** Strip in-memory pre-send fields before persisting on a message entity. */
 export function toPublicMessageAttachments(attachments: ApiMessageAttachment[]): ApiMessageAttachment[] {
 	return attachments.map((attachment) => {
-		const { _sourceFile: _sf, _thumbnailBlob: _tb, ...publicAttachment } = attachment as PreSendMediaAttachment;
+		const { _sourceFile: _sf, _thumbnailBlob: _tb, _previewUrl: _pu, ...publicAttachment } = attachment as PreSendMediaAttachment;
 		return publicAttachment;
 	});
 }
@@ -123,6 +132,44 @@ async function processVideoFile<T>(file: File): Promise<T> {
 	return metadata as T;
 }
 
+/**
+ * Longest edge of the preview the sender's own row renders. Covers the widest
+ * message column on a 2x screen; past that the extra pixels are decoded, held in
+ * memory and never seen.
+ */
+const LOCAL_PREVIEW_MAX_EDGE = 1024;
+
+/**
+ * A display-sized copy of a picked image, made from the decode `processImageFile`
+ * already pays for. CSS cannot do this: a 4000x3000 photo drawn into a 200px box
+ * still decodes to a ~48MB bitmap, so ten of them cost half a gigabyte. Sizing it
+ * here is what makes the preview affordable when a whole album is in flight.
+ */
+function downscaledPreviewUrl(img: HTMLImageElement, type: string): Promise<string | undefined> {
+	return new Promise((resolve) => {
+		try {
+			const longest = Math.max(img.width, img.height);
+			if (!longest) return resolve(undefined);
+
+			const scale = Math.min(1, LOCAL_PREVIEW_MAX_EDGE / longest);
+			const canvas = document.createElement('canvas');
+			canvas.width = Math.max(1, Math.round(img.width * scale));
+			canvas.height = Math.max(1, Math.round(img.height * scale));
+
+			const ctx = canvas.getContext('2d');
+			if (!ctx) return resolve(undefined);
+			ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+
+			// Keep alpha for the formats that carry it; everything else is smaller
+			// as a jpeg, and this copy is thrown away as soon as the row is gone.
+			const outputType = type === 'image/png' || type === 'image/webp' ? type : 'image/jpeg';
+			canvas.toBlob((blob) => resolve(blob ? URL.createObjectURL(blob) : undefined), outputType, 0.85);
+		} catch {
+			resolve(undefined);
+		}
+	});
+}
+
 function processImageFile<T>(file: File): Promise<T> {
 	return new Promise((resolve) => {
 		const reader = new FileReader();
@@ -133,7 +180,8 @@ function processImageFile<T>(file: File): Promise<T> {
 					...createFileMetadata(file),
 					width: img.width,
 					height: img.height,
-					_sourceFile: file
+					_sourceFile: file,
+					_previewUrl: await downscaledPreviewUrl(img, file.type)
 				} as T;
 
 				resolve(metadata);

--- a/libs/utils/src/lib/utils/file.ts
+++ b/libs/utils/src/lib/utils/file.ts
@@ -41,8 +41,13 @@ export function createLocalPreviewUrl(attachment: ApiMessageAttachment): string 
 	const sourceFile = getPreSendSourceFile(attachment);
 	if (!sourceFile) return undefined;
 
-	const filetype = attachment.filetype || sourceFile.type;
-	if (!filetype?.startsWith('image/')) return undefined;
+	// Presign rewrites `filetype` to the bare upload CATEGORY ("image"), so by the
+	// time the row is built the MIME survives only on the file itself. Read that
+	// first and take the category as the fallback — matching on `image/` alone
+	// misses every attachment that has already been through presign, which is all
+	// of them by the time anything renders.
+	const mime = sourceFile.type || attachment.filetype || '';
+	if (!mime.startsWith('image/') && attachment.filetype !== 'image') return undefined;
 
 	try {
 		return URL.createObjectURL(sourceFile);

--- a/libs/utils/src/lib/utils/file.ts
+++ b/libs/utils/src/lib/utils/file.ts
@@ -31,6 +31,26 @@ export function getPreSendThumbnailBlob(attachment: ApiMessageAttachment): Blob 
 	return (attachment as PreSendMediaAttachment)._thumbnailBlob;
 }
 
+/**
+ * An object url for the file being uploaded, so the row can show it while the
+ * CDN object does not exist yet. Images only: a document already renders as a
+ * named box, and the video player has its own poster path — handing either one
+ * a url nothing reads would just pin the file in memory.
+ */
+export function createLocalPreviewUrl(attachment: ApiMessageAttachment): string | undefined {
+	const sourceFile = getPreSendSourceFile(attachment);
+	if (!sourceFile) return undefined;
+
+	const filetype = attachment.filetype || sourceFile.type;
+	if (!filetype?.startsWith('image/')) return undefined;
+
+	try {
+		return URL.createObjectURL(sourceFile);
+	} catch {
+		return undefined;
+	}
+}
+
 export function revokePreSendAttachmentUrls(attachment: ApiMessageAttachment): void {
 	const att = attachment as PreSendMediaAttachment;
 	if (att.url?.startsWith('blob:')) {
@@ -38,6 +58,9 @@ export function revokePreSendAttachmentUrls(attachment: ApiMessageAttachment): v
 	}
 	if (att.thumbnail?.startsWith('blob:')) {
 		URL.revokeObjectURL(att.thumbnail);
+	}
+	if (att.local_source?.startsWith('blob:')) {
+		URL.revokeObjectURL(att.local_source);
 	}
 }
 

--- a/libs/utils/src/lib/utils/file.ts
+++ b/libs/utils/src/lib/utils/file.ts
@@ -74,40 +74,43 @@ export function createLocalPreviewUrl(attachment: ApiMessageAttachment): string 
 	const mime = sourceFile.type || attachment.filetype || '';
 	if (!mime.startsWith('image/') && attachment.filetype !== 'image') return undefined;
 
-	// The display-sized copy made when the file was picked. Falling back to the
-	// original keeps a row that has none from going blank, at the price of holding
-	// the full file until the message leaves the store.
-	const preview = (attachment as PreSendMediaAttachment)._previewUrl;
-	if (preview) return rememberPreview(preview);
+	// The display-sized copy made when the file was picked, falling back to the
+	// original for a row that has none. The url is minted here rather than stored
+	// on the attachment, so revoking one is always recoverable: a resend, or a
+	// re-render after the cap evicted this row's preview, just opens the blob
+	// again instead of handing the img a url that no longer resolves.
+	const source = (attachment as PreSendMediaAttachment)._previewBlob ?? sourceFile;
 
 	try {
-		return rememberPreview(URL.createObjectURL(sourceFile));
+		return rememberPreview(URL.createObjectURL(source));
 	} catch {
 		return undefined;
 	}
 }
 
-export function revokePreSendAttachmentUrls(attachment: ApiMessageAttachment): void {
+/**
+ * `keep` is for the case where the row is being replaced rather than dropped and
+ * some of its urls move to the replacement — revoking those would blank the very
+ * row that just inherited them.
+ */
+export function revokePreSendAttachmentUrls(attachment: ApiMessageAttachment, keep?: ReadonlySet<string>): void {
 	const att = attachment as PreSendMediaAttachment;
-	if (att.url?.startsWith('blob:')) {
+	if (att.url?.startsWith('blob:') && !keep?.has(att.url)) {
 		URL.revokeObjectURL(att.url);
 	}
-	if (att.thumbnail?.startsWith('blob:')) {
+	if (att.thumbnail?.startsWith('blob:') && !keep?.has(att.thumbnail)) {
 		URL.revokeObjectURL(att.thumbnail);
 	}
-	if (att.local_source?.startsWith('blob:')) {
+	if (att.local_source?.startsWith('blob:') && !keep?.has(att.local_source)) {
 		forgetLocalPreview(att.local_source);
 		URL.revokeObjectURL(att.local_source);
-	}
-	if (att._previewUrl?.startsWith('blob:') && att._previewUrl !== att.local_source) {
-		URL.revokeObjectURL(att._previewUrl);
 	}
 }
 
 /** Strip in-memory pre-send fields before persisting on a message entity. */
 export function toPublicMessageAttachments(attachments: ApiMessageAttachment[]): ApiMessageAttachment[] {
 	return attachments.map((attachment) => {
-		const { _sourceFile: _sf, _thumbnailBlob: _tb, _previewUrl: _pu, ...publicAttachment } = attachment as PreSendMediaAttachment;
+		const { _sourceFile: _sf, _thumbnailBlob: _tb, _previewBlob: _pb, ...publicAttachment } = attachment as PreSendMediaAttachment;
 		return publicAttachment;
 	});
 }
@@ -166,12 +169,21 @@ async function processVideoFile<T>(file: File): Promise<T> {
 const LOCAL_PREVIEW_MAX_EDGE = 1024;
 
 /**
+ * Formats a canvas cannot copy without destroying them. `drawImage` takes a
+ * single frame, so a gif or an animated webp comes back as a still — and since
+ * the sender's row prefers its local copy for as long as the row exists, that
+ * still is what they would watch until a reload. These keep their original
+ * bytes instead; the live-preview cap is what makes that affordable.
+ */
+const ANIMATED_IMAGE_TYPES = new Set(['image/gif', 'image/webp', 'image/apng', 'image/avif']);
+
+/**
  * A display-sized copy of a picked image, made from the decode `processImageFile`
  * already pays for. CSS cannot do this: a 4000x3000 photo drawn into a 200px box
  * still decodes to a ~48MB bitmap, so ten of them cost half a gigabyte. Sizing it
  * here is what makes the preview affordable when a whole album is in flight.
  */
-function downscaledPreviewUrl(img: HTMLImageElement, type: string): Promise<string | undefined> {
+function downscaledPreviewBlob(img: HTMLImageElement, type: string): Promise<Blob | undefined> {
 	return new Promise((resolve) => {
 		try {
 			const longest = Math.max(img.width, img.height);
@@ -188,8 +200,8 @@ function downscaledPreviewUrl(img: HTMLImageElement, type: string): Promise<stri
 
 			// Keep alpha for the formats that carry it; everything else is smaller
 			// as a jpeg, and this copy is thrown away as soon as the row is gone.
-			const outputType = type === 'image/png' || type === 'image/webp' ? type : 'image/jpeg';
-			canvas.toBlob((blob) => resolve(blob ? URL.createObjectURL(blob) : undefined), outputType, 0.85);
+			const outputType = type === 'image/png' ? type : 'image/jpeg';
+			canvas.toBlob((blob) => resolve(blob ?? undefined), outputType, 0.85);
 		} catch {
 			resolve(undefined);
 		}
@@ -207,7 +219,7 @@ function processImageFile<T>(file: File): Promise<T> {
 					width: img.width,
 					height: img.height,
 					_sourceFile: file,
-					_previewUrl: await downscaledPreviewUrl(img, file.type)
+					_previewBlob: ANIMATED_IMAGE_TYPES.has(file.type) ? undefined : await downscaledPreviewBlob(img, file.type)
 				} as T;
 
 				resolve(metadata);


### PR DESCRIPTION
## The bug

Send a picture and the row is blank until the upload finishes — no preview, not even a placeholder. A `.txt` shows nothing either (that half is already fixed on develop by #13629, just not deployed yet).

## Why

Presign runs before the message is sent and rewrites the attachment url to its CDN object (`presignUpload.ts:45`), so the optimistic row points at an object that **does not exist yet**, with `presign_finish: []`. The presign gate then does its job:

```
Photo.tsx  shouldLoad = canAutoLoad && !isPresignPending && (...)   → false
```

That gate is right — loading the CDN url early gets a 404 that the image proxy caches for a week (`cache-control: public, max-age=604800` on failures), which is a far worse bug than a blank row.

What was left to render were the skeleton and the sending indicator, **both absolutely positioned**, inside a wrapper whose style is `width: width ? \`${width}px\` : 'auto'`. A locally picked file has no measured width, so the wrapper is `auto` with no in-flow children — zero wide, and nothing on screen.

## The fix

- `local_source`: an object url for the file, attached to the optimistic message only. It is built from `_sourceFile` (already kept for the upload), stays off `attachmentsMessage`, so neither the wire payload nor the 4KB size guard ever sees a blob url.
- `Photo` renders it while `isSending || isPresignPending`, **in the layout flow** — so it is also what gives the row its size — with the spinner and label overlaid as before.
- The skeleton is in the flow too now, so a row with no local source (a receiver, a resend) shows a real box instead of collapsing.
- The url is revoked as soon as the row stops uploading; an object url pins the whole file in memory and the store keeps the attachment long after.
- Images only. A document already renders as a named box, and the video player has its own poster path — creating a url nothing reads would just hold the file.

## Testing

- Typecheck over the touched libs: no errors in the changed files.
- `prettier --check` on all six files: clean.