### PR TITLE
fix(web): stop the sender from asking the proxy for objects it just wrote

### DIFF
--- a/libs/components/src/lib/components/MessageWithUser/Photo.tsx
+++ b/libs/components/src/lib/components/MessageWithUser/Photo.tsx
@@ -178,7 +178,12 @@ const Photo = <T,>({
 
 	const thumbnailDataUri = photo.thumbnail?.dataUri;
 	const hasThumbnail = !!thumbnailDataUri;
-	const canOpenViewer = !isPresignPending;
+	// `isPresignPending` alone leaves the upload-first paths open: an anonymous
+	// send is never presign-pending, only sending, and the row already carries the
+	// CDN url of an object that has not been written yet. Opening the viewer on it
+	// asks the image proxy for that object and pins the failure in its cache for a
+	// week. The desktop row gates on the same set of states.
+	const canOpenViewer = !isUploading;
 
 	// The proxied copy is absolutely positioned, so between "start loading" and
 	// "decoded" there is nothing in the layout at all and the row goes blank for

--- a/libs/utils/src/lib/utils/file.ts
+++ b/libs/utils/src/lib/utils/file.ts
@@ -1,6 +1,6 @@
 import type { Dispatch } from '@reduxjs/toolkit';
 import type { ApiMessageAttachment } from 'mezon-js';
-import { IMAGE_MAX_FILE_SIZE, MAX_FILE_SIZE, fileTypeImage } from '../constant';
+import { IMAGE_MAX_FILE_SIZE, MAX_FILE_ATTACHMENTS, MAX_FILE_SIZE, fileTypeImage } from '../constant';
 import { captureVideoPosterFromUrl } from '../helper/videoPoster';
 import type {
 	IMentionOnMessage,
@@ -37,23 +37,38 @@ export function getPreSendThumbnailBlob(attachment: ApiMessageAttachment): Blob 
  * cap these accumulate for the whole session. A row whose preview has been
  * revoked falls back to the network copy on its own, so the oldest can go.
  */
-const LIVE_LOCAL_PREVIEWS = 12;
+/**
+ * Counting previews was the wrong unit. A message may carry MAX_FILE_ATTACHMENTS
+ * of them, so any count below that let a single send revoke its own oldest
+ * previews mid-upload — and those rows then asked the image proxy for objects
+ * that had just been written, which is the one request this whole path exists to
+ * avoid. The floor is therefore one full message; the byte ceiling is what keeps
+ * the pathological case (an album of untouched gifs, which skip the downscale)
+ * from holding half a gigabyte.
+ */
+const LIVE_PREVIEW_MAX_BYTES = 128 * 1024 * 1024;
 
-const livePreviews: string[] = [];
+const livePreviews: { url: string; bytes: number }[] = [];
+let livePreviewBytes = 0;
 
-function rememberPreview(url: string): string {
-	livePreviews.push(url);
-	while (livePreviews.length > LIVE_LOCAL_PREVIEWS) {
+function rememberPreview(url: string, bytes: number): string {
+	livePreviews.push({ url, bytes });
+	livePreviewBytes += bytes;
+	while (livePreviews.length > 1 && (livePreviews.length > MAX_FILE_ATTACHMENTS || livePreviewBytes > LIVE_PREVIEW_MAX_BYTES)) {
 		const oldest = livePreviews.shift();
-		if (oldest) URL.revokeObjectURL(oldest);
+		if (!oldest) break;
+		livePreviewBytes -= oldest.bytes;
+		URL.revokeObjectURL(oldest.url);
 	}
 	return url;
 }
 
 /** Called when a preview is revoked elsewhere, so the cap does not count it twice. */
 export function forgetLocalPreview(url: string): void {
-	const at = livePreviews.indexOf(url);
-	if (at !== -1) livePreviews.splice(at, 1);
+	const at = livePreviews.findIndex((preview) => preview.url === url);
+	if (at === -1) return;
+	livePreviewBytes -= livePreviews[at].bytes;
+	livePreviews.splice(at, 1);
 }
 
 /**
@@ -82,7 +97,7 @@ export function createLocalPreviewUrl(attachment: ApiMessageAttachment): string 
 	const source = (attachment as PreSendMediaAttachment)._previewBlob ?? sourceFile;
 
 	try {
-		return rememberPreview(URL.createObjectURL(source));
+		return rememberPreview(URL.createObjectURL(source), source.size);
 	} catch {
 		return undefined;
 	}

--- a/libs/utils/src/lib/utils/index.ts
+++ b/libs/utils/src/lib/utils/index.ts
@@ -830,9 +830,10 @@ export async function getWebUploadedAttachments(payload: {
 				throw new Error(`Upload failed for ${createdFile.name}`);
 			}
 
-			if (result && createdFile.thumbnailBlob && attachment?.thumbnailUpload && createdFile.thumbnail && createdFile.type.startsWith('video')) {
-				await uploadFileToPath(attachment.thumbnailUpload, createdFile.thumbnailBlob, createdFile.thumbnailBlob?.size);
-			}
+			// The video poster is uploaded by generatePathAttachments, before the
+			// message is posted — its url is only put on the wire once the object
+			// exists. It used to be uploaded here instead, after the message had
+			// already published the url, with the result discarded.
 			fileUploadForeman.releaseWorker();
 			const id = attachment.uploadName?.split('/').pop()?.split('.')[0];
 			return id;

--- a/libs/utils/src/lib/utils/presignUpload.ts
+++ b/libs/utils/src/lib/utils/presignUpload.ts
@@ -1,3 +1,4 @@
+import { uploadFileToPath } from '@mezon/transport';
 import type { ApiMessageAttachment, ApiSession, Client } from 'mezon-js';
 import { AttachmentTypeUpload } from '../types';
 import { isMezonCdnUrl, isTenorUrl } from './urlSanitization';
@@ -25,16 +26,26 @@ export async function generatePathAttachments(client: Client, session: ApiSessio
 					width: attach.width,
 					height: attach.height
 				});
+				// The poster is uploaded HERE, before the message is posted, and its url
+				// is published only once the object is actually on the CDN. It used to
+				// ride along after the main file, with its result thrown away — so a
+				// failed poster PUT left every client pointing at an object that was
+				// never written, and one imgproxy miss on that url is cached for a
+				// week. It is a few tens of kilobytes; paying for it up front is what
+				// makes the url on the wire a promise the sender has already kept.
 				let thumbnail;
-				if (attach.filetype?.startsWith('video') && (attach as File & { _thumbnailBlob?: Blob })?._thumbnailBlob) {
-					const thumbnailBlob = (attach as File & { _thumbnailBlob?: Blob })._thumbnailBlob as Blob;
+				const thumbnailBlob = (attach as File & { _thumbnailBlob?: Blob })?._thumbnailBlob;
+				if (attach.filetype?.startsWith('video') && thumbnailBlob) {
 					const ms = Date.now();
 					const filename = `${ms}_thumbnail.png`;
-					thumbnail = await client.uploadAttachmentFile(session, {
+					const presignedThumbnail = await client.uploadAttachmentFile(session, {
 						filename,
 						filetype: thumbnailBlob.type,
 						size: thumbnailBlob.size
 					});
+					if (presignedThumbnail?.url && (await uploadFileToPath(presignedThumbnail.url, thumbnailBlob, thumbnailBlob.size))) {
+						thumbnail = presignedThumbnail;
+					}
 				}
 
 				return {
@@ -44,8 +55,7 @@ export async function generatePathAttachments(client: Client, session: ApiSessio
 					uploadName: data.filename,
 					url: `${process.env.NX_BASE_IMG_URL}/${data.filename}`,
 					uploadPath: data.url,
-					...(thumbnail && thumbnail?.filename && { thumbnail: `${process.env.NX_BASE_IMG_URL}/${thumbnail.filename}` }),
-					...(thumbnail && thumbnail?.url && { thumbnailUpload: thumbnail.url })
+					...(thumbnail && thumbnail?.filename && { thumbnail: `${process.env.NX_BASE_IMG_URL}/${thumbnail.filename}` })
 				};
 			} catch (error) {
 				console.error('error: ', error);


### PR DESCRIPTION
Three paths could ask imgproxy for an object that was not on the CDN yet — or never would be. A miss there is cached for a week, for every client, and it is always triggered by the one person who did not need the request.

### The poster upload's result was discarded

`uploadFileToPath` answers a failed PUT with `false`, not a throw, and the video poster's call ignored the return value — while the main file's call has `if (!result) throw` with a comment explaining exactly this hazard three lines above. A failed poster left the message pointing at an object that was never written.

The poster is now uploaded inside `generatePathAttachments`, before the message is posted, and `thumbnail` is put on the wire only once the object exists.

**Measured:** the poster PNG is PUT before the video, and the row renders it.

### The live-preview cap counted the wrong thing

A message may carry `MAX_FILE_ATTACHMENTS` previews, so a cap of 12 let one send revoke its own oldest previews mid-upload.

**Measured before:** 15 pictures → 3 previews revoked → those three tiles loaded from `imgproxy.komu.vn` (`complete: true`, `naturalWidth: 153`) for objects written seconds earlier.
**Measured after:** 15/15 tiles render from their local blob, 0 proxy requests.

The floor is one full message now, plus a byte ceiling for what the count cannot see — an album of gifs, which skip the downscale and keep their original bytes.

### The viewer opened on rows that were still uploading

`canOpenViewer = !isPresignPending` left the upload-first paths open: an anonymous send is never presign-pending, only sending, and its row already carries the CDN url of an object that does not exist. The desktop row gates on the whole set of states; this one now does too.

---

Verified against a live prod session in CLAN TEST 01 → #general. No behaviour change for a settled row: A/B'd the viewer against develop's build on the same tile.