### PR TITLE
260831 - WEB - Fix: Hidden open menu button on Safari iOS (WebKit)

### DIFF
--- a/libs/ui/src/lib/Icons/icons.tsx
+++ b/libs/ui/src/lib/Icons/icons.tsx
@@ -1805,14 +1805,14 @@ export const Download: React.FC<IconProps> = ({ defaultFill1 = '#AEAEAE', defaul
 };
 
 export const OpenMenu: React.FC<IconProps> = ({
-	defaultSize = 'w-5 h-5 ',
+	defaultSize = 'w-5 h-5',
 	defaultFill1 = 'currentColor',
 	defaultFill2 = 'currentColor',
 	defaultFill3 = 'currentColor',
 	...props
 }: IconProps) => {
 	return (
-		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 297 297" {...props}>
+		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 297 297" className={defaultSize} {...props}>
 			{' '}
 			<g>
 				{' '}


### PR DESCRIPTION
## Cause
The default width and height of the svg is not initialized, so WebKit doesn't render it on screen since height = 0.

## Solution
Added default width and height.

## Tests

https://github.com/user-attachments/assets/279b8fcc-4651-46a5-bd59-6cf384999931

