### PR TITLE
260826-web-fix- Empty space is displayed when sending a Facebook reel

### DIFF
--- a/libs/components/src/lib/components/MessageBox/PreviewOgp.tsx
+++ b/libs/components/src/lib/components/MessageBox/PreviewOgp.tsx
@@ -10,7 +10,7 @@ import {
 } from '@mezon/store';
 import { Icons } from '@mezon/ui';
 import type { IInvite } from '@mezon/utils';
-import { INVITE_URL_REGEX, checkInviteLinkValid, isFacebookLink, isTikTokLink, isYouTubeLink } from '@mezon/utils';
+import { INVITE_URL_REGEX, checkInviteLinkValid, isTikTokLink, isYouTubeLink } from '@mezon/utils';
 import { memo, useCallback, useEffect, useRef, useState, type SyntheticEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
@@ -51,7 +51,7 @@ function PreviewOgp({ contextId }: PreviewOgpProps) {
 			return;
 		}
 
-		const isSocialMediaLink = isYouTubeLink(ogpLink.url) || isFacebookLink(ogpLink.url) || isTikTokLink(ogpLink.url);
+		const isSocialMediaLink = isYouTubeLink(ogpLink.url) || isTikTokLink(ogpLink.url);
 		if (isSocialMediaLink) {
 			setData(null);
 			dispatch(referencesActions.clearOgpData());

--- a/libs/core/src/lib/chat/hooks/useThreadMessage.ts
+++ b/libs/core/src/lib/chat/hooks/useThreadMessage.ts
@@ -20,7 +20,6 @@ import {
 	EBacktickType,
 	generatePathAttachments,
 	getWebUploadedAttachments,
-	isFacebookLink,
 	isTikTokLink,
 	isYouTubeLink,
 	uniqueUsers
@@ -84,7 +83,7 @@ export function useThreadMessage({ channelId, mode, username }: UseThreadMessage
 			let threadContent = content;
 			const store = getStore();
 			const ogpData = selectOgpData(store.getState());
-			const isSocialMediaLink = ogpData?.url && (isYouTubeLink(ogpData.url) || isFacebookLink(ogpData.url) || isTikTokLink(ogpData.url));
+			const isSocialMediaLink = ogpData?.url && (isYouTubeLink(ogpData.url) || isTikTokLink(ogpData.url));
 			const isOgpFromThreadBox =
 				ogpData &&
 				(ogpData.channel_id === thread.channel_id || ogpData.channel_id === CREATING_THREAD) &&

--- a/libs/store/src/lib/messages/messages.slice.ts
+++ b/libs/store/src/lib/messages/messages.slice.ts
@@ -22,7 +22,6 @@ import {
 	getMessageCreateTimeSeconds,
 	getPublicKeys,
 	getWebUploadedAttachments,
-	isFacebookLink,
 	isTikTokLink,
 	isYouTubeLink,
 	mergePresignFinishContent,
@@ -1358,7 +1357,7 @@ export const sendMessage = createAsyncThunk('messages/sendMessage', async (paylo
 
 		const ogpData = selectOgpData(rootState);
 
-		const isSocialMediaLink = ogpData?.url && (isYouTubeLink(ogpData.url) || isFacebookLink(ogpData.url) || isTikTokLink(ogpData.url));
+		const isSocialMediaLink = ogpData?.url && (isYouTubeLink(ogpData.url) || isTikTokLink(ogpData.url));
 
 		if (ogpData && ogpData?.channel_id === channelId && content?.mk && content?.mk?.length > 0 && !isSocialMediaLink) {
 			const mk = [...(content.mk ?? [])];

--- a/libs/store/src/lib/topicDiscussion/topicDiscussions.slice.ts
+++ b/libs/store/src/lib/topicDiscussion/topicDiscussions.slice.ts
@@ -1,14 +1,6 @@
 import { captureSentryError } from '@mezon/logger';
 import type { IMessageSendPayload, IMessageWithUser, LoadingStatus } from '@mezon/utils';
-import {
-	CREATING_TOPIC,
-	EBacktickType,
-	generatePathAttachments,
-	getWebUploadedAttachments,
-	isFacebookLink,
-	isTikTokLink,
-	isYouTubeLink
-} from '@mezon/utils';
+import { CREATING_TOPIC, EBacktickType, generatePathAttachments, getWebUploadedAttachments, isTikTokLink, isYouTubeLink } from '@mezon/utils';
 import type { EntityState, PayloadAction } from '@reduxjs/toolkit';
 import { createAsyncThunk, createEntityAdapter, createSelector, createSlice } from '@reduxjs/toolkit';
 import type {
@@ -263,7 +255,7 @@ export const handleSendTopic = createAsyncThunk('topics/sendTopicMessage', async
 	let topicContent = content;
 	const state = thunkAPI.getState() as RootState;
 	const ogpData = selectOgpData(state);
-	const isSocialMediaLink = ogpData?.url && (isYouTubeLink(ogpData.url) || isFacebookLink(ogpData.url) || isTikTokLink(ogpData.url));
+	const isSocialMediaLink = ogpData?.url && (isYouTubeLink(ogpData.url) || isTikTokLink(ogpData.url));
 	const isOgpFromTopicBox =
 		ogpData &&
 		(ogpData.channel_id === topicId || ogpData.channel_id === CREATING_TOPIC || ogpData.channel_id === channelId) &&

--- a/libs/utils/src/lib/utils/embed-social.ts
+++ b/libs/utils/src/lib/utils/embed-social.ts
@@ -6,7 +6,6 @@ export function isYouTubeLink(url: string): boolean {
 
 export function getLinkType(url: string): EBacktickType {
 	if (isYouTubeLink(url)) return EBacktickType.LINKYOUTUBE;
-	if (isFacebookLink(url)) return EBacktickType.LINKFACEBOOK;
 	if (isTikTokLink(url)) return EBacktickType.LINKTIKTOK;
 	return EBacktickType.LINK;
 }


### PR DESCRIPTION
[videoo.webm](https://github.com/user-attachments/assets/e8cad731-e63a-40fe-843e-47363fa49c6a)
