### PR TITLE
feat(web): play a YouTube channel app on a public embed route

### DIFF
--- a/apps/chat/src/app/app.tsx
+++ b/apps/chat/src/app/app.tsx
@@ -4,7 +4,7 @@ import { getMezonConfig, MezonContextProvider, useMezon } from '@mezon/transport
 
 import { PopupManagerProvider } from '@mezon/components';
 import { PermissionProvider } from '@mezon/core';
-import { createContext, Suspense, useContext, useEffect, useMemo, useState } from 'react';
+import { createContext, lazy, Suspense, useContext, useEffect, useMemo, useState } from 'react';
 import 'react-contexify/ReactContexify.css';
 import { I18nextProvider, useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
@@ -22,6 +22,19 @@ void import('livekit-client').then(({ LogLevel, setLogLevel }) => {
 ThemeManager.initializeTheme();
 
 const mezon = getMezonConfig();
+
+/**
+ * Public pages that are only a viewer — no session, no store, no socket.
+ *
+ * They are mounted above `MezonStoreProvider` on purpose: its `BootstrapGate`
+ * calls `connectSocket()` whenever a persisted session exists, so letting a
+ * video window boot the shell would open one more socket for the account every
+ * time the user opens a video.
+ */
+const EMBED_PATH_PREFIX = '/embed/';
+const YoutubeEmbed = lazy(() => import(/* webpackChunkName: "embed-pages" */ './pages/embed/YoutubeEmbed'));
+
+const isEmbedPath = () => typeof window !== 'undefined' && window.location.pathname.startsWith(EMBED_PATH_PREFIX);
 
 export const LoadingFallbackWrapper = () => <LoadingFallback />;
 
@@ -117,6 +130,14 @@ function AppWrapper() {
 			splashScreen.style.display = 'none';
 		}
 	}, []);
+
+	if (isEmbedPath()) {
+		return (
+			<Suspense fallback={<LoadingFallbackWrapper />}>
+				<YoutubeEmbed />
+			</Suspense>
+		);
+	}
 
 	return (
 		<I18nextProvider i18n={i18n}>

--- a/apps/chat/src/app/pages/embed/YoutubeEmbed.tsx
+++ b/apps/chat/src/app/pages/embed/YoutubeEmbed.tsx
@@ -1,0 +1,69 @@
+import { extractYouTubeStartSeconds, youtubeVideoIdFromLink } from '@mezon/utils';
+import { useEffect, useMemo } from 'react';
+
+const VIDEO_ID_REGEX = /^[a-zA-Z0-9_-]{11}$/;
+
+/**
+ * Public player page for a YouTube channel app: `/embed/youtube?v=<id>[&t=<seconds>]`.
+ *
+ * The route takes no session, so it works from a desktop browser window as well as
+ * from a chat tab. `v` is validated against the YouTube id shape before it reaches
+ * the iframe src — this page renders whatever a stranger puts in the query string.
+ *
+ * It reads the query string off `window.location` rather than through the router:
+ * `AppWrapper` mounts it before the store and the router exist, so that a video
+ * window never opens a second socket for the account (see app.tsx).
+ */
+export default function YoutubeEmbed() {
+	const searchParams = useMemo(() => new URLSearchParams(typeof window === 'undefined' ? '' : window.location.search), []);
+
+	const videoId = useMemo(() => {
+		const fromParam = searchParams.get('v')?.trim() ?? '';
+		if (VIDEO_ID_REGEX.test(fromParam)) {
+			return fromParam;
+		}
+		return youtubeVideoIdFromLink(searchParams.get('url') ?? '');
+	}, [searchParams]);
+
+	const start = useMemo(() => {
+		const raw = searchParams.get('t')?.trim() ?? '';
+		if (/^\d+$/.test(raw)) {
+			return Number(raw);
+		}
+		return extractYouTubeStartSeconds(searchParams.get('url') ?? '');
+	}, [searchParams]);
+
+	useEffect(() => {
+		document.title = 'Mezon';
+	}, []);
+
+	if (!videoId) {
+		return (
+			<div className="w-screen h-screen flex items-center justify-center bg-black text-white">
+				<p className="text-base opacity-80">This link does not point to a YouTube video.</p>
+			</div>
+		);
+	}
+
+	const embedParams = new URLSearchParams({
+		autoplay: '1',
+		rel: '0',
+		playsinline: '1'
+	});
+	if (start > 0) {
+		embedParams.set('start', String(start));
+	}
+
+	return (
+		<div className="w-screen h-screen bg-black">
+			<iframe
+				className="w-full h-full border-0"
+				src={`https://www.youtube.com/embed/${videoId}?${embedParams.toString()}`}
+				title="YouTube video player"
+				allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share; fullscreen"
+				referrerPolicy="strict-origin-when-cross-origin"
+				allowFullScreen
+			/>
+		</div>
+	);
+}

--- a/apps/chat/src/app/routes/index.tsx
+++ b/apps/chat/src/app/routes/index.tsx
@@ -58,6 +58,7 @@ const MemberMain = lazy(() => import(/* webpackChunkName: "member-pages" */ '../
 const ChannelSettingMain = lazy(() => import(/* webpackChunkName: "setting-pages" */ '../pages/setting/channelSetting'));
 const ThreadsMain = lazy(() => import(/* webpackChunkName: "thread-pages" */ '../pages/thread'));
 const MobileDownload = lazy(() => import('../pages/mobile-download'));
+const YoutubeEmbed = lazy(() => import(/* webpackChunkName: "embed-pages" */ '../pages/embed/YoutubeEmbed'));
 
 const SuspenseFallback = () => {
 	const { setSuspenseLoading } = useLoading();
@@ -173,6 +174,15 @@ export const Routes = memo(() => {
 						element: (
 							<Suspense fallback={<SuspenseFallback />}>
 								<MobileDownload />
+							</Suspense>
+						)
+					},
+					{
+						// Public: a YouTube channel app opens here instead of on youtube.com.
+						path: 'embed/youtube',
+						element: (
+							<Suspense fallback={<SuspenseFallback />}>
+								<YoutubeEmbed />
 							</Suspense>
 						)
 					},

--- a/libs/utils/src/lib/utils/embed-social.ts
+++ b/libs/utils/src/lib/utils/embed-social.ts
@@ -10,10 +10,44 @@ export function getLinkType(url: string): EBacktickType {
 	return EBacktickType.LINK;
 }
 
+// A YouTube id is always 11 chars of [A-Za-z0-9_-]; anchoring on that is what keeps
+// a hostile `url` from being pasted straight into an iframe src.
+const YOUTUBE_VIDEO_ID_REGEX = /(?:youtube\.com\/(?:watch\?(?:[^#]*&)?v=|v\/|e\/|embed\/|shorts\/|live\/)|youtu\.be\/)([a-zA-Z0-9_-]{11})/;
+
+export function extractYouTubeVideoId(url: string): string {
+	return url.match(YOUTUBE_VIDEO_ID_REGEX)?.[1] ?? '';
+}
+
+const YOUTUBE_HOSTS = ['youtube.com', 'www.youtube.com', 'm.youtube.com', 'music.youtube.com', 'youtu.be'];
+
+/**
+ * The video a link points at, or '' when the link is not a YouTube URL.
+ *
+ * The host check matters where the link comes from outside: `extractYouTubeVideoId`
+ * matches anywhere in the string, so `https://elsewhere.example/?next=youtu.be/<id>`
+ * would otherwise read as a video.
+ */
+export function youtubeVideoIdFromLink(url: string): string {
+	try {
+		return YOUTUBE_HOSTS.includes(new URL(url).hostname.toLowerCase()) ? extractYouTubeVideoId(url) : '';
+	} catch {
+		return '';
+	}
+}
+
+/** `?t=90`, `?t=1m30s` and `?start=90` all mean "start 90 seconds in". */
+export function extractYouTubeStartSeconds(url: string): number {
+	const raw = url.match(/[?&](?:t|start)=([0-9hms]+)/i)?.[1];
+	if (!raw) return 0;
+	if (/^\d+$/.test(raw)) return Number(raw);
+	const [, h = '0', m = '0', s = '0'] = raw.match(/^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/) ?? [];
+	return Number(h) * 3600 + Number(m) * 60 + Number(s);
+}
+
 export function getYouTubeEmbedUrl(url: string): string {
 	// check xss
-	const match = url.match(/(?:youtube\.com\/(?:watch\?v=|v\/|e\/|embed\/|shorts\/)|youtu\.be\/)([a-zA-Z0-9_-]{11})/);
-	return match ? `https://www.youtube.com/embed/${match[1]}` : '';
+	const videoId = extractYouTubeVideoId(url);
+	return videoId ? `https://www.youtube.com/embed/${videoId}` : '';
 }
 
 export function getFacebookEmbedUrl(url: string): string {


### PR DESCRIPTION
A channel app whose URL is a YouTube video used to open the whole youtube.com page in a popup, with a signed `data`/`clanId` hash that YouTube ignores. Add `/embed/youtube?v=<id>[&t=<seconds>]`: a public, session-less route that renders nothing but the video in an iframe, and send YouTube apps there instead — no hash RPC, no site around the video.

`v` is validated against the 11-char YouTube id shape before it reaches the iframe src, and only real YouTube hosts take the new branch, so a normal app URL still goes through the signed launch untouched.