### PR TITLE
fix(web): restore the develop typecheck after the local-preview merge

### DIFF
--- a/libs/store/src/lib/messages/messages.slice.ts
+++ b/libs/store/src/lib/messages/messages.slice.ts
@@ -6,6 +6,7 @@ import type {
 	IMessageSendPayload,
 	IMessageWithUser,
 	LoadingStatus,
+	PreSendMediaAttachment,
 	PublicKeyMaterial
 } from '@mezon/utils';
 import {
@@ -1672,7 +1673,8 @@ export const sendEphemeralMessage = createAsyncThunk('messages/sendEphemeralMess
 		if (attachments && attachments.length > 0) {
 			thunkAPI.dispatch(handleUploadFileToMinIO(attachments));
 
-			attachments.forEach(revokePreSendAttachmentUrls);
+			// Not point-free: forEach would hand the index in as `keep`.
+			attachments.forEach((attachment) => revokePreSendAttachmentUrls(attachment));
 		}
 
 		let avatarToUse = avatar;
@@ -2121,7 +2123,7 @@ export const messagesSlice = createSlice({
 			// an object uploaded seconds ago — the request that pins a failure in
 			// the proxy's cache, and the one thing this whole path exists to
 			// avoid. The picture stays; only the wire payload is public.
-			const previous = existingMessage.attachments ?? [];
+			const previous = (existingMessage.attachments ?? []) as PreSendMediaAttachment[];
 			const spare = [...previous];
 			const carried = new Set<string>();
 			const withLocalSource = attachments.map((attachment) => {
@@ -2890,7 +2892,8 @@ const handleRemoveOneMessage = ({ state, channelId, messageId }: { state: Messag
 	}
 
 	const removedMessage = channelEntity.entities[messageId];
-	removedMessage?.attachments?.forEach(revokePreSendAttachmentUrls);
+	// Not point-free: forEach would hand the index in as `keep`.
+	removedMessage?.attachments?.forEach((attachment) => revokePreSendAttachmentUrls(attachment));
 
 	return channelMessagesAdapter.removeOne(channelEntity, messageId);
 };


### PR DESCRIPTION
`revokePreSendAttachmentUrls` takes an optional `keep` set as its second argument, so handing it straight to `forEach` binds the array index there. That is the type error, and it is also a real crash: `keep?.has(...)` does not short-circuit on a number, so the call throws the moment an attachment actually holds a blob url — an ephemeral send with attachments never reaches `writeEphemeralMessage`, and removing an optimistic row that still carries a local preview throws inside the reducer.

`local_source` lives on `PreSendMediaAttachment`, not on the generated `ApiMessageAttachment`, so the carry-over lookup has to read the pre-send shape to see it.