### PR TITLE
260831 - WEB - Refactor: Put VoiceInteractive button out of ReactionControls to ControlBar

### DIFF
--- a/libs/components/src/lib/components/VoiceChannel/ControlBar/ControlBar.tsx
+++ b/libs/components/src/lib/components/VoiceChannel/ControlBar/ControlBar.tsx
@@ -26,6 +26,7 @@ import Tooltip from 'rc-tooltip';
 import { RecordingControl } from '../Recording/RecordingControl';
 import { AgentControl } from './AgentControl';
 import { RaisingHandControls } from './RaisingHandControl';
+import { VoiceInteractiveControl } from './VoiceInteractiveControl';
 import { useControlBarPermissions } from './hooks/useControlBarPermissions';
 import { useViewControls } from './hooks/useViewControls';
 
@@ -36,6 +37,7 @@ export type ControlBarControls = {
 	leave?: boolean;
 	noiseSuppression?: boolean;
 	backgroundEffect?: boolean;
+	voiceInteractive?: boolean;
 	emoji?: boolean;
 	sound?: boolean;
 	popout?: boolean;
@@ -79,6 +81,7 @@ const ControlBar = ({
 	const visibleControls = useControlBarPermissions(controls);
 	const { isOpenPopOut, togglePopout } = useViewControls();
 	const [permissionModalSource, setPermissionModalSource] = useState<Track.Source | null>(null);
+	const [showVoiceInteractive, setShowVoiceInteractive] = useState(false);
 	const { cameraPermissionState, microphonePermissionState, refreshPermissions } = useMediaPermissions();
 
 	const browserSupportsScreenSharing = supportsScreenSharing();
@@ -226,12 +229,26 @@ const ControlBar = ({
 		}
 	}, [permissionModalSource, openPermissionModal, closePermissionModal]);
 
+	useEffect(() => {
+		if (!showVoiceInteractive) return;
+		const handleKeyDown = (e: KeyboardEvent) => {
+			if (e.key === 'Escape' || e.key === 'Esc') {
+				setShowVoiceInteractive(false);
+			}
+		};
+		window.addEventListener('keydown', handleKeyDown);
+		return () => window.removeEventListener('keydown', handleKeyDown);
+	}, [showVoiceInteractive]);
+
 	return (
 		<div className="lk-control-bar !flex !justify-between !border-none !bg-transparent max-md:flex-col">
 			{/* Desktop groups emoji, sound and record together on the left (mezon-ui/src/chat/voice.rs). */}
 			<div className="flex justify-start items-center gap-4">
 				{!isExternalCalling && (
 					<ReactionControls isGroupCall={isGroupCall} isGridView={isGridView} isShowMember={isShowMember} className="max-md:hidden" />
+				)}
+				{visibleControls.voiceInteractive && (
+					<VoiceInteractiveControl showVoiceInteractive={showVoiceInteractive} onVisibleChange={setShowVoiceInteractive} />
 				)}
 				{visibleControls.recording && <RecordingControl channelLabel={channelLabel} />}
 			</div>

--- a/libs/components/src/lib/components/VoiceChannel/ControlBar/ReactionControls.tsx
+++ b/libs/components/src/lib/components/VoiceChannel/ControlBar/ReactionControls.tsx
@@ -2,7 +2,6 @@ import clsx from 'clsx';
 import { memo } from 'react';
 import { EmojiReactionControl } from './EmojiReactionControl';
 import { SoundReactionControl } from './SoundReactionControl';
-import { VoiceInteractiveControl } from './VoiceInteractiveControl';
 import { useReactionControls } from './hooks/useReactionControls';
 
 interface ReactionControlsProps {
@@ -13,16 +12,7 @@ interface ReactionControlsProps {
 }
 
 export const ReactionControls = memo(({ isGroupCall, isGridView, isShowMember, className }: ReactionControlsProps) => {
-	const {
-		showEmojiPanel,
-		setShowEmojiPanel,
-		showSoundPanel,
-		setShowSoundPanel,
-		showVoiceInteractive,
-		setShowVoiceInteractive,
-		handleEmojiSelect,
-		handleSoundSelect
-	} = useReactionControls();
+	const { showEmojiPanel, setShowEmojiPanel, showSoundPanel, setShowSoundPanel, handleEmojiSelect, handleSoundSelect } = useReactionControls();
 
 	if (isGroupCall) {
 		return null;
@@ -44,7 +34,6 @@ export const ReactionControls = memo(({ isGroupCall, isGridView, isShowMember, c
 				onVisibleChange={setShowSoundPanel}
 				onSoundSelect={handleSoundSelect}
 			/>
-			<VoiceInteractiveControl showVoiceInteractive={showVoiceInteractive} onVisibleChange={setShowVoiceInteractive} />
 		</div>
 	);
 });

--- a/libs/components/src/lib/components/VoiceChannel/ControlBar/hooks/useControlBarPermissions.ts
+++ b/libs/components/src/lib/components/VoiceChannel/ControlBar/hooks/useControlBarPermissions.ts
@@ -24,6 +24,7 @@ export function useControlBarPermissions(controls?: ControlBarControls) {
 
 		// Recording is a purely local capture — it needs no publish permission.
 		visible.recording ??= true;
+		visible.voiceInteractive ??= true;
 
 		if (!localPermissions) {
 			visible.camera = false;

--- a/libs/components/src/lib/components/VoiceChannel/ControlBar/hooks/useReactionControls.ts
+++ b/libs/components/src/lib/components/VoiceChannel/ControlBar/hooks/useReactionControls.ts
@@ -9,12 +9,10 @@ export function useReactionControls() {
 
 	const [showEmojiPanel, setShowEmojiPanel] = useState(false);
 	const [showSoundPanel, setShowSoundPanel] = useState(false);
-	const [showVoiceInteractive, setShowVoiceInteractive] = useState(false);
 
 	useEffect(() => {
 		setShowEmojiPanel(false);
 		setShowSoundPanel(false);
-		setShowVoiceInteractive(false);
 	}, [voiceInfo?.channelId]);
 
 	useEffect(() => {
@@ -39,17 +37,6 @@ export function useReactionControls() {
 		return () => window.removeEventListener('keydown', handleKeyDown);
 	}, [showSoundPanel]);
 
-	useEffect(() => {
-		if (!showVoiceInteractive) return;
-		const handleKeyDown = (e: KeyboardEvent) => {
-			if (e.key === 'Escape' || e.key === 'Esc') {
-				setShowVoiceInteractive(false);
-			}
-		};
-		window.addEventListener('keydown', handleKeyDown);
-		return () => window.removeEventListener('keydown', handleKeyDown);
-	}, [showVoiceInteractive]);
-
 	const handleEmojiSelect = useCallback(
 		(emojiId: string, emoji: string) => {
 			sendEmojiReaction(emoji, emojiId);
@@ -69,8 +56,6 @@ export function useReactionControls() {
 		setShowEmojiPanel,
 		showSoundPanel,
 		setShowSoundPanel,
-		showVoiceInteractive,
-		setShowVoiceInteractive,
 		handleEmojiSelect,
 		handleSoundSelect,
 		sendRaisingHand


### PR DESCRIPTION
## Changes
Refactored VoiceInteractive button to ControlBar keeping the same logic as before.

## Tests
<img width="1285" height="319" alt="image" src="https://github.com/user-attachments/assets/dcf7eead-ec55-4af1-9b8a-5cd6416cce8b" />
